### PR TITLE
Homepage refresh and supported chains documentation

### DIFF
--- a/docs/blockchain/introduction.md
+++ b/docs/blockchain/introduction.md
@@ -20,6 +20,8 @@ Unlike traditional blockchain RPC providers that offer raw node data, Bitquery p
 
 ## Supported Blockchains
 
+**[Supported blockchains & networks (V1, V2, Kafka, gRPC, ClickHouse, cloud) →](/docs/blockchain/supported-chains/)** — See a single matrix of which chains are covered per interface (GraphQL versions, Kafka, CoreCast, ClickHouse warehouse, Parquet/datashares).
+
 Bitquery provides comprehensive blockchain data across **40+ blockchains** through two active API versions:
 
 ### **V2 APIs**
@@ -45,6 +47,7 @@ Our comprehensive V1 API supporting 40+ blockchains with historical data:
 **Supported Blockchains:** Bitcoin, Ethereum, Solana, BSC, Polygon, Bitcoin Cash, Litecoin, Bitcoin SV, Dash, Zcash, Avalanche, Klaytn, Celo, Moonbeam, Fantom, Cronos, Cosmos, Hedera, Flow, EOS, Ripple (XRP), Stellar, Algorand, Cardano, Filecoin, and more.
 
 **Documentation:**
+- **[Supported chains by interface](/docs/blockchain/supported-chains/)** — Coverage matrix: V1/V2, Kafka, gRPC, ClickHouse, cloud
 - **[V2 Documentation](https://docs.bitquery.io/docs/)** - Latest APIs with real-time streaming
 - **[V1 Documentation](https://docs.bitquery.io/v1/)** - Comprehensive APIs with 40+ blockchain support
 
@@ -543,7 +546,7 @@ A: Bitquery is a comprehensive blockchain data platform that provides pre-indexe
 
 ### Q: Which blockchains does Bitquery support?
 
-A: Bitquery supports 40+ blockchains across two API versions:
+A: Bitquery supports 40+ blockchains across two API versions. For a detailed **per-interface** list (including Kafka, gRPC, ClickHouse, and cloud), see **[Supported blockchains & networks](/docs/blockchain/supported-chains/)**.
 
 **V2 APIs:**
 - **EVM Chains**: Ethereum, BSC, Arbitrum, Base, Polygon, Optimism, opBNB
@@ -553,6 +556,7 @@ A: Bitquery supports 40+ blockchains across two API versions:
 - **Supported Blockchains**: Bitcoin, Ethereum, Solana, BSC, Polygon, Bitcoin Cash, Litecoin, Bitcoin SV, Dash, Zcash, Avalanche, Klaytn, Celo, Moonbeam, Fantom, Cronos, Cosmos, Hedera, Flow, EOS, Ripple (XRP), Stellar, Algorand, Cardano, Filecoin, and more.
 
 **Documentation:**
+- **[Supported chains by interface](/docs/blockchain/supported-chains/)** — Coverage matrix: V1/V2, Kafka, gRPC, ClickHouse, cloud
 - **[V2 Documentation](https://docs.bitquery.io/docs/)** - Latest APIs with real-time streaming
 - **[V1 Documentation](https://docs.bitquery.io/v1/)** - Comprehensive APIs with 40+ blockchain support
 

--- a/docs/blockchain/supported-chains.mdx
+++ b/docs/blockchain/supported-chains.mdx
@@ -1,0 +1,122 @@
+---
+title: Supported blockchains & networks (V1, V2, Kafka, gRPC, ClickHouse)
+description: "Compare Bitquery coverage across Bitcoin, Ethereum, Solana, BNB Chain, Polygon, Base, Arbitrum, Optimism, Tron, and 15+ other networks. See which chains are available on V1 GraphQL, V2 GraphQL WebSocket, Kafka protobuf, Solana CoreCast gRPC, ClickHouse replica SQL, and cloud Parquet exports."
+sidebar_position: 0
+image: img/heroImage4.png
+keywords:
+  - Bitquery supported chains
+  - multichain blockchain API
+  - Bitcoin Ethereum Solana API
+  - V1 vs V2 blockchain coverage
+  - Kafka blockchain streams chains
+  - Solana gRPC CoreCast
+  - ClickHouse blockchain replica
+  - cloud Parquet blockchain datasets
+  - BNB Chain Polygon Base Arbitrum
+  - blockchain data platform networks
+  - GraphQL WebSocket chains
+  - real-time crypto data chains
+---
+
+import Head from "@docusaurus/Head";
+
+<Head>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "TechArticle",
+      headline:
+        "Supported blockchains and networks: Bitquery V1, V2, Kafka, gRPC, ClickHouse, cloud",
+      description:
+        "Product-level coverage matrix for Bitquery APIs: which blockchains are supported on legacy V1 GraphQL, current V2 GraphQL and WebSocket, Apache Kafka protobuf streams, Solana CoreCast gRPC, ClickHouse replica access, and cloud Parquet datasets.",
+      author: { "@type": "Organization", name: "Bitquery", url: "https://bitquery.io" },
+      publisher: { "@type": "Organization", name: "Bitquery", url: "https://bitquery.io" },
+      mainEntityOfPage: {
+        "@type": "WebPage",
+        "@id": "https://docs.bitquery.io/docs/blockchain/supported-chains/",
+      },
+      keywords:
+        "blockchain API, multichain, Ethereum, Solana, Bitcoin, BSC, Polygon, Kafka, GraphQL, ClickHouse",
+    })}
+  </script>
+</Head>
+
+# Supported blockchains & networks
+
+This guide lists **which blockchains Bitquery indexes** and how that lines up with each **delivery interface** on **[bitquery.io](https://bitquery.io/)**: legacy **[V1 GraphQL](https://docs.bitquery.io/v1/)** (broad catalog—schema reference), **[Data streams & GraphQL](https://bitquery.io/products/data-streams)** and **[WebSocket streams](https://bitquery.io/products/websocket-streams)** for real time, **[Kafka streams](https://bitquery.io/products/kafka-streams)** (protobuf), **[Solana gRPC (CoreCast)](https://bitquery.io/products/solana-grpc-streams)**, **[ClickHouse data warehouse](https://bitquery.io/products/data-warehouse)** with **[MCP server](https://bitquery.io/products/bitquery-mcp-server)** for AI clients, and **[cloud datashares & exports](https://bitquery.io/products/streaming)** (S3, Snowflake, BigQuery, and more). Major networks include **Bitcoin**, **Ethereum**, **Solana**, **BNB Chain**, **Polygon**, **Tron**, **Base**, **Arbitrum**, **Optimism**, and **Cardano**, plus additional L1s in the [matrix below](#supported-chains-matrix)—always validate your plan, entitlement, and live **[GraphQL IDE](https://ide.bitquery.io/)** before shipping.
+
+**Legend:** ✓ = included in this product line’s chain catalog below. **—** = not listed in that line’s default set (other Bitquery products or plans may still apply—ask support).
+
+---
+
+## Matrix: chain × product {#supported-chains-matrix}
+
+**ClickHouse replica:** SQL over Bitquery’s **[managed ClickHouse data warehouse](https://bitquery.io/products/data-warehouse)**—dedicated clusters with read replicas and real-time ingestion across **40+ chains** (see product page for full positioning). **Chain coverage for your project matches the catalog below** (aligned with cloud-style exports), with **tables and schema** depending on entitlement; for **AI assistants**, use the **[Bitquery MCP server](https://bitquery.io/products/bitquery-mcp-server)** ([technical setup](/docs/mcp/mcp-server/)).
+
+<div className="supportedChainsStickyTable">
+
+| Network | V1 GraphQL | V2 GraphQL / WebSocket | Kafka (protobuf) | Cloud (Parquet / datasets) | ClickHouse replica |
+|---------|:----------:|:----------------------:|:----------------:|:--------------------------:|:------------------:|
+| Bitcoin | ✓ | — | ✓ | ✓ | ✓ |
+| Litecoin | ✓ | — | — | ✓ | ✓ |
+| Bitcoin Cash | ✓ | — | — | ✓ | ✓ |
+| Zcash | ✓ | — | — | ✓ | ✓ |
+| Dash | ✓ | — | — | ✓ | ✓ |
+| Ethereum | ✓ | ✓ | ✓ | ✓ | ✓ |
+| BNB Chain (BSC) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Avalanche | ✓ | — | — | ✓ | ✓ |
+| Klaytn | ✓ | — | — | ✓ | ✓ |
+| Tron | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Celo | ✓ | — | — | ✓ | ✓ |
+| Algorand | ✓ | — | — | ✓ | ✓ |
+| Moonbeam | ✓ | — | — | ✓ | ✓ |
+| Fantom | ✓ | — | — | ✓ | ✓ |
+| Cronos | ✓ | — | — | ✓ | ✓ |
+| Solana | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Cardano | ✓ | — | — | ✓ | ✓ |
+| Polygon | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Filecoin | ✓ | — | — | ✓ | ✓ |
+| Ripple (XRP) | ✓ | — | — | ✓ | ✓ |
+| Stellar | ✓ | — | — | ✓ | ✓ |
+| Arbitrum | — | ✓ | ✓ | ✓ | ✓ |
+| Optimism | — | ✓ | ✓ | ✓ | ✓ |
+| Base | — | ✓ | ✓ | ✓ | ✓ |
+
+</div>
+
+:::note More networks
+
+**V1** historically covers **40+** blockchains—see the [V1 docs](https://docs.bitquery.io/v1/) for the full, schema-accurate list and **[Bitquery platform](https://bitquery.io/)** for plans. **V2** may also expose additional networks in the IDE (for example **opBNB**, **TON**) that are not repeated in the short list above—check live schema and [chain docs](/docs/blockchain/introduction/).
+
+**Kafka** also exposes multi-chain **`trading.prices`** and **`trading.trades`** topics—see **[Kafka streams](https://bitquery.io/products/kafka-streams)** and [Kafka streaming concepts](/docs/streams/kafka-streaming-concepts/).
+
+:::
+
+---
+
+## gRPC (CoreCast)
+
+**Solana only** — filtered protobuf streams to `corecast.bitquery.io`. Not multi-chain.
+
+- [Solana gRPC streams (product)](https://bitquery.io/products/solana-grpc-streams) · [CoreCast docs](/docs/grpc/solana/introduction/)
+
+---
+
+## Where to read more
+
+| Product | Get started |
+|--------|-------------|
+| **V2** | [Bitquery platform](https://bitquery.io/) · [Data streams](https://bitquery.io/products/data-streams) · [WebSocket streams](https://bitquery.io/products/websocket-streams) · Docs: [Intro](https://docs.bitquery.io/docs/intro/) · Chains: [Ethereum](https://bitquery.io/blockchains/ethereum-blockchain-api), [BNB Chain](https://docs.bitquery.io/docs/blockchain/BSC/), [Arbitrum](https://bitquery.io/blockchains/arbitrum-blockchain-api), [Optimism](https://bitquery.io/blockchains/optimism-blockchain-api), [Base](https://bitquery.io/blockchains/base-blockchain-api), [Polygon](https://bitquery.io/blockchains/polygon-blockchain-api), [Solana](https://bitquery.io/blockchains/solana-blockchain-api), [Tron](https://bitquery.io/blockchains/tron-blockchain-api) |
+| **V1** | [Bitquery platform](https://bitquery.io/) · [V1 documentation](https://docs.bitquery.io/v1/) · [V1 vs V2 (IDE & schema)](https://docs.bitquery.io/v1/docs/graphql-ide/v1-and-v2) |
+| **Kafka** | [Kafka streams](https://bitquery.io/products/kafka-streams) · [Real-time streaming hub](https://bitquery.io/products/streaming) · Docs: [Streams overview](https://docs.bitquery.io/docs/streams/) · [Kafka concepts](https://docs.bitquery.io/docs/streams/kafka-streaming-concepts/) |
+| **Cloud** | [Streaming & datashares](https://bitquery.io/products/streaming) · Docs: [Cloud data](https://docs.bitquery.io/docs/cloud/) · [EVM](https://docs.bitquery.io/docs/cloud/evm/) · [Solana](https://docs.bitquery.io/docs/cloud/solana/) · [Bitcoin](https://docs.bitquery.io/docs/cloud/bitcoin/) · [Tron](https://docs.bitquery.io/docs/cloud/tron/) |
+| **ClickHouse replica** | [ClickHouse data warehouse](https://bitquery.io/products/data-warehouse) · [MCP server](https://bitquery.io/products/bitquery-mcp-server) · [MCP docs](https://docs.bitquery.io/docs/mcp/mcp-server/) |
+
+---
+
+## See also
+
+- [ClickHouse data warehouse](https://bitquery.io/products/data-warehouse) — fully managed clusters, replicas, and real-time ingestion
+- [Data streams & Kafka / WebSocket / gRPC](https://bitquery.io/products/data-streams)
+- [Blockchain data APIs overview](/docs/blockchain/introduction/)
+- [gRPC vs WebSocket vs Kafka](/docs/streams/) (docs)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1005,50 +1005,88 @@ const config = {
         style: "dark",
         links: [
           {
-            title: "Links",
+            title: "Start here",
             items: [
-              {
-                label: "Website",
-                to: "https://bitquery.io",
-              },
-              {
-                label: "V1 Docs",
-                to: "https://docs.bitquery.io/v1/",
-              },
-              {
-                label: "V2 Docs",
-                to: "docs/intro",
-              },
+              { label: "Platform overview", to: "/docs/intro/" },
+              { label: "Getting started — first query", to: "/docs/start/first-query/" },
+              { label: "Starter queries", to: "/docs/start/starter-queries/" },
+              { label: "Starter subscriptions (WebSocket)", to: "/docs/start/starter-subscriptions/" },
+              { label: "Supported chains (V1, V2, Kafka…)", to: "/docs/blockchain/supported-chains/" },
+              { label: "Blockchain APIs overview", to: "/docs/blockchain/introduction/" },
+              { label: "V1 documentation", href: "https://docs.bitquery.io/v1/" },
+              { label: "V1 vs V2 APIs (IDE & schema)", href: "https://docs.bitquery.io/v1/docs/graphql-ide/v1-and-v2" },
+            ],
+          },
+          {
+            title: "Data & metrics",
+            items: [
+              { label: "Token prices & OHLCV", to: "/docs/trading/crypto-price-api/introduction/" },
+              { label: "DEX trades", to: "/docs/trading/crypto-trades-api/trades-api/" },
+              { label: "Transfers & wallet flows", to: "/docs/start/mental-model-transfers-events-calls/" },
+              { label: "Contract calls & traces", to: "/docs/API-Blog/what-are-internal-transactions-how-to-get-them/" },
+              { label: "Smart-contract events", to: "/docs/start/mental-model-transfers-events-calls/" },
+              { label: "NFTs & metadata", to: "/docs/blockchain/Ethereum/nft/nft-api/" },
+              { label: "Balances & holders", to: "/docs/evm/balances/" },
+              { label: "Mempool & pending txs", to: "/docs/start/mempool/" },
+            ],
+          },
+          {
+            title: "Interfaces & streaming",
+            items: [
+              { label: "GraphQL (HTTP)", to: "/docs/start/first-query/" },
+              { label: "WebSocket subscriptions", to: "/docs/start/starter-subscriptions/" },
+              { label: "Kafka streaming concepts", to: "/docs/streams/kafka-streaming-concepts/" },
+              { label: "Streams overview", to: "/docs/streams/" },
+              { label: "MCP server", to: "/docs/mcp/mcp-server/" },
+              { label: "Cloud datasets (Parquet)", to: "/docs/cloud/" },
+              { label: "Solana gRPC (CoreCast)", to: "/docs/grpc/solana/introduction/" },
+            ],
+          },
+          {
+            title: "Tools & explorers",
+            items: [
+              { label: "DEXrabbit", href: "https://dexrabbit.com/" },
+              { label: "Explorer", href: "https://explorer.bitquery.io/" },
+              { label: "GraphQL IDE", href: "https://ide.bitquery.io/" },
+              { label: "Tools & SDKs directory", to: "/docs/tools-directory/" },
+              { label: "Blockchain ClickHouse warehouse", href: "https://bitquery.io/products/data-warehouse" },
+              { label: "Visit bitquery.io", href: "https://bitquery.io/" },
+              { label: "Enterprise & sales", href: "https://bitquery.io/contact" },
+            ],
+          },
+          {
+            title: "Blockchains",
+            items: [
+              { label: "Ethereum", to: "/docs/blockchain/Ethereum/" },
+              { label: "Solana", to: "/docs/blockchain/Solana/" },
+              { label: "BNB Chain (BSC)", to: "/docs/blockchain/BSC/" },
+              { label: "Base", to: "/docs/blockchain/Base/" },
+              { label: "Polygon", to: "/docs/blockchain/Matic/" },
+              { label: "Arbitrum", to: "/docs/blockchain/Arbitrum/" },
+              { label: "Optimism", to: "/docs/blockchain/Optimism/" },
+              { label: "Tron", to: "/docs/blockchain/Tron/" },
+              { label: "More networks…", to: "/docs/blockchain/introduction/" },
+            ],
+          },
+          {
+            title: "Guides & use cases",
+            items: [
+              { label: "Traders & desks →", to: "/docs/trading/crypto-price-api/introduction/" },
+              { label: "Analysts & quants →", to: "/docs/graphql/dataset/archive/" },
+              { label: "Auditors & finance →", to: "/docs/evm/balances/" },
+              { label: "Investigators & compliance →", href: "https://docs.bitquery.io/v1/docs/Examples/coinpath/money-flow-api" },
+              { label: "How-to guides & recipes", to: "/docs/category/how-to-guides/" },
             ],
           },
           {
             title: "Community",
             items: [
-              {
-                label: "Telegram",
-                href: "https://t.me/Bloxy_info",
-              },
-              {
-                label: "Twitter",
-                href: "https://twitter.com/Bitquery_io",
-              },
-            ],
-          },
-          {
-            title: "More",
-            items: [
-              {
-                label: "Forum",
-                href: "https://community.bitquery.io/",
-              },
-              {
-                label: "GitHub",
-                href: "https://github.com/bitquery",
-              },
-              {
-                label: "Blog",
-                to: "https://bitquery.io/blog",
-              },
+              { label: "Telegram", href: "https://t.me/Bloxy_info" },
+              { label: "Twitter / X", href: "https://twitter.com/Bitquery_io" },
+              { label: "Forum", href: "https://community.bitquery.io/" },
+              { label: "GitHub", href: "https://github.com/bitquery" },
+              { label: "Blog", href: "https://bitquery.io/blog" },
+              { label: "Newsletter", href: "https://bitquery.substack.com/" },
             ],
           },
         ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -337,6 +337,7 @@ const sidebars = {
         id: "blockchain/introduction",
       },
       items: [
+        "blockchain/supported-chains",
         {
           type: "category",
           label: "Ethereum",

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -5,63 +5,106 @@ import styles from "./styles.module.css";
 
 const capabilityCards = [
   {
+    icon: "⚡",
     title: "GraphQL queries",
     description:
-      "Build HTTP queries for transfers, trades, NFTs, and events across 40+ networks.",
+      "HTTP queries for transfers, trades, NFTs, and events across 40+ networks.",
     to: "/docs/start/first-query/",
   },
   {
+    icon: "🔌",
     title: "Live subscriptions",
     description:
-      "Stream updates over WebSocket with the same GraphQL shape as queries.",
+      "WebSocket streams with the same GraphQL shape as your queries.",
     to: "/docs/start/starter-subscriptions/",
   },
   {
+    icon: "📡",
     title: "Kafka streams",
     description:
-      "Low-latency protobuf topics for high-volume pipelines and fan-out.",
+      "Protobuf topics for high-volume pipelines and many consumers.",
     to: "/docs/streams/kafka-streaming-concepts/",
   },
   {
+    icon: "☁️",
     title: "Cloud datasets",
     description:
-      "Parquet exports to S3, Snowflake, BigQuery, and other warehouses.",
+      "Parquet in S3, Snowflake, BigQuery, and more for analytics workloads.",
     to: "/docs/cloud/",
   },
   {
+    icon: "⏳",
     title: "Mempool data",
     description:
-      "See broadcast transactions before confirmation for simulation and tooling.",
+      "Broadcast transactions before confirmation—simulation, ordering, tooling.",
     to: "/docs/start/mempool/",
   },
   {
+    icon: "📊",
     title: "DeFi & trading cubes",
     description:
-      "DEX trades, pools, and token-level aggregates without running your own node.",
+      "DEX trades, pools, and aggregates without running archive nodes.",
     to: "/docs/cubes/dextrades-dextradebytokens-trading-trades/",
   },
 ];
 
-const interfaceRows = [
+const interfaceCards = [
   {
+    icon: "🌐",
     name: "GraphQL (HTTP)",
-    bestFor: "Ad-hoc queries, dashboards, backfills.",
+    hint: "Ad-hoc queries, dashboards, backfills",
     to: "/docs/start/endpoints/",
   },
   {
+    icon: "⚡",
     name: "Subscriptions (WebSocket)",
-    bestFor: "Live feeds with push updates.",
+    hint: "Push updates as blocks and trades arrive",
     to: "/docs/start/getting-updates/",
   },
   {
+    icon: "📨",
     name: "Kafka",
-    bestFor: "Scale-out consumers and enterprise pipelines.",
+    hint: "Scale-out pipelines and replay",
     to: "/docs/streams/kafka-streaming-concepts/",
   },
   {
+    icon: "📦",
     name: "Cloud files",
-    bestFor: "Analytics, ML, and long archival windows.",
+    hint: "Long windows, warehouses, ML",
     to: "/docs/cloud/",
+  },
+];
+
+const conceptItems = [
+  {
+    icon: "🧭",
+    title: "Mental model",
+    desc: "Transfers, events, and contract calls on-chain.",
+    to: "/docs/start/mental-model-transfers-events-calls/",
+  },
+  {
+    icon: "🗄️",
+    title: "Datasets",
+    desc: "Archive, realtime, and combined windows.",
+    to: "/docs/graphql/dataset/combined/",
+  },
+  {
+    icon: "📚",
+    title: "Examples by chain",
+    desc: "Starter queries grouped by ecosystem.",
+    to: "/docs/start/starter-queries/",
+  },
+  {
+    icon: "🛰️",
+    title: "gRPC (Solana+)",
+    desc: "Native streaming alongside GraphQL.",
+    to: "/docs/grpc/solana/introduction/",
+  },
+  {
+    icon: "🔗",
+    title: "Internal txs",
+    desc: "Traces and internal calls explained.",
+    to: "/docs/API-Blog/what-are-internal-transactions-how-to-get-them/",
   },
 ];
 
@@ -72,146 +115,209 @@ const useCaseLinks = [
     label: "Real-time balance tracker",
     to: "/docs/usecases/real-time-balance-tracker/overview/",
   },
-  { label: "Mempool fees & analysis", to: "/docs/usecases/mempool-transaction-fee/" },
+  {
+    label: "Mempool fees & analysis",
+    to: "/docs/usecases/mempool-transaction-fee/",
+  },
   { label: "NFT analytics", to: "/docs/usecases/nft-analytics/" },
   { label: "Copy trading bot", to: "/docs/usecases/copy-trading-bot/" },
 ];
 
-function CapabilityCard({ title, description, to }) {
+function Section({ children, alt }) {
   return (
-    <div className={clsx("col col--4", styles.cardCol)}>
-      <div className={styles.capabilityCard}>
-        <h3 className={styles.cardTitle}>
-          <Link to={to}>{title}</Link>
-        </h3>
+    <div className={clsx(styles.section, alt && styles.sectionAlt)}>{children}</div>
+  );
+}
+
+function SectionHeader({ kicker, title, children }) {
+  return (
+    <header className={styles.sectionHeader}>
+      {kicker ? <p className={styles.kicker}>{kicker}</p> : null}
+      <h2 className={styles.sectionHeading}>{title}</h2>
+      {children ? <div className={styles.sectionLead}>{children}</div> : null}
+    </header>
+  );
+}
+
+function CapabilityCard({ icon, title, description, to }) {
+  return (
+    <div className={clsx("col col--12 col--md-6 col--lg-4", styles.cardCol)}>
+      <Link to={to} className={styles.capabilityCard}>
+        <span className={styles.cardIcon} aria-hidden>
+          {icon}
+        </span>
+        <h3 className={styles.cardTitle}>{title}</h3>
         <p className={styles.cardBody}>{description}</p>
-        <Link className={styles.cardLink} to={to}>
-          Open docs →
-        </Link>
-      </div>
+        <span className={styles.cardCta}>
+          Read docs <span aria-hidden>→</span>
+        </span>
+      </Link>
     </div>
   );
 }
 
-export default function HomepageFeatures() {
+function InterfaceCard({ icon, name, hint, to }) {
+  return (
+    <div className={clsx("col col--12 col--sm-6", styles.interfaceCol)}>
+      <Link to={to} className={styles.interfaceCard}>
+        <span className={styles.interfaceIcon} aria-hidden>
+          {icon}
+        </span>
+        <div className={styles.interfaceBody}>
+          <h3 className={styles.interfaceName}>{name}</h3>
+          <p className={styles.interfaceHint}>{hint}</p>
+        </div>
+      </Link>
+    </div>
+  );
+}
+
+function ConceptTile({ icon, title, desc, to }) {
+  return (
+    <Link to={to} className={styles.conceptTile}>
+      <span className={styles.conceptIcon} aria-hidden>
+        {icon}
+      </span>
+      <div>
+        <h3 className={styles.conceptTitle}>{title}</h3>
+        <p className={styles.conceptDesc}>{desc}</p>
+      </div>
+      <span className={styles.conceptArrow} aria-hidden>
+        →
+      </span>
+    </Link>
+  );
+}
+
+export default function HomepageFeatures({ tagline }) {
   return (
     <section className={styles.features}>
-      <div className="container">
-        <h2 className={styles.sectionHeading}>What you can build with</h2>
-        <p className={styles.sectionLead}>
-          Pick a capability below, or read the{" "}
-          <Link to="/docs/intro/">full platform overview</Link> for datasets,
-          IDE, and auth.
-        </p>
-        <div className="row">
-          {capabilityCards.map((card) => (
-            <CapabilityCard key={card.to} {...card} />
-          ))}
-        </div>
-      </div>
-
-      <div className={clsx("container", styles.sectionBlock)}>
-        <h2 className={styles.sectionHeading}>Interfaces</h2>
-        <p className={styles.sectionLead}>
-          Same underlying data—choose the delivery mechanism that fits latency
-          and scale. See also{" "}
-          <Link to="/docs/mcp/mcp-server/">MCP Server</Link> for IDE and agent
-          integrations.
-        </p>
-        <div className={styles.interfaceTableWrap}>
-          <table className={styles.interfaceTable}>
-            <thead>
-              <tr>
-                <th scope="col">Interface</th>
-                <th scope="col">Best for</th>
-              </tr>
-            </thead>
-            <tbody>
-              {interfaceRows.map((row) => (
-                <tr key={row.to}>
-                  <td>
-                    <Link to={row.to}>{row.name}</Link>
-                  </td>
-                  <td>{row.bestFor}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div className={clsx("container", styles.sectionBlock)}>
-        <h2 className={styles.sectionHeading}>Data concepts</h2>
-        <p className={styles.sectionLead}>
-          Learn how transfers, events, calls, and protocol-level trades fit
-          together, then browse curated examples by chain.
-        </p>
-        <ul className={styles.linkList}>
-          <li>
-            <Link to="/docs/start/mental-model-transfers-events-calls/">
-              Mental model: transfers, events &amp; calls
-            </Link>
-          </li>
-          <li>
-            <Link to="/docs/graphql/dataset/archive/">Archive dataset</Link>
-            {" · "}
-            <Link to="/docs/graphql/dataset/realtime/">Realtime dataset</Link>
-            {" · "}
-            <Link to="/docs/graphql/dataset/combined/">Combined dataset</Link>
-          </li>
-          <li>
-            <Link to="/docs/start/starter-queries/">Starter queries by chain</Link>
-            {" · "}
-            <Link to="/docs/grpc/solana/introduction/">
-              gRPC streaming (Solana &amp; more)
-            </Link>
-          </li>
-          <li>
-            <Link to="/docs/API-Blog/what-are-internal-transactions-how-to-get-them/">
-              Internal transactions &amp; traces
-            </Link>
-          </li>
-        </ul>
-      </div>
-
-      <div className={clsx("container", styles.sectionBlock)}>
-        <h2 className={styles.sectionHeading}>Popular use cases</h2>
-        <p className={styles.sectionLead}>
-          Step-by-step guides for bots, dashboards, and monitoring.{" "}
-          <Link to="/docs/category/how-to-guides/">
-            Browse all how-to guides →
-          </Link>
-        </p>
-        <div className="row">
-          {useCaseLinks.map((item) => (
-            <div
-              key={item.to}
-              className={clsx("col col--12 col--md-6 col--lg-4", styles.useCaseCol)}
-            >
-              <Link className={styles.useCaseLink} to={item.to}>
-                {item.label}
-              </Link>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div className={clsx("container", styles.sectionBlock)}>
-        <div className="text--center" style={{ marginBottom: "1rem" }}>
-          <p style={{ fontWeight: "bold", fontSize: "1.1em" }}>
-            New to Bitquery? Watch a short intro{" "}
-            <span role="img" aria-label="point down">
-              👇
+      {tagline ? (
+        <div className={styles.taglineStrip}>
+          <div className={clsx("container", styles.taglineInner)}>
+            <span className={styles.taglineMark} aria-hidden>
+              ◆
             </span>
+            <p>{tagline}</p>
+          </div>
+        </div>
+      ) : null}
+
+      <Section>
+        <div className="container">
+          <SectionHeader kicker="Capabilities" title="What you can build with">
+            <p>
+              Same indexed chains and protocols everywhere—pick HTTP, websocket,
+              or batch export. Prefer the{" "}
+              <Link to="/docs/intro/">platform overview</Link> for IDE, auth,
+              and dataset details.
+            </p>
+          </SectionHeader>
+          <div className="row">
+            {capabilityCards.map((card) => (
+              <CapabilityCard key={card.to} {...card} />
+            ))}
+          </div>
+        </div>
+      </Section>
+
+      <Section alt>
+        <div className="container">
+          <SectionHeader kicker="Delivery" title="Interfaces">
+            <p>
+              Match latency and throughput to your stack. Agents and editors
+              can also use{" "}
+              <Link to="/docs/mcp/mcp-server/">MCP Server</Link>.
+            </p>
+          </SectionHeader>
+          <div className="row">
+            {interfaceCards.map((card) => (
+              <InterfaceCard key={card.to} {...card} />
+            ))}
+          </div>
+        </div>
+      </Section>
+
+      <Section>
+        <div className="container">
+          <SectionHeader kicker="Foundations" title="Data concepts">
+            <p>
+              Start with how on-chain activity is modeled, then align time
+              windows with your product.
+            </p>
+          </SectionHeader>
+          <div className={styles.conceptGrid}>
+            {conceptItems.map((item) => (
+              <ConceptTile key={item.to} {...item} />
+            ))}
+          </div>
+          <p className={styles.datasetLinks}>
+            <Link className={styles.datasetLink} to="/docs/graphql/dataset/archive/">
+              Archive
+            </Link>
+            <span className={styles.dot} aria-hidden>
+              ·
+            </span>
+            <Link className={styles.datasetLink} to="/docs/graphql/dataset/realtime/">
+              Realtime
+            </Link>
+            <span className={styles.dot} aria-hidden>
+              ·
+            </span>
+            <Link className={styles.datasetLink} to="/docs/graphql/dataset/combined/">
+              Combined
+            </Link>
           </p>
         </div>
-        <div style={{ maxWidth: "640px", margin: "0 auto" }}>
-          <video style={{ width: "100%", height: "auto" }} controls>
-            <source src="/img/intro_video.mp4" type="video/mp4" />
-            Your browser does not support the video tag.
-          </video>
+      </Section>
+
+      <Section alt>
+        <div className="container">
+          <SectionHeader kicker="Recipes" title="Popular use cases">
+            <p>
+              End-to-end tutorials for bots and dashboards.{" "}
+              <Link
+                className={styles.inlineBrowse}
+                to="/docs/category/how-to-guides/"
+              >
+                Browse all how-to guides
+              </Link>
+            </p>
+          </SectionHeader>
+          <div className="row">
+            {useCaseLinks.map((item) => (
+              <div
+                key={item.to}
+                className={clsx(
+                  "col col--12 col--md-6 col--lg-4",
+                  styles.useCaseCol
+                )}
+              >
+                <Link className={styles.useCaseLink} to={item.to}>
+                  <span>{item.label}</span>
+                  <span className={styles.useCaseArrow} aria-hidden>
+                    →
+                  </span>
+                </Link>
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      </Section>
+
+      <Section>
+        <div className={clsx("container", styles.videoSection)}>
+          <SectionHeader kicker="Overview" title="See Bitquery in action">
+            <p>Quick walkthrough of the IDE and running your first query.</p>
+          </SectionHeader>
+          <div className={styles.videoFrame}>
+            <video className={styles.video} controls preload="metadata">
+              <source src="/img/intro_video.mp4" type="video/mp4" />
+              Your browser does not support the video tag.
+            </video>
+          </div>
+        </div>
+      </Section>
     </section>
   );
 }

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -5,319 +5,192 @@ import styles from "./styles.module.css";
 
 const capabilityCards = [
   {
-    icon: "⚡",
     title: "GraphQL queries",
     description:
       "HTTP queries for transfers, trades, NFTs, and events across 40+ networks.",
     to: "/docs/start/first-query/",
   },
   {
-    icon: "🔌",
     title: "Live subscriptions",
     description:
       "WebSocket streams with the same GraphQL shape as your queries.",
     to: "/docs/start/starter-subscriptions/",
   },
   {
-    icon: "📡",
     title: "Kafka streams",
     description:
       "Protobuf topics for high-volume pipelines and many consumers.",
     to: "/docs/streams/kafka-streaming-concepts/",
   },
   {
-    icon: "☁️",
     title: "Cloud datasets",
     description:
-      "Parquet in S3, Snowflake, BigQuery, and more for analytics workloads.",
+      "Parquet in S3, Snowflake, BigQuery, and warehouses.",
     to: "/docs/cloud/",
   },
   {
-    icon: "⏳",
     title: "Mempool data",
     description:
-      "Broadcast transactions before confirmation—simulation, ordering, tooling.",
+      "Broadcast transactions before confirmation.",
     to: "/docs/start/mempool/",
   },
   {
-    icon: "📊",
     title: "DeFi & trading cubes",
     description:
-      "DEX trades, pools, and aggregates without running archive nodes.",
+      "DEX trades, pools, and aggregates without archive nodes.",
     to: "/docs/cubes/dextrades-dextradebytokens-trading-trades/",
   },
 ];
 
-const interfaceCards = [
-  {
-    icon: "🌐",
-    name: "GraphQL (HTTP)",
-    hint: "Ad-hoc queries, dashboards, backfills",
-    to: "/docs/start/endpoints/",
-  },
-  {
-    icon: "⚡",
-    name: "Subscriptions (WebSocket)",
-    hint: "Push updates as blocks and trades arrive",
-    to: "/docs/start/getting-updates/",
-  },
-  {
-    icon: "📨",
-    name: "Kafka",
-    hint: "Scale-out pipelines and replay",
-    to: "/docs/streams/kafka-streaming-concepts/",
-  },
-  {
-    icon: "📦",
-    name: "Cloud files",
-    hint: "Long windows, warehouses, ML",
-    to: "/docs/cloud/",
-  },
+const interfaceItems = [
+  { abbr: "HTTP", name: "GraphQL (HTTP)", hint: "Queries, dashboards", to: "/docs/start/endpoints/" },
+  { abbr: "WS", name: "Subscriptions", hint: "Push over WebSocket", to: "/docs/start/getting-updates/" },
+  { abbr: "KF", name: "Kafka", hint: "Scale-out pipelines", to: "/docs/streams/kafka-streaming-concepts/" },
+  { abbr: "CL", name: "Cloud files", hint: "Batch & analytics", to: "/docs/cloud/" },
 ];
 
-const conceptItems = [
-  {
-    icon: "🧭",
-    title: "Mental model",
-    desc: "Transfers, events, and contract calls on-chain.",
-    to: "/docs/start/mental-model-transfers-events-calls/",
-  },
-  {
-    icon: "🗄️",
-    title: "Datasets",
-    desc: "Archive, realtime, and combined windows.",
-    to: "/docs/graphql/dataset/combined/",
-  },
-  {
-    icon: "📚",
-    title: "Examples by chain",
-    desc: "Starter queries grouped by ecosystem.",
-    to: "/docs/start/starter-queries/",
-  },
-  {
-    icon: "🛰️",
-    title: "gRPC (Solana+)",
-    desc: "Native streaming alongside GraphQL.",
-    to: "/docs/grpc/solana/introduction/",
-  },
-  {
-    icon: "🔗",
-    title: "Internal txs",
-    desc: "Traces and internal calls explained.",
-    to: "/docs/API-Blog/what-are-internal-transactions-how-to-get-them/",
-  },
+const conceptLinks = [
+  { label: "Mental model: transfers, events, calls", to: "/docs/start/mental-model-transfers-events-calls/" },
+  { label: "Archive dataset", to: "/docs/graphql/dataset/archive/" },
+  { label: "Realtime dataset", to: "/docs/graphql/dataset/realtime/" },
+  { label: "Combined dataset", to: "/docs/graphql/dataset/combined/" },
+  { label: "Starter queries by chain", to: "/docs/start/starter-queries/" },
+  { label: "gRPC streaming (Solana)", to: "/docs/grpc/solana/introduction/" },
+  { label: "Internal transactions & traces", to: "/docs/API-Blog/what-are-internal-transactions-how-to-get-them/" },
 ];
 
 const useCaseLinks = [
   { label: "Telegram trading bot", to: "/docs/usecases/telegram-bot/" },
   { label: "Polymarket alerts", to: "/docs/usecases/polymarket-tg-alerts-bot/" },
-  {
-    label: "Real-time balance tracker",
-    to: "/docs/usecases/real-time-balance-tracker/overview/",
-  },
-  {
-    label: "Mempool fees & analysis",
-    to: "/docs/usecases/mempool-transaction-fee/",
-  },
+  { label: "Real-time balance tracker", to: "/docs/usecases/real-time-balance-tracker/overview/" },
+  { label: "Mempool fees & analysis", to: "/docs/usecases/mempool-transaction-fee/" },
   { label: "NFT analytics", to: "/docs/usecases/nft-analytics/" },
   { label: "Copy trading bot", to: "/docs/usecases/copy-trading-bot/" },
 ];
 
-function Section({ children, alt }) {
+function SquareMark({ large }) {
   return (
-    <div className={clsx(styles.section, alt && styles.sectionAlt)}>{children}</div>
+    <span
+      className={clsx(styles.squareMark, large && styles.squareMarkLg)}
+      aria-hidden
+    />
   );
 }
 
-function SectionHeader({ kicker, title, children }) {
+function CapabilityCard({ title, description, to }) {
   return (
-    <header className={styles.sectionHeader}>
-      {kicker ? <p className={styles.kicker}>{kicker}</p> : null}
-      <h2 className={styles.sectionHeading}>{title}</h2>
-      {children ? <div className={styles.sectionLead}>{children}</div> : null}
-    </header>
-  );
-}
-
-function CapabilityCard({ icon, title, description, to }) {
-  return (
-    <div className={clsx("col col--12 col--md-6 col--lg-4", styles.cardCol)}>
+    <div className={clsx("col col--12 col--sm-6 col--lg-4", styles.cardCol)}>
       <Link to={to} className={styles.capabilityCard}>
-        <span className={styles.cardIcon} aria-hidden>
-          {icon}
-        </span>
+        <SquareMark />
         <h3 className={styles.cardTitle}>{title}</h3>
         <p className={styles.cardBody}>{description}</p>
-        <span className={styles.cardCta}>
-          Read docs <span aria-hidden>→</span>
-        </span>
+        <span className={styles.cardCta}>Read docs</span>
       </Link>
     </div>
-  );
-}
-
-function InterfaceCard({ icon, name, hint, to }) {
-  return (
-    <div className={clsx("col col--12 col--sm-6", styles.interfaceCol)}>
-      <Link to={to} className={styles.interfaceCard}>
-        <span className={styles.interfaceIcon} aria-hidden>
-          {icon}
-        </span>
-        <div className={styles.interfaceBody}>
-          <h3 className={styles.interfaceName}>{name}</h3>
-          <p className={styles.interfaceHint}>{hint}</p>
-        </div>
-      </Link>
-    </div>
-  );
-}
-
-function ConceptTile({ icon, title, desc, to }) {
-  return (
-    <Link to={to} className={styles.conceptTile}>
-      <span className={styles.conceptIcon} aria-hidden>
-        {icon}
-      </span>
-      <div>
-        <h3 className={styles.conceptTitle}>{title}</h3>
-        <p className={styles.conceptDesc}>{desc}</p>
-      </div>
-      <span className={styles.conceptArrow} aria-hidden>
-        →
-      </span>
-    </Link>
   );
 }
 
 export default function HomepageFeatures({ tagline }) {
   return (
     <section className={styles.features}>
-      {tagline ? (
-        <div className={styles.taglineStrip}>
-          <div className={clsx("container", styles.taglineInner)}>
-            <span className={styles.taglineMark} aria-hidden>
-              ◆
-            </span>
-            <p>{tagline}</p>
-          </div>
-        </div>
-      ) : null}
-
-      <Section>
+      {/* Single dense band: narrative + caps + interfaces */}
+      <div className={styles.band}>
         <div className="container">
-          <SectionHeader kicker="Capabilities" title="What you can build with">
-            <p>
-              Same indexed chains and protocols everywhere—pick HTTP, websocket,
-              or batch export. Prefer the{" "}
-              <Link to="/docs/intro/">platform overview</Link> for IDE, auth,
-              and dataset details.
-            </p>
-          </SectionHeader>
+          <div className={styles.topRow}>
+            <SquareMark large />
+            <div className={styles.topRowText}>
+              <h2 className={styles.primaryTitle}>What you can build</h2>
+              {tagline ? <p className={styles.taglineInline}>{tagline}</p> : null}
+              <p className={styles.primaryLead}>
+                Same data over HTTP, websocket, Kafka, or cloud files. Details:{" "}
+                <Link to="/docs/intro/">platform overview</Link>,{" "}
+                <Link to="/docs/mcp/mcp-server/">MCP Server</Link>.
+              </p>
+            </div>
+            <SquareMark large />
+          </div>
+
           <div className="row">
             {capabilityCards.map((card) => (
               <CapabilityCard key={card.to} {...card} />
             ))}
           </div>
-        </div>
-      </Section>
 
-      <Section alt>
-        <div className="container">
-          <SectionHeader kicker="Delivery" title="Interfaces">
-            <p>
-              Match latency and throughput to your stack. Agents and editors
-              can also use{" "}
-              <Link to="/docs/mcp/mcp-server/">MCP Server</Link>.
-            </p>
-          </SectionHeader>
-          <div className="row">
-            {interfaceCards.map((card) => (
-              <InterfaceCard key={card.to} {...card} />
-            ))}
+          <div className={styles.interfaceLabelRow}>
+            <span className={styles.squareRule} aria-hidden />
+            <h3 className={styles.interfaceHeading}>Interfaces</h3>
+            <span className={styles.squareRule} aria-hidden />
           </div>
-        </div>
-      </Section>
-
-      <Section>
-        <div className="container">
-          <SectionHeader kicker="Foundations" title="Data concepts">
-            <p>
-              Start with how on-chain activity is modeled, then align time
-              windows with your product.
-            </p>
-          </SectionHeader>
-          <div className={styles.conceptGrid}>
-            {conceptItems.map((item) => (
-              <ConceptTile key={item.to} {...item} />
-            ))}
-          </div>
-          <p className={styles.datasetLinks}>
-            <Link className={styles.datasetLink} to="/docs/graphql/dataset/archive/">
-              Archive
-            </Link>
-            <span className={styles.dot} aria-hidden>
-              ·
-            </span>
-            <Link className={styles.datasetLink} to="/docs/graphql/dataset/realtime/">
-              Realtime
-            </Link>
-            <span className={styles.dot} aria-hidden>
-              ·
-            </span>
-            <Link className={styles.datasetLink} to="/docs/graphql/dataset/combined/">
-              Combined
-            </Link>
-          </p>
-        </div>
-      </Section>
-
-      <Section alt>
-        <div className="container">
-          <SectionHeader kicker="Recipes" title="Popular use cases">
-            <p>
-              End-to-end tutorials for bots and dashboards.{" "}
-              <Link
-                className={styles.inlineBrowse}
-                to="/docs/category/how-to-guides/"
-              >
-                Browse all how-to guides
+          <div className={styles.interfaceGrid}>
+            {interfaceItems.map((item) => (
+              <Link key={item.to} to={item.to} className={styles.interfaceCell}>
+                <span className={styles.abbrSquare}>{item.abbr}</span>
+                <div>
+                  <span className={styles.interfaceName}>{item.name}</span>
+                  <span className={styles.interfaceHint}>{item.hint}</span>
+                </div>
               </Link>
-            </p>
-          </SectionHeader>
-          <div className="row">
-            {useCaseLinks.map((item) => (
-              <div
-                key={item.to}
-                className={clsx(
-                  "col col--12 col--md-6 col--lg-4",
-                  styles.useCaseCol
-                )}
-              >
-                <Link className={styles.useCaseLink} to={item.to}>
-                  <span>{item.label}</span>
-                  <span className={styles.useCaseArrow} aria-hidden>
-                    →
-                  </span>
-                </Link>
-              </div>
             ))}
           </div>
         </div>
-      </Section>
+      </div>
 
-      <Section>
-        <div className={clsx("container", styles.videoSection)}>
-          <SectionHeader kicker="Overview" title="See Bitquery in action">
-            <p>Quick walkthrough of the IDE and running your first query.</p>
-          </SectionHeader>
-          <div className={styles.videoFrame}>
+      {/* One compact band: concepts | use cases (side by side on large screens) */}
+      <div className={clsx(styles.band, styles.bandAlt)}>
+        <div className="container">
+          <div className={styles.twoCol}>
+            <div className={styles.panel}>
+              <h3 className={styles.panelTitle}>
+                <SquareMark /> Data concepts
+              </h3>
+              <ul className={styles.compactList}>
+                {conceptLinks.map((c) => (
+                  <li key={c.to}>
+                    <Link className={styles.conceptLink} to={c.to}>
+                      {c.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className={styles.panel}>
+              <h3 className={styles.panelTitle}>
+                <SquareMark /> Popular use cases
+              </h3>
+              <ul className={styles.useCaseDense}>
+                {useCaseLinks.map((u) => (
+                  <li key={u.to}>
+                    <Link to={u.to} className={styles.useCaseDenseLink}>
+                      {u.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+              <p className={styles.browseMore}>
+                <Link to="/docs/category/how-to-guides/">All how-to guides</Link>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Minimal video block: square frame, minimal copy */}
+      <div className={styles.band}>
+        <div className={clsx("container", styles.videoRow)}>
+          <SquareMark />
+          <p className={styles.videoCaption}>Intro walkthrough · IDE · first query</p>
+          <SquareMark />
+        </div>
+        <div className={clsx("container", styles.videoBox)}>
+          <div className={styles.videoSquareFrame}>
             <video className={styles.video} controls preload="metadata">
               <source src="/img/intro_video.mp4" type="video/mp4" />
               Your browser does not support the video tag.
             </video>
           </div>
         </div>
-      </Section>
+      </div>
     </section>
   );
 }

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -1,79 +1,93 @@
 import React from "react";
 import clsx from "clsx";
+import Link from "@docusaurus/Link";
 import styles from "./styles.module.css";
 
-const FeatureList = [
+const capabilityCards = [
   {
-    title: "Real-time Blockchain Data",
-    // Svg: require('@site/static/img/BitqueryBW.svg').default,
-    description: (
-      <>
-        Get access to real-time blockchain data through the GraphQL
-        subscriptions.
-      </>
-    ),
+    title: "GraphQL queries",
+    description:
+      "Build HTTP queries for transfers, trades, NFTs, and events across 40+ networks.",
+    to: "/docs/start/first-query/",
   },
   {
-    title: "GraphQL API",
-    // Svg: require('@site/static/img/BitqueryBW.svg').default,
-    description: (
-      <>
-        Access tokens transfers, DEX Trades, NFTs, and other data through
-        Bitquery GraphQL APIs.
-      </>
-    ),
+    title: "Live subscriptions",
+    description:
+      "Stream updates over WebSocket with the same GraphQL shape as queries.",
+    to: "/docs/start/starter-subscriptions/",
   },
   {
-    title: "Cloud Data Sets",
-    // Svg: require('@site/static/img/BitqueryBW.svg').default,
-    description: (
-      <>
-        Access to blockchain data through cloud infra such as AWS S3, Microsoft
-        Azure, Snowflake, Google BigQuery, etc.{" "}
-      </>
-    ),
+    title: "Kafka streams",
+    description:
+      "Low-latency protobuf topics for high-volume pipelines and fan-out.",
+    to: "/docs/streams/kafka-streaming-concepts/",
   },
   {
-    title: "Blockchain Traces",
-    // Svg: require('@site/static/img/BitqueryBW.svg').default,
-    description: (
-      <>
-        Trace every transaction in detail without the need to manage your own
-        archive nodes.{" "}
-      </>
-    ),
+    title: "Cloud datasets",
+    description:
+      "Parquet exports to S3, Snowflake, BigQuery, and other warehouses.",
+    to: "/docs/cloud/",
   },
   {
-    title: "Mempool Information",
-    // Svg: require('@site/static/img/BitqueryBW.svg').default,
-    description: (
-      <>
-        Capture all broadcasted transactions to obtain real-time data for easy
-        transaction simulation.
-      </>
-    ),
+    title: "Mempool data",
+    description:
+      "See broadcast transactions before confirmation for simulation and tooling.",
+    to: "/docs/start/mempool/",
   },
   {
-    title: "DeFi APIs",
-    // Svg: require('@site/static/img/BitqueryBW.svg').default,
-    description: (
-      <>
-        Explore DEX trades, LPs, DAOs, lending, and borrowing info across
-        different networks.
-      </>
-    ),
+    title: "DeFi & trading cubes",
+    description:
+      "DEX trades, pools, and token-level aggregates without running your own node.",
+    to: "/docs/cubes/dextrades-dextradebytokens-trading-trades/",
   },
 ];
 
-function Feature({ Svg, title, description }) {
+const interfaceRows = [
+  {
+    name: "GraphQL (HTTP)",
+    bestFor: "Ad-hoc queries, dashboards, backfills.",
+    to: "/docs/start/endpoints/",
+  },
+  {
+    name: "Subscriptions (WebSocket)",
+    bestFor: "Live feeds with push updates.",
+    to: "/docs/start/getting-updates/",
+  },
+  {
+    name: "Kafka",
+    bestFor: "Scale-out consumers and enterprise pipelines.",
+    to: "/docs/streams/kafka-streaming-concepts/",
+  },
+  {
+    name: "Cloud files",
+    bestFor: "Analytics, ML, and long archival windows.",
+    to: "/docs/cloud/",
+  },
+];
+
+const useCaseLinks = [
+  { label: "Telegram trading bot", to: "/docs/usecases/telegram-bot/" },
+  { label: "Polymarket alerts", to: "/docs/usecases/polymarket-tg-alerts-bot/" },
+  {
+    label: "Real-time balance tracker",
+    to: "/docs/usecases/real-time-balance-tracker/overview/",
+  },
+  { label: "Mempool fees & analysis", to: "/docs/usecases/mempool-transaction-fee/" },
+  { label: "NFT analytics", to: "/docs/usecases/nft-analytics/" },
+  { label: "Copy trading bot", to: "/docs/usecases/copy-trading-bot/" },
+];
+
+function CapabilityCard({ title, description, to }) {
   return (
-    <div className={clsx("col col--4")}>
-      <div className="text--center">
-        {/* <Svg className={styles.featureSvg} role="img" /> */}
-      </div>
-      <div className="text--center padding-horiz--md">
-        <h3>{title}</h3>
-        <p>{description}</p>
+    <div className={clsx("col col--4", styles.cardCol)}>
+      <div className={styles.capabilityCard}>
+        <h3 className={styles.cardTitle}>
+          <Link to={to}>{title}</Link>
+        </h3>
+        <p className={styles.cardBody}>{description}</p>
+        <Link className={styles.cardLink} to={to}>
+          Open docs →
+        </Link>
       </div>
     </div>
   );
@@ -83,28 +97,121 @@ export default function HomepageFeatures() {
   return (
     <section className={styles.features}>
       <div className="container">
+        <h2 className={styles.sectionHeading}>What you can build with</h2>
+        <p className={styles.sectionLead}>
+          Pick a capability below, or read the{" "}
+          <Link to="/docs/intro/">full platform overview</Link> for datasets,
+          IDE, and auth.
+        </p>
         <div className="row">
-          <div className={clsx("col col--12")}>
-            <div className="text--center" style={{ marginBottom: '20px' }}>
-            <p style={{ fontWeight: 'bold', fontSize: '1.2em' }}>
-              Click this video to know how to get started <span role="img" aria-label="point down">👇</span></p>
-            </div>
-            <div style={{ maxWidth: '640px', margin: '0 auto' }}>
-              <video style={{ width: '100%', height: 'auto' }} controls>
-                <source src="/img/intro_video.mp4" type="video/mp4" />
-                Your browser does not support the video tag.
-              </video>
-            </div>
-          </div>
-        </div>
-      </div>
-      {/* <div className="container">
-        <div className="row">
-          {FeatureList.map((props, idx) => (
-            <Feature key={idx} {...props} />
+          {capabilityCards.map((card) => (
+            <CapabilityCard key={card.to} {...card} />
           ))}
         </div>
-      </div> */}
+      </div>
+
+      <div className={clsx("container", styles.sectionBlock)}>
+        <h2 className={styles.sectionHeading}>Interfaces</h2>
+        <p className={styles.sectionLead}>
+          Same underlying data—choose the delivery mechanism that fits latency
+          and scale. See also{" "}
+          <Link to="/docs/mcp/mcp-server/">MCP Server</Link> for IDE and agent
+          integrations.
+        </p>
+        <div className={styles.interfaceTableWrap}>
+          <table className={styles.interfaceTable}>
+            <thead>
+              <tr>
+                <th scope="col">Interface</th>
+                <th scope="col">Best for</th>
+              </tr>
+            </thead>
+            <tbody>
+              {interfaceRows.map((row) => (
+                <tr key={row.to}>
+                  <td>
+                    <Link to={row.to}>{row.name}</Link>
+                  </td>
+                  <td>{row.bestFor}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className={clsx("container", styles.sectionBlock)}>
+        <h2 className={styles.sectionHeading}>Data concepts</h2>
+        <p className={styles.sectionLead}>
+          Learn how transfers, events, calls, and protocol-level trades fit
+          together, then browse curated examples by chain.
+        </p>
+        <ul className={styles.linkList}>
+          <li>
+            <Link to="/docs/start/mental-model-transfers-events-calls/">
+              Mental model: transfers, events &amp; calls
+            </Link>
+          </li>
+          <li>
+            <Link to="/docs/graphql/dataset/archive/">Archive dataset</Link>
+            {" · "}
+            <Link to="/docs/graphql/dataset/realtime/">Realtime dataset</Link>
+            {" · "}
+            <Link to="/docs/graphql/dataset/combined/">Combined dataset</Link>
+          </li>
+          <li>
+            <Link to="/docs/start/starter-queries/">Starter queries by chain</Link>
+            {" · "}
+            <Link to="/docs/grpc/solana/introduction/">
+              gRPC streaming (Solana &amp; more)
+            </Link>
+          </li>
+          <li>
+            <Link to="/docs/API-Blog/what-are-internal-transactions-how-to-get-them/">
+              Internal transactions &amp; traces
+            </Link>
+          </li>
+        </ul>
+      </div>
+
+      <div className={clsx("container", styles.sectionBlock)}>
+        <h2 className={styles.sectionHeading}>Popular use cases</h2>
+        <p className={styles.sectionLead}>
+          Step-by-step guides for bots, dashboards, and monitoring.{" "}
+          <Link to="/docs/category/how-to-guides/">
+            Browse all how-to guides →
+          </Link>
+        </p>
+        <div className="row">
+          {useCaseLinks.map((item) => (
+            <div
+              key={item.to}
+              className={clsx("col col--12 col--md-6 col--lg-4", styles.useCaseCol)}
+            >
+              <Link className={styles.useCaseLink} to={item.to}>
+                {item.label}
+              </Link>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className={clsx("container", styles.sectionBlock)}>
+        <div className="text--center" style={{ marginBottom: "1rem" }}>
+          <p style={{ fontWeight: "bold", fontSize: "1.1em" }}>
+            New to Bitquery? Watch a short intro{" "}
+            <span role="img" aria-label="point down">
+              👇
+            </span>
+          </p>
+        </div>
+        <div style={{ maxWidth: "640px", margin: "0 auto" }}>
+          <video style={{ width: "100%", height: "auto" }} controls>
+            <source src="/img/intro_video.mp4" type="video/mp4" />
+            Your browser does not support the video tag.
+          </video>
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -79,14 +79,14 @@ function SquareMark({ large }) {
 
 function CapabilityCard({ title, description, to }) {
   return (
-    <div className={clsx("col col--12 col--sm-6 col--lg-4", styles.cardCol)}>
-      <Link to={to} className={styles.capabilityCard}>
-        <SquareMark />
-        <h3 className={styles.cardTitle}>{title}</h3>
-        <p className={styles.cardBody}>{description}</p>
-        <span className={styles.cardCta}>Read docs</span>
-      </Link>
-    </div>
+    <Link to={to} className={styles.capabilityCard}>
+      <div className={styles.cardIconBox} aria-hidden>
+        <span className={styles.squareMark} />
+      </div>
+      <h3 className={styles.cardTitle}>{title}</h3>
+      <p className={styles.cardBody}>{description}</p>
+      <span className={styles.cardCta}>Read docs</span>
+    </Link>
   );
 }
 
@@ -94,7 +94,7 @@ export default function HomepageFeatures({ tagline }) {
   return (
     <section className={styles.features}>
       {/* Single dense band: narrative + caps + interfaces */}
-      <div className={styles.band}>
+      <div className={clsx(styles.band, styles.bandSurface)}>
         <div className="container">
           <div className={styles.topRow}>
             <SquareMark large />
@@ -110,7 +110,7 @@ export default function HomepageFeatures({ tagline }) {
             <SquareMark large />
           </div>
 
-          <div className="row">
+          <div className={styles.capabilityGrid}>
             {capabilityCards.map((card) => (
               <CapabilityCard key={card.to} {...card} />
             ))}
@@ -176,7 +176,7 @@ export default function HomepageFeatures({ tagline }) {
       </div>
 
       {/* Minimal video block: square frame, minimal copy */}
-      <div className={styles.band}>
+      <div className={clsx(styles.band, styles.bandVideo)}>
         <div className={clsx("container", styles.videoRow)}>
           <SquareMark />
           <p className={styles.videoCaption}>Intro walkthrough · IDE · first query</p>

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -2,190 +2,360 @@ import React from "react";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
 import styles from "./styles.module.css";
+import { PRODUCTION_MARKETING_SITE } from "@site/src/utils/productionUrl";
+import {
+  bitqueryTools,
+  chainListFullUrl,
+  chains,
+  dataTypes,
+  interfaces,
+  introVideoUrl,
+  personas,
+  platformOverviewUrl,
+  trendingPages,
+  useCases,
+  v1V2ApiGuideUrl,
+} from "./sectionsData";
 
-const capabilityCards = [
-  {
-    title: "GraphQL queries",
-    description:
-      "HTTP queries for transfers, trades, NFTs, and events across 40+ networks.",
-    to: "/docs/start/first-query/",
-  },
-  {
-    title: "Live subscriptions",
-    description:
-      "WebSocket streams with the same GraphQL shape as your queries.",
-    to: "/docs/start/starter-subscriptions/",
-  },
-  {
-    title: "Kafka streams",
-    description:
-      "Protobuf topics for high-volume pipelines and many consumers.",
-    to: "/docs/streams/kafka-streaming-concepts/",
-  },
-  {
-    title: "Cloud datasets",
-    description:
-      "Parquet in S3, Snowflake, BigQuery, and warehouses.",
-    to: "/docs/cloud/",
-  },
-  {
-    title: "Mempool data",
-    description:
-      "Broadcast transactions before confirmation.",
-    to: "/docs/start/mempool/",
-  },
-  {
-    title: "DeFi & trading cubes",
-    description:
-      "DEX trades, pools, and aggregates without archive nodes.",
-    to: "/docs/cubes/dextrades-dextradebytokens-trading-trades/",
-  },
-];
-
-const interfaceItems = [
-  { abbr: "HTTP", name: "GraphQL (HTTP)", hint: "Queries, dashboards", to: "/docs/start/endpoints/" },
-  { abbr: "WS", name: "Subscriptions", hint: "Push over WebSocket", to: "/docs/start/getting-updates/" },
-  { abbr: "KF", name: "Kafka", hint: "Scale-out pipelines", to: "/docs/streams/kafka-streaming-concepts/" },
-  { abbr: "CL", name: "Cloud files", hint: "Batch & analytics", to: "/docs/cloud/" },
-];
-
-const conceptLinks = [
-  { label: "Mental model: transfers, events, calls", to: "/docs/start/mental-model-transfers-events-calls/" },
-  { label: "Archive dataset", to: "/docs/graphql/dataset/archive/" },
-  { label: "Realtime dataset", to: "/docs/graphql/dataset/realtime/" },
-  { label: "Combined dataset", to: "/docs/graphql/dataset/combined/" },
-  { label: "Starter queries by chain", to: "/docs/start/starter-queries/" },
-  { label: "gRPC streaming (Solana)", to: "/docs/grpc/solana/introduction/" },
-  { label: "Internal transactions & traces", to: "/docs/API-Blog/what-are-internal-transactions-how-to-get-them/" },
-];
-
-const useCaseLinks = [
-  { label: "Telegram trading bot", to: "/docs/usecases/telegram-bot/" },
-  { label: "Polymarket alerts", to: "/docs/usecases/polymarket-tg-alerts-bot/" },
-  { label: "Real-time balance tracker", to: "/docs/usecases/real-time-balance-tracker/overview/" },
-  { label: "Mempool fees & analysis", to: "/docs/usecases/mempool-transaction-fee/" },
-  { label: "NFT analytics", to: "/docs/usecases/nft-analytics/" },
-  { label: "Copy trading bot", to: "/docs/usecases/copy-trading-bot/" },
-];
-
-function SquareMark({ large }) {
+function SectionHeader({ kicker, title, children, align = "center" }) {
   return (
-    <span
-      className={clsx(styles.squareMark, large && styles.squareMarkLg)}
-      aria-hidden
-    />
-  );
-}
-
-function CapabilityCard({ title, description, to }) {
-  return (
-    <Link to={to} className={styles.capabilityCard}>
-      <div className={styles.cardIconBox} aria-hidden>
-        <span className={styles.squareMark} />
-      </div>
-      <h3 className={styles.cardTitle}>{title}</h3>
-      <p className={styles.cardBody}>{description}</p>
-      <span className={styles.cardCta}>Read docs</span>
-    </Link>
+    <header
+      className={clsx(
+        styles.sectionHeader,
+        align === "left" && styles.sectionHeaderLeft,
+        align === "center" && styles.sectionHeaderCenter
+      )}
+    >
+      {kicker ? <p className={styles.sectionKicker}>{kicker}</p> : null}
+      <h2 className={styles.sectionTitle}>{title}</h2>
+      {children ? <div className={styles.sectionIntro}>{children}</div> : null}
+    </header>
   );
 }
 
 export default function HomepageFeatures({ tagline }) {
   return (
     <section className={styles.features}>
-      {/* Single dense band: narrative + caps + interfaces */}
-      <div className={clsx(styles.band, styles.bandSurface)}>
+      {/* 1 — Data: split rail + sharp chips */}
+      <div className={clsx(styles.band, styles.bandData)}>
+        <div className={styles.bandDataDecor} aria-hidden />
         <div className="container">
-          <div className={styles.topRow}>
-            <SquareMark large />
-            <div className={styles.topRowText}>
-              <h2 className={styles.primaryTitle}>What you can build</h2>
-              {tagline ? <p className={styles.taglineInline}>{tagline}</p> : null}
-              <p className={styles.primaryLead}>
-                Same data over HTTP, websocket, Kafka, or cloud files. Details:{" "}
-                <Link to="/docs/intro/">platform overview</Link>,{" "}
-                <Link to="/docs/mcp/mcp-server/">MCP Server</Link>.
-              </p>
+          <div className={styles.dataSectionLayout}>
+            <aside className={styles.dataRail} aria-hidden="true">
+              <span className={styles.dataRailNum}>01</span>
+              <span className={styles.dataRailLine} />
+              <span className={styles.dataRailLabel}>Data</span>
+            </aside>
+            <div className={styles.dataSectionBody}>
+              <SectionHeader kicker="What you query" title="Data & metrics" align="left">
+                {tagline ? (
+                  <p className={styles.sectionLead}>{tagline}</p>
+                ) : (
+                  <p className={styles.sectionLead}>
+                    Prices, liquidity events, wallet flows, and protocol traces
+                    across Bitquery datasets — same schema for historical and live
+                    workloads.
+                  </p>
+                )}
+              </SectionHeader>
+              <ul className={styles.dataChipGrid}>
+                {dataTypes.map((d) => (
+                  <li key={d.to}>
+                    <Link to={d.to} className={styles.dataChip}>
+                      <span className={styles.dataChipLabel}>{d.label}</span>
+                      <span className={styles.dataChipHint}>{d.hint}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
             </div>
-            <SquareMark large />
           </div>
+        </div>
+      </div>
 
-          <div className={styles.capabilityGrid}>
-            {capabilityCards.map((card) => (
-              <CapabilityCard key={card.to} {...card} />
+      {/* 2 — Interfaces: striped band + offset panel */}
+      <div className={clsx(styles.band, styles.bandInterfaces)}>
+        <div className={styles.bandInterfacesStripes} aria-hidden />
+        <div className="container">
+          <div className={styles.interfacesIntro}>
+            <span className={styles.stepBadge}>02</span>
+            <SectionHeader kicker="How you connect" title="Interfaces" align="left">
+              <p className={styles.sectionLead}>
+                One mental model: GraphQL for shapes, then stream the same fields
+                over WebSocket, Kafka, MCP, or gRPC.
+              </p>
+            </SectionHeader>
+          </div>
+          <div className={styles.interfacesPanel}>
+            <div className={styles.interfacesPanelHd}>
+              <span className={styles.interfacesPanelAccent} aria-hidden />
+              <p className={styles.interfacesPanelTag}>Delivery modes</p>
+            </div>
+            <div className={styles.interfaceGrid}>
+              {interfaces.map((item) => (
+                <Link key={item.abbr} to={item.to} className={styles.interfaceCell}>
+                  <span className={styles.abbrSquare}>{item.abbr}</span>
+                  <div>
+                    <span className={styles.interfaceName}>{item.name}</span>
+                    <span className={styles.interfaceHint}>{item.hint}</span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+          <div className={styles.apiVersionCta} role="note">
+            <p className={styles.apiVersionCtaText}>
+              <strong>V1 and V2</strong> use different GraphQL schemas and IDE
+              flows. Compare them if you are migrating or reusing older queries.
+            </p>
+            <Link
+              href={v1V2ApiGuideUrl}
+              className={clsx(
+                "button button--outline button--primary",
+                styles.apiVersionBtn
+              )}
+            >
+              V1 vs V2 API guide
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {/* 3 — Tools & explorers */}
+      <div className={clsx(styles.band, styles.bandTools)}>
+        <div className="container">
+          <div className={styles.toolsIntro}>
+            <span className={styles.stepBadge}>03</span>
+            <SectionHeader kicker="Ship faster" title="Tools & explorers" align="left">
+              <p className={styles.sectionLead}>
+                Explore markets, debug queries, and browse demos and SDKs built on
+                Bitquery.
+              </p>
+            </SectionHeader>
+          </div>
+          <ul className={styles.toolsGrid}>
+            {bitqueryTools.map((tool) => (
+              <li key={tool.title}>
+                <Link
+                  href={tool.href}
+                  className={styles.toolCard}
+                  {...(tool.external
+                    ? { target: "_blank", rel: "noopener noreferrer" }
+                    : {})}
+                >
+                  <span className={styles.toolCardTitleRow}>
+                    <span className={styles.toolCardTitle}>{tool.title}</span>
+                    {tool.external ? (
+                      <span className={styles.toolCardOutbound} aria-hidden>
+                        ↗
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className={styles.toolCardHint}>{tool.hint}</span>
+                </Link>
+              </li>
             ))}
-          </div>
+          </ul>
+        </div>
+      </div>
 
-          <div className={styles.interfaceLabelRow}>
-            <span className={styles.squareRule} aria-hidden />
-            <h3 className={styles.interfaceHeading}>Interfaces</h3>
-            <span className={styles.squareRule} aria-hidden />
+      {/* 4 — Chains: monospace matrix */}
+      <div className={clsx(styles.band, styles.bandChains)}>
+        <div className="container">
+          <div className={styles.chainsHeaderRow}>
+            <span className={styles.stepBadgeAlt}>04</span>
+            <SectionHeader
+              kicker="Coverage"
+              title="Blockchains supported"
+              align="left"
+            >
+              <p className={styles.sectionLead}>
+                40+ networks across V1 & V2 — EVM, Solana, Tron, Bitcoin, and
+                more.
+              </p>
+            </SectionHeader>
           </div>
-          <div className={styles.interfaceGrid}>
-            {interfaceItems.map((item) => (
-              <Link key={item.to} to={item.to} className={styles.interfaceCell}>
-                <span className={styles.abbrSquare}>{item.abbr}</span>
-                <div>
-                  <span className={styles.interfaceName}>{item.name}</span>
-                  <span className={styles.interfaceHint}>{item.hint}</span>
-                </div>
+          <div className={styles.chainMatrix}>
+            <div className={styles.chainMatrixInner}>
+              {chains.map((c) => (
+                <Link key={c.label} to={c.to} className={styles.chainTag}>
+                  {c.label}
+                </Link>
+              ))}
+              <Link
+                to={chainListFullUrl}
+                className={clsx(styles.chainTag, styles.chainTagEm)}
+              >
+                Supported chains →
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 4 — Personas: numbered + alternating frames */}
+      <div className={clsx(styles.band, styles.bandPersonas)}>
+        <div className={styles.bandPersonasWaves} aria-hidden />
+        <div className="container">
+          <div className={styles.personasIntro}>
+            <SectionHeader
+              kicker="Who builds here"
+              title="Built for your team"
+              align="center"
+            >
+              <p className={styles.sectionLead}>
+                From discretionary traders to audit-ready reporting — pick a path
+                and open the matching docs.
+              </p>
+            </SectionHeader>
+          </div>
+          <div className={styles.personaGrid}>
+            {personas.map((p, i) => (
+              <Link
+                key={p.title}
+                to={p.to}
+                className={clsx(
+                  styles.personaCard,
+                  i % 2 === 1 && styles.personaCardDashed
+                )}
+              >
+                <span className={styles.personaNum}>{i + 1}</span>
+                <h3 className={styles.personaTitle}>{p.title}</h3>
+                <p className={styles.personaBody}>{p.body}</p>
+                <span className={styles.personaCta}>Explore →</span>
               </Link>
             ))}
           </div>
         </div>
       </div>
 
-      {/* One compact band: concepts | use cases (side by side on large screens) */}
-      <div className={clsx(styles.band, styles.bandAlt)}>
+      {/* 5 — Trending: bento (featured + grid) */}
+      <div className={clsx(styles.band, styles.bandTrending)}>
         <div className="container">
-          <div className={styles.twoCol}>
-            <div className={styles.panel}>
-              <h3 className={styles.panelTitle}>
-                <SquareMark /> Data concepts
-              </h3>
-              <ul className={styles.compactList}>
-                {conceptLinks.map((c) => (
-                  <li key={c.to}>
-                    <Link className={styles.conceptLink} to={c.to}>
-                      {c.label}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </div>
+          <SectionHeader
+            kicker="Popular right now"
+            title="Trending documentation"
+            align="center"
+          >
+            <p className={styles.sectionLead}>
+              High-traffic guides teams open first when integrating streaming
+              market data.
+            </p>
+          </SectionHeader>
+          <div className={styles.trendingBento}>
+            {trendingPages.map((t, i) => (
+              <Link
+                key={t.to}
+                to={t.to}
+                className={clsx(
+                  styles.trendingCard,
+                  i === 0 && styles.trendingCardFeatured
+                )}
+              >
+                {i === 0 ? (
+                  <span className={styles.trendingFeaturedLabel}>Featured</span>
+                ) : null}
+                <h3 className={styles.trendingTitle}>{t.title}</h3>
+                <p className={styles.trendingBody}>{t.body}</p>
+                <span className={styles.trendingCta}>Open guide</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
 
-            <div className={styles.panel}>
-              <h3 className={styles.panelTitle}>
-                <SquareMark /> Popular use cases
-              </h3>
-              <ul className={styles.useCaseDense}>
-                {useCaseLinks.map((u) => (
-                  <li key={u.to}>
-                    <Link to={u.to} className={styles.useCaseDenseLink}>
-                      {u.label}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-              <p className={styles.browseMore}>
-                <Link to="/docs/category/how-to-guides/">All how-to guides</Link>
+      {/* 6 — Use cases: terminal-style block */}
+      <div className={clsx(styles.band, styles.bandUseCases)}>
+        <div className="container">
+          <div className={styles.useCasesSplit}>
+            <SectionHeader kicker="Recipes" title="Use cases & how-tos" align="left">
+              <p className={styles.sectionLead}>
+                End-to-end examples: bots, dashboards, alerts, and research
+                pipelines.
               </p>
+            </SectionHeader>
+            <div className={styles.useCaseTerminal}>
+              <div className={styles.useCaseTerminalBar}>
+                <span className={styles.useCaseDot} />
+                <span className={styles.useCaseDot} />
+                <span className={styles.useCaseDot} />
+                <span className={styles.useCaseTerminalTitle}>examples</span>
+              </div>
+              <div className={styles.useCaseCols}>
+                <ul className={styles.useCaseList}>
+                  {useCases.slice(0, 4).map((u) => (
+                    <li key={u.to}>
+                      <Link className={styles.useCaseLink} to={u.to}>
+                        {u.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+                <ul className={styles.useCaseList}>
+                  {useCases.slice(4).map((u) => (
+                    <li key={u.to}>
+                      <Link className={styles.useCaseLink} to={u.to}>
+                        {u.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </div>
           </div>
         </div>
       </div>
 
-      {/* Minimal video block: square frame, minimal copy */}
+      {/* 7 — Trust: inverted strip */}
+      <div className={clsx(styles.band, styles.bandTrust)}>
+        <div className="container">
+          <div className={styles.trustSplit}>
+            <div className={styles.trustCopy}>
+              <p className={styles.trustKicker}>Production scale</p>
+              <h2 className={styles.trustTitle}>Trusted for on-chain data</h2>
+              <p className={styles.trustLead}>
+                Exchanges, funds, protocols, and investigators rely on Bitquery for
+                trading, compliance, and research — from ad-hoc GraphQL to
+                Kafka-scale delivery.
+              </p>
+            </div>
+            <div className={styles.trustActions}>
+              <Link
+                className={styles.trustBtn}
+                href={`${PRODUCTION_MARKETING_SITE}/`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Visit bitquery.io
+              </Link>
+              <Link
+                className={styles.trustBtnGhost}
+                href={`${PRODUCTION_MARKETING_SITE}/contact`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Enterprise & sales
+              </Link>
+              <Link className={styles.trustBtnGhost} to={platformOverviewUrl}>
+                Platform overview
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Video — rounded + label chip */}
       <div className={clsx(styles.band, styles.bandVideo)}>
         <div className={clsx("container", styles.videoRow)}>
-          <SquareMark />
-          <p className={styles.videoCaption}>Intro walkthrough · IDE · first query</p>
-          <SquareMark />
+          <span className={styles.videoChip}>Watch</span>
+          <p className={styles.videoCaption}>
+            Intro walkthrough · IDE · first query
+          </p>
         </div>
         <div className={clsx("container", styles.videoBox)}>
-          <div className={styles.videoSquareFrame}>
+          <div className={styles.videoFrame}>
             <video className={styles.video} controls preload="metadata">
-              <source src="/img/intro_video.mp4" type="video/mp4" />
+              <source src={introVideoUrl} type="video/mp4" />
               Your browser does not support the video tag.
             </video>
           </div>

--- a/src/components/HomepageFeatures/sectionsData.js
+++ b/src/components/HomepageFeatures/sectionsData.js
@@ -1,0 +1,210 @@
+import { prodDocsPath } from "@site/src/utils/productionUrl";
+
+const u = prodDocsPath;
+
+export const dataTypes = [
+  {
+    label: "Token prices & OHLCV",
+    hint: "Real-time & historical candles",
+    to: u("/docs/trading/crypto-price-api/introduction/"),
+  },
+  {
+    label: "DEX trades",
+    hint: "Swaps, venues, USD notionals",
+    to: u("/docs/trading/crypto-trades-api/trades-api/"),
+  },
+  {
+    label: "Transfers & wallet flows",
+    hint: "Token movements, counterparties",
+    to: u("/docs/start/mental-model-transfers-events-calls/"),
+  },
+  {
+    label: "Contract calls & traces",
+    hint: "Decoded calls, internals",
+    to: u("/docs/API-Blog/what-are-internal-transactions-how-to-get-them/"),
+  },
+  {
+    label: "Smart-contract events",
+    hint: "Logs, protocols, aggregations",
+    to: u("/docs/start/mental-model-transfers-events-calls/"),
+  },
+  {
+    label: "NFTs & metadata",
+    hint: "Collections, transfers, marketplaces",
+    to: u("/docs/blockchain/Ethereum/nft/nft-api/"),
+  },
+  {
+    label: "Balances & holders",
+    hint: "EVM & Solana holder sets",
+    to: u("/docs/evm/balances/"),
+  },
+  {
+    label: "Mempool & pending txs",
+    hint: "Pre-confirmation activity",
+    to: u("/docs/start/mempool/"),
+  },
+];
+
+export const interfaces = [
+  {
+    abbr: "GQL",
+    name: "GraphQL (HTTP)",
+    hint: "Queries & archives",
+    to: u("/docs/start/first-query/"),
+  },
+  {
+    abbr: "WS",
+    name: "WebSocket",
+    hint: "Live subscriptions",
+    to: u("/docs/start/starter-subscriptions/"),
+  },
+  {
+    abbr: "KF",
+    name: "Kafka",
+    hint: "Protobuf streams",
+    to: u("/docs/streams/kafka-streaming-concepts/"),
+  },
+  {
+    abbr: "MCP",
+    name: "MCP server",
+    hint: "AI agents · ClickHouse-backed",
+    to: u("/docs/mcp/mcp-server/"),
+  },
+  {
+    abbr: "S3",
+    name: "Cloud datasets",
+    hint: "Parquet · warehouses",
+    to: u("/docs/cloud/"),
+  },
+  {
+    abbr: "CH",
+    name: "ClickHouse",
+    hint: "Via MCP & exports",
+    to: u("/docs/mcp/mcp-server/"),
+  },
+  {
+    abbr: "gRPC",
+    name: "gRPC streaming",
+    hint: "Solana CoreCast",
+    to: u("/docs/grpc/solana/introduction/"),
+  },
+];
+
+/** Product UIs & tooling — production URLs only (see productionUrl.js for docs). */
+export const bitqueryTools = [
+  {
+    title: "DEXrabbit",
+    hint: "Real-time DEX analytics, tokens, pairs & market heatmaps",
+    href: "https://dexrabbit.com/",
+    external: true,
+  },
+  {
+    title: "Explorer",
+    hint: "Search transactions, tokens & activity across chains",
+    href: "https://explorer.bitquery.io/",
+    external: true,
+  },
+  {
+    title: "GraphQL IDE",
+    hint: "Author, test & share queries against the Bitquery API",
+    href: "https://ide.bitquery.io/",
+    external: true,
+  },
+  {
+    title: "Other tools",
+    hint: "Apps, dashboards, SDKs & agent skills built on Bitquery",
+    href: u("/docs/tools-directory/"),
+    external: false,
+  },
+];
+
+export const chains = [
+  { label: "Ethereum", to: u("/docs/blockchain/Ethereum/") },
+  { label: "Solana", to: u("/docs/blockchain/Solana/") },
+  { label: "BSC", to: u("/docs/blockchain/BSC/") },
+  { label: "Base", to: u("/docs/blockchain/Base/") },
+  { label: "Polygon", to: u("/docs/blockchain/Matic/") },
+  { label: "Arbitrum", to: u("/docs/blockchain/Arbitrum/") },
+  { label: "Optimism", to: u("/docs/blockchain/Optimism/") },
+  { label: "Tron", to: u("/docs/blockchain/Tron/") },
+  { label: "More networks", to: u("/docs/blockchain/introduction/") },
+];
+
+export const personas = [
+  {
+    title: "Traders & desks",
+    body: "Low-latency prices, OHLC, DEX flow, Pump.fun and Solana tape.",
+    to: u("/docs/trading/crypto-price-api/introduction/"),
+  },
+  {
+    title: "Analysts & quants",
+    body: "Cross-chain aggregates, historical archives, and repeatable GraphQL patterns.",
+    to: u("/docs/graphql/dataset/archive/"),
+  },
+  {
+    title: "Auditors & finance",
+    body: "Balances, transfers, and settlement trails for proof and reconciliation.",
+    to: u("/docs/evm/balances/"),
+  },
+  {
+    title: "Investigators & compliance",
+    body: "Wallet timelines, money-flow tracing, entity helpers, and exportable datasets.",
+    to: u("/v1/docs/Examples/coinpath/money-flow-api"),
+  },
+];
+
+export const trendingPages = [
+  {
+    title: "Pump.fun API",
+    body: "Live memecoin trades, OHLCV, bonding curve, PumpSwap migration.",
+    to: u("/docs/blockchain/Solana/Pumpfun/Pump-Fun-API/"),
+  },
+  {
+    title: "Token prices & OHLCV",
+    body: "Multi-chain candles, 1s bars, and price index methodology.",
+    to: u("/docs/trading/crypto-price-api/crypto-ohlc-candle-k-line-api/"),
+  },
+  {
+    title: "Polymarket on-chain",
+    body: "Prediction markets, wallets, PnL, and streaming fills.",
+    to: u("/docs/examples/polymarket-api/polymarket-markets-api/"),
+  },
+  {
+    title: "Token holders",
+    body: "Top holders, concentration, and balance snapshots.",
+    to: u("/docs/blockchain/Solana/solana-token-holders/"),
+  },
+  {
+    title: "MCP for trading data",
+    body: "Natural language over ClickHouse — IDE & agent ready.",
+    to: u("/docs/mcp/mcp-server/"),
+  },
+  {
+    title: "Kafka streaming",
+    body: "Scale-out consumers across trading and EVM topics.",
+    to: u("/docs/streams/"),
+  },
+];
+
+export const useCases = [
+  { label: "Telegram trading bot", to: u("/docs/usecases/telegram-bot/") },
+  { label: "Polymarket alerts", to: u("/docs/usecases/polymarket-tg-alerts-bot/") },
+  {
+    label: "Real-time balance tracker",
+    to: u("/docs/usecases/real-time-balance-tracker/overview/"),
+  },
+  { label: "Mempool fee analysis", to: u("/docs/usecases/mempool-transaction-fee/") },
+  { label: "NFT analytics", to: u("/docs/usecases/nft-analytics/") },
+  { label: "Copy trading bot", to: u("/docs/usecases/copy-trading-bot/") },
+  {
+    label: "TradingView OHLC feed",
+    to: u("/docs/usecases/tradingview-subscription-realtime/realtime_OHLC/"),
+  },
+  { label: "How-to guides (all)", to: u("/docs/category/how-to-guides/") },
+];
+
+export const chainListFullUrl = u("/docs/blockchain/supported-chains/");
+export const platformOverviewUrl = u("/docs/intro/");
+export const introVideoUrl = u("/img/intro_video.mp4");
+/** V1 docs: how V1 GraphQL differs from V2 (same domain, /v1/docs/…). */
+export const v1V2ApiGuideUrl = u("/v1/docs/graphql-ide/v1-and-v2");

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -1,12 +1,117 @@
 .features {
   display: flex;
-  align-items: center;
-  padding: 2rem 0;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 2rem 0 3rem;
   width: 100%;
+}
+
+.sectionHeading {
+  text-align: center;
+  font-size: 1.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.sectionLead {
+  text-align: center;
+  max-width: 42rem;
+  margin: 0 auto 1.5rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.sectionBlock {
+  margin-top: 2.5rem;
+}
+
+.cardCol {
+  margin-bottom: 1.25rem;
+}
+
+.capabilityCard {
+  height: 100%;
+  padding: 1.25rem 1rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-global-radius);
+  background: var(--ifm-background-surface-color);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.cardTitle {
+  font-size: 1.15rem;
+  margin-bottom: 0.5rem;
+}
+
+.cardTitle a {
+  color: var(--ifm-heading-color);
+}
+
+.cardTitle a:hover {
+  text-decoration: none;
+}
+
+.cardBody {
+  flex: 1;
+  margin-bottom: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.cardLink {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.interfaceTableWrap {
+  overflow-x: auto;
+  max-width: 48rem;
+  margin: 0 auto;
+}
+
+.interfaceTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.interfaceTable th,
+.interfaceTable td {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  padding: 0.65rem 0.85rem;
+  text-align: left;
+}
+
+.interfaceTable th {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.linkList {
+  max-width: 40rem;
+  margin: 0 auto;
+  line-height: 1.8;
+}
+
+.useCaseCol {
+  margin-bottom: 0.75rem;
+}
+
+.useCaseLink {
+  display: block;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-global-radius);
+  font-weight: 500;
+  text-align: center;
+}
+
+.useCaseLink:hover {
+  border-color: var(--ifm-color-primary);
+  text-decoration: none;
 }
 
 .featureSvg {
   height: 200px;
   width: 200px;
 }
-

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -7,15 +7,65 @@
   border-bottom: 1px solid var(--ifm-color-emphasis-200);
 }
 
+/* First homepage strip: faint brand tint so it reads as its own section */
+.bandSurface {
+  background: color-mix(
+    in srgb,
+    var(--ifm-color-primary) 5%,
+    var(--ifm-background-color)
+  );
+  border-bottom-color: color-mix(
+    in srgb,
+    var(--ifm-color-primary) 18%,
+    var(--ifm-color-emphasis-200)
+  );
+}
+
 .bandAlt {
-  background: var(--ifm-color-emphasis-100);
+  background: color-mix(
+    in srgb,
+    var(--ifm-color-emphasis-100) 92%,
+    var(--ifm-color-primary) 8%
+  );
+  border-bottom-color: var(--ifm-color-emphasis-300);
+}
+
+/* Video block: neutral band so it alternates with the band above */
+.bandVideo {
+  background: var(--ifm-color-emphasis-50);
+  border-bottom: none;
+}
+
+:global(html[data-theme="dark"]) .bandSurface {
+  background: color-mix(
+    in srgb,
+    var(--ifm-color-primary) 9%,
+    var(--ifm-background-color)
+  );
+  border-bottom-color: color-mix(
+    in srgb,
+    var(--ifm-color-primary) 22%,
+    var(--ifm-color-emphasis-200)
+  );
+}
+
+:global(html[data-theme="dark"]) .bandAlt {
+  background: color-mix(in srgb, var(--ifm-color-emphasis-100) 88%, #0a0e14 12%);
+}
+
+:global(html[data-theme="dark"]) .bandVideo {
+  background: color-mix(
+    in srgb,
+    var(--ifm-background-surface-color) 65%,
+    var(--ifm-background-color)
+  );
 }
 
 /* ── Decorative squares ─────────────────────────────────── */
 .squareMark {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
+  display: block;
+  width: 12px;
+  height: 12px;
   flex-shrink: 0;
   background: var(--ifm-color-primary);
 }
@@ -63,57 +113,123 @@
   color: var(--ifm-color-emphasis-700);
 }
 
-.cardCol {
-  margin-bottom: 0.65rem;
+.cardIconBox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  margin-bottom: 0.75rem;
+  border: 2px solid var(--ifm-color-primary);
+  background: color-mix(in srgb, var(--ifm-color-primary) 14%, transparent);
+  box-sizing: border-box;
+}
+
+.capabilityGrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+  margin-top: 0.25rem;
+}
+
+@media (min-width: 576px) {
+  .capabilityGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 996px) {
+  .capabilityGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.1rem;
+  }
 }
 
 .capabilityCard {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  min-height: 10.5rem;
   height: 100%;
-  padding: 0.85rem 1rem 0.75rem;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 0;
+  padding: 1.25rem 1.2rem 1.1rem;
+  border: 1px solid var(--ifm-color-emphasis-400);
+  border-radius: 2px;
   background: var(--ifm-background-surface-color);
+  font-family: var(--ifm-font-family-base);
   text-decoration: none !important;
   color: inherit;
   transition:
     border-color 0.15s ease,
-    box-shadow 0.15s ease;
-  box-shadow: none;
+    box-shadow 0.15s ease,
+    background-color 0.15s ease;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.05);
 }
 
 .capabilityCard:hover {
   border-color: var(--ifm-color-primary);
-  box-shadow: inset 0 0 0 1px var(--ifm-color-primary);
+  box-shadow: 0 0 0 1px var(--ifm-color-primary);
+  background: color-mix(
+    in srgb,
+    var(--ifm-color-primary) 6%,
+    var(--ifm-background-surface-color)
+  );
 }
 
-.capabilityCard .squareMark {
-  margin-bottom: 0.5rem;
+.capabilityCard:active {
+  transform: translateY(1px);
 }
 
 .cardTitle {
-  font-size: 0.98rem;
+  font-size: 1.0625rem;
   font-weight: 700;
-  margin: 0 0 0.35rem;
+  margin: 0 0 0.5rem;
+  line-height: 1.25;
   color: var(--ifm-heading-color);
+  letter-spacing: -0.015em;
 }
 
 .cardBody {
   flex: 1;
-  margin: 0 0 0.5rem;
-  font-size: 0.82rem;
-  line-height: 1.45;
-  color: var(--ifm-color-emphasis-700);
+  margin: 0 0 0.85rem;
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--ifm-color-emphasis-800);
 }
 
 .cardCta {
-  font-size: 0.78rem;
+  font-size: 0.8125rem;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   color: var(--ifm-color-primary);
+  margin-top: auto;
+}
+
+/* Dark theme: lift cards off page for readability */
+:global(html[data-theme="dark"]) .capabilityCard {
+  background: #1c2128;
+  border-color: #3d4a5c;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}
+
+:global(html[data-theme="dark"]) .capabilityCard:hover {
+  background: #222a35;
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 1px var(--ifm-color-primary), 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+:global(html[data-theme="dark"]) .cardTitle {
+  color: #f0f3f6;
+}
+
+:global(html[data-theme="dark"]) .cardBody {
+  color: #c4cdd5;
+}
+
+:global(html[data-theme="dark"]) .cardIconBox {
+  background: color-mix(in srgb, var(--ifm-color-primary) 22%, #0d1117);
+  border-color: var(--ifm-color-primary-light);
 }
 
 .interfaceLabelRow {
@@ -350,6 +466,10 @@
   .capabilityCard,
   .interfaceCell {
     transition: none;
+  }
+
+  .capabilityCard:active {
+    transform: none;
   }
 }
 

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -2,93 +2,69 @@
   width: 100%;
 }
 
-.taglineStrip {
-  background: linear-gradient(
-    90deg,
-    color-mix(in srgb, var(--ifm-color-primary) 14%, var(--ifm-background-color)),
-    color-mix(in srgb, var(--ifm-color-primary) 8%, var(--ifm-background-color))
-  );
+.band {
+  padding: 1.5rem 0 1.75rem;
   border-bottom: 1px solid var(--ifm-color-emphasis-200);
-  padding: 0.85rem 0;
 }
 
-.taglineInner {
+.bandAlt {
+  background: var(--ifm-color-emphasis-100);
+}
+
+/* ── Decorative squares ─────────────────────────────────── */
+.squareMark {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  background: var(--ifm-color-primary);
+}
+
+.squareMarkLg {
+  width: 14px;
+  height: 14px;
+}
+
+.topRow {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.75rem;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.topRowText {
+  flex: 1;
   text-align: center;
+  max-width: 46rem;
+  margin: 0 auto;
 }
 
-.taglineInner p {
-  margin: 0;
-  font-size: 0.95rem;
-  font-weight: 500;
-  color: var(--ifm-color-emphasis-800);
-  max-width: 48rem;
-  line-height: 1.45;
-}
-
-.taglineMark {
-  color: var(--ifm-color-primary);
-  font-size: 0.65rem;
-  opacity: 0.9;
-  flex-shrink: 0;
-}
-
-.section {
-  padding: 3rem 0;
-}
-
-.sectionAlt {
-  background: var(--ifm-color-emphasis-100);
-  border-top: 1px solid var(--ifm-color-emphasis-200);
-  border-bottom: 1px solid var(--ifm-color-emphasis-200);
-}
-
-.sectionHeader {
-  text-align: center;
-  margin-bottom: 2rem;
-}
-
-.kicker {
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--ifm-color-primary);
-  margin: 0 0 0.5rem;
-}
-
-.sectionHeading {
-  font-size: clamp(1.5rem, 3vw, 2rem);
+.primaryTitle {
+  font-size: 1.35rem;
   font-weight: 800;
+  margin: 0 0 0.35rem;
   letter-spacing: -0.02em;
-  margin: 0 0 0.75rem;
   color: var(--ifm-heading-color);
 }
 
-.sectionLead {
-  max-width: 40rem;
-  margin: 0 auto;
-  color: var(--ifm-color-emphasis-700);
-  font-size: 1.05rem;
-  line-height: 1.6;
-}
-
-.sectionLead p {
-  margin: 0;
-}
-
-.inlineBrowse {
-  display: inline-block;
-  margin-left: 0.35rem;
+.taglineInline {
+  margin: 0 0 0.5rem;
+  font-size: 0.88rem;
   font-weight: 600;
-  white-space: nowrap;
+  color: var(--ifm-color-emphasis-700);
+  line-height: 1.4;
+}
+
+.primaryLead {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--ifm-color-emphasis-700);
 }
 
 .cardCol {
-  margin-bottom: 1.25rem;
+  margin-bottom: 0.65rem;
 }
 
 .capabilityCard {
@@ -96,311 +72,284 @@
   flex-direction: column;
   align-items: flex-start;
   height: 100%;
-  padding: 1.35rem 1.25rem 1.15rem;
-  border-radius: 14px;
-  border: 1px solid var(--ifm-color-emphasis-200);
+  padding: 0.85rem 1rem 0.75rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0;
   background: var(--ifm-background-surface-color);
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
   text-decoration: none !important;
   color: inherit;
-  position: relative;
-  overflow: hidden;
   transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease,
-    border-color 0.2s ease;
-}
-
-.capabilityCard::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: linear-gradient(
-    90deg,
-    var(--ifm-color-primary),
-    color-mix(in srgb, var(--ifm-color-primary) 55%, transparent)
-  );
-  opacity: 0.85;
-  transform: scaleX(0.35);
-  transform-origin: left;
-  transition: transform 0.25s ease;
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+  box-shadow: none;
 }
 
 .capabilityCard:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.1);
-  border-color: color-mix(in srgb, var(--ifm-color-primary) 35%, var(--ifm-color-emphasis-200));
+  border-color: var(--ifm-color-primary);
+  box-shadow: inset 0 0 0 1px var(--ifm-color-primary);
 }
 
-.capabilityCard:hover::before {
-  transform: scaleX(1);
-}
-
-.cardIcon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.75rem;
-  height: 2.75rem;
-  border-radius: 12px;
-  font-size: 1.35rem;
-  line-height: 1;
-  margin-bottom: 0.85rem;
-  background: color-mix(in srgb, var(--ifm-color-primary) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--ifm-color-primary) 22%, transparent);
+.capabilityCard .squareMark {
+  margin-bottom: 0.5rem;
 }
 
 .cardTitle {
-  font-size: 1.12rem;
+  font-size: 0.98rem;
   font-weight: 700;
-  margin: 0 0 0.45rem;
+  margin: 0 0 0.35rem;
   color: var(--ifm-heading-color);
 }
 
 .cardBody {
   flex: 1;
-  margin: 0 0 1rem;
-  font-size: 0.92rem;
-  line-height: 1.5;
+  margin: 0 0 0.5rem;
+  font-size: 0.82rem;
+  line-height: 1.45;
   color: var(--ifm-color-emphasis-700);
 }
 
 .cardCta {
-  font-size: 0.88rem;
+  font-size: 0.78rem;
   font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
   color: var(--ifm-color-primary);
 }
 
-.interfaceCol {
-  margin-bottom: 1rem;
-}
-
-.interfaceCard {
+.interfaceLabelRow {
   display: flex;
-  align-items: flex-start;
-  gap: 1rem;
-  height: 100%;
-  padding: 1.15rem 1.2rem;
-  border-radius: 12px;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  background: var(--ifm-background-surface-color);
-  text-decoration: none !important;
-  color: inherit;
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.04);
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease,
-    border-color 0.2s ease;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 1.25rem 0 0.65rem;
 }
 
-.interfaceCard:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
-  border-color: color-mix(in srgb, var(--ifm-color-primary) 30%, var(--ifm-color-emphasis-200));
-}
-
-.interfaceIcon {
-  font-size: 1.5rem;
-  line-height: 1;
+.interfaceHeading {
+  margin: 0;
   flex-shrink: 0;
-}
-
-.interfaceBody {
-  min-width: 0;
-}
-
-.interfaceName {
-  font-size: 1.02rem;
-  font-weight: 700;
-  margin: 0 0 0.25rem;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
   color: var(--ifm-heading-color);
 }
 
-.interfaceHint {
-  margin: 0;
-  font-size: 0.88rem;
-  line-height: 1.45;
-  color: var(--ifm-color-emphasis-700);
+.squareRule {
+  flex: 1;
+  height: 1px;
+  background: var(--ifm-color-emphasis-300);
+  max-height: 1px;
 }
 
-.conceptGrid {
+/* small square accents on rules */
+.interfaceLabelRow .squareRule {
+  flex: 1;
+  height: 3px;
+  max-height: none;
+  background: repeating-linear-gradient(
+    to right,
+    var(--ifm-color-emphasis-400) 0,
+    var(--ifm-color-emphasis-400) 3px,
+    transparent 3px,
+    transparent 7px
+  );
+}
+
+.interfaceGrid {
   display: grid;
-  gap: 0.85rem;
-  max-width: 52rem;
-  margin: 0 auto 1.25rem;
+  grid-template-columns: 1fr;
+  gap: 0;
+  border: 1px solid var(--ifm-color-emphasis-300);
 }
 
 @media (min-width: 768px) {
-  .conceptGrid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .interfaceGrid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .interfaceCell {
+    border-right: 1px solid var(--ifm-color-emphasis-300);
+  }
+
+  .interfaceCell:last-child {
+    border-right: none;
   }
 }
 
-.conceptTile {
+.interfaceCell {
   display: flex;
-  align-items: center;
-  gap: 0.95rem;
-  padding: 1rem 1.1rem;
-  border-radius: 12px;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  background: var(--ifm-background-surface-color);
+  align-items: flex-start;
+  gap: 0.65rem;
+  padding: 0.65rem 0.75rem;
   text-decoration: none !important;
   color: inherit;
-  transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease,
-    transform 0.2s ease;
+  background: var(--ifm-background-surface-color);
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  transition: background 0.12s ease;
 }
 
-.conceptTile:hover {
-  border-color: var(--ifm-color-primary);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.07);
-  transform: translateX(4px);
+@media (min-width: 768px) {
+  .interfaceCell {
+    border-bottom: none;
+    min-height: 4.75rem;
+  }
 }
 
-.conceptIcon {
-  font-size: 1.35rem;
-  line-height: 1;
+.interfaceCell:hover {
+  background: color-mix(in srgb, var(--ifm-color-primary) 8%, var(--ifm-background-surface-color));
+}
+
+.abbrSquare {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
   flex-shrink: 0;
-  width: 2.35rem;
-  text-align: center;
+  border: 2px solid var(--ifm-color-primary);
+  border-radius: 0;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  color: var(--ifm-color-primary);
+  font-family: var(--ifm-font-family-monospace), ui-monospace, monospace;
 }
 
-.conceptTitle {
-  font-size: 0.98rem;
+.interfaceName {
+  display: block;
+  font-size: 0.82rem;
   font-weight: 700;
-  margin: 0 0 0.2rem;
   color: var(--ifm-heading-color);
+  margin-bottom: 0.15rem;
 }
 
-.conceptDesc {
-  margin: 0;
-  font-size: 0.85rem;
-  line-height: 1.45;
+.interfaceHint {
+  display: block;
+  font-size: 0.75rem;
+  line-height: 1.35;
   color: var(--ifm-color-emphasis-700);
 }
 
-.conceptArrow {
-  margin-left: auto;
-  flex-shrink: 0;
-  font-weight: 700;
-  color: var(--ifm-color-primary);
-  opacity: 0;
-  transform: translateX(-6px);
-  transition:
-    opacity 0.2s ease,
-    transform 0.2s ease;
+.twoCol {
+  display: grid;
+  gap: 1rem 1.5rem;
+  grid-template-columns: 1fr;
 }
 
-.conceptTile:hover .conceptArrow {
-  opacity: 1;
-  transform: translateX(0);
+@media (min-width: 996px) {
+  .twoCol {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    align-items: start;
+  }
 }
 
-.datasetLinks {
-  text-align: center;
-  margin: 0;
+.panel {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  padding: 0.85rem 1rem;
+  background: var(--ifm-background-surface-color);
+  border-radius: 0;
+}
+
+.bandAlt .panel {
+  background: var(--ifm-background-color);
+}
+
+.panelTitle {
+  margin: 0 0 0.6rem;
   font-size: 0.92rem;
-  font-weight: 600;
-}
-
-.datasetLink {
-  color: var(--ifm-color-primary);
-  font-weight: 700;
-}
-
-.datasetLink:hover {
-  color: var(--ifm-color-primary-dark);
-}
-
-.dot {
-  margin: 0 0.4rem;
-  color: var(--ifm-color-emphasis-600);
-  font-weight: 700;
-}
-
-.useCaseCol {
-  margin-bottom: 0.85rem;
-}
-
-.useCaseLink {
+  font-weight: 800;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.85rem 1.1rem;
-  border-radius: 12px;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  background: var(--ifm-background-surface-color);
-  font-weight: 600;
-  font-size: 0.95rem;
-  text-decoration: none !important;
-  color: var(--ifm-font-color-base);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease,
-    border-color 0.2s ease;
+  gap: 0.5rem;
+  color: var(--ifm-heading-color);
 }
 
-.useCaseLink:hover {
-  border-color: var(--ifm-color-primary);
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--ifm-color-primary) 35%, transparent),
-    0 10px 24px rgba(0, 0, 0, 0.08);
-  transform: translateY(-2px);
+.panelTitle .squareMark {
+  margin-top: 2px;
 }
 
-.useCaseArrow {
-  color: var(--ifm-color-primary);
+.compactList,
+.useCaseDense {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.compactList li,
+.useCaseDense li {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.compactList li:first-child,
+.useCaseDense li:first-child {
+  border-top: none;
+}
+
+.conceptLink {
+  display: block;
+  padding: 0.42rem 0;
+  font-size: 0.84rem;
+  font-weight: 500;
+}
+
+.useCaseDenseLink {
+  display: block;
+  padding: 0.42rem 0;
+  font-size: 0.84rem;
+  font-weight: 500;
+}
+
+.browseMore {
+  margin: 0.5rem 0 0;
+  font-size: 0.82rem;
   font-weight: 700;
-  flex-shrink: 0;
-  transition: transform 0.2s ease;
 }
 
-.useCaseLink:hover .useCaseArrow {
-  transform: translateX(4px);
+.videoRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+  padding-bottom: 0.65rem;
 }
 
-.videoSection {
-  max-width: 720px;
-  margin: 0 auto;
+.videoCaption {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ifm-color-emphasis-700);
 }
 
-.videoFrame {
-  border-radius: 16px;
-  overflow: hidden;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  box-shadow:
-    0 4px 6px rgba(0, 0, 0, 0.04),
-    0 24px 48px rgba(0, 0, 0, 0.1);
+.videoBox {
+  display: flex;
+  justify-content: center;
+}
+
+.videoSquareFrame {
+  border: 2px solid var(--ifm-color-emphasis-400);
   background: #000;
+  max-width: 560px;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  border-radius: 0;
+  box-sizing: border-box;
 }
 
 .video {
   display: block;
   width: 100%;
   height: auto;
-  vertical-align: bottom;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .capabilityCard,
-  .interfaceCard,
-  .conceptTile,
-  .useCaseLink,
-  .capabilityCard::before {
+  .interfaceCell {
     transition: none;
-  }
-
-  .capabilityCard:hover,
-  .interfaceCard:hover,
-  .conceptTile:hover,
-  .useCaseLink:hover {
-    transform: none;
   }
 }
 

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -3,291 +3,369 @@
 }
 
 .band {
-  padding: 1.5rem 0 1.75rem;
+  padding: 2.25rem 0 2.65rem;
   border-bottom: 1px solid var(--ifm-color-emphasis-200);
 }
 
-/* First homepage strip: faint brand tint so it reads as its own section */
-.bandSurface {
-  background: color-mix(
-    in srgb,
-    var(--ifm-color-primary) 5%,
-    var(--ifm-background-color)
-  );
-  border-bottom-color: color-mix(
-    in srgb,
-    var(--ifm-color-primary) 18%,
-    var(--ifm-color-emphasis-200)
-  );
+/* ── Shared headers ─────────────────────────────────────── */
+.sectionHeader {
+  margin-bottom: 0;
 }
 
-.bandAlt {
-  background: color-mix(
-    in srgb,
-    var(--ifm-color-emphasis-100) 92%,
-    var(--ifm-color-primary) 8%
-  );
-  border-bottom-color: var(--ifm-color-emphasis-300);
-}
-
-/* Video block: neutral band so it alternates with the band above */
-.bandVideo {
-  background: var(--ifm-color-emphasis-50);
-  border-bottom: none;
-}
-
-:global(html[data-theme="dark"]) .bandSurface {
-  background: color-mix(
-    in srgb,
-    var(--ifm-color-primary) 9%,
-    var(--ifm-background-color)
-  );
-  border-bottom-color: color-mix(
-    in srgb,
-    var(--ifm-color-primary) 22%,
-    var(--ifm-color-emphasis-200)
-  );
-}
-
-:global(html[data-theme="dark"]) .bandAlt {
-  background: color-mix(in srgb, var(--ifm-color-emphasis-100) 88%, #0a0e14 12%);
-}
-
-:global(html[data-theme="dark"]) .bandVideo {
-  background: color-mix(
-    in srgb,
-    var(--ifm-background-surface-color) 65%,
-    var(--ifm-background-color)
-  );
-}
-
-/* ── Decorative squares ─────────────────────────────────── */
-.squareMark {
-  display: block;
-  width: 12px;
-  height: 12px;
-  flex-shrink: 0;
-  background: var(--ifm-color-primary);
-}
-
-.squareMarkLg {
-  width: 14px;
-  height: 14px;
-}
-
-.topRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1.25rem;
-}
-
-.topRowText {
-  flex: 1;
+.sectionHeaderCenter {
   text-align: center;
-  max-width: 46rem;
-  margin: 0 auto;
+  max-width: 42rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 
-.primaryTitle {
-  font-size: 1.35rem;
-  font-weight: 800;
+.sectionHeaderLeft {
+  text-align: left;
+  max-width: 40rem;
+}
+
+.sectionKicker {
   margin: 0 0 0.35rem;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+}
+
+.sectionHeaderLeft .sectionKicker {
+  letter-spacing: 0.18em;
+  color: var(--ifm-color-primary-darker);
+}
+
+.sectionTitle {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+  font-weight: 800;
   letter-spacing: -0.02em;
   color: var(--ifm-heading-color);
+  line-height: 1.15;
 }
 
-.taglineInline {
-  margin: 0 0 0.5rem;
-  font-size: 0.88rem;
-  font-weight: 600;
-  color: var(--ifm-color-emphasis-700);
-  line-height: 1.4;
-}
-
-.primaryLead {
+.sectionIntro {
   margin: 0;
-  font-size: 0.9rem;
-  line-height: 1.5;
-  color: var(--ifm-color-emphasis-700);
 }
 
-.cardIconBox {
+.sectionLead {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.58;
+  color: var(--ifm-color-emphasis-800);
+  text-wrap: balance;
+}
+
+.stepBadge {
+  flex-shrink: 0;
+  width: 2.75rem;
+  height: 2.75rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
-  flex-shrink: 0;
-  margin-bottom: 0.75rem;
-  border: 2px solid var(--ifm-color-primary);
-  background: color-mix(in srgb, var(--ifm-color-primary) 14%, transparent);
-  box-sizing: border-box;
+  border-radius: 50%;
+  font-size: 0.95rem;
+  font-weight: 900;
+  font-family: var(--ifm-font-family-monospace), ui-monospace, monospace;
+  color: #fff;
+  background: var(--ifm-color-primary);
+  box-shadow: 0 4px 0 color-mix(in srgb, var(--ifm-color-primary-darkest) 55%, #000);
 }
 
-.capabilityGrid {
+.stepBadgeAlt {
+  flex-shrink: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid var(--ifm-color-primary);
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-weight: 900;
+  font-family: var(--ifm-font-family-monospace), ui-monospace, monospace;
+  color: var(--ifm-color-primary);
+  background: transparent;
+}
+
+/* ═══ 1 DATA — rail + dot field + sharp chips ═══════════════ */
+.bandData {
+  position: relative;
+  overflow: hidden;
+  background: var(--ifm-background-color);
+  border-bottom-color: var(--ifm-color-emphasis-300);
+  padding-top: 2.5rem;
+}
+
+.bandDataDecor {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  opacity: 0.45;
+  background-image: radial-gradient(
+    var(--ifm-color-emphasis-300) 1px,
+    transparent 1px
+  );
+  background-size: 18px 18px;
+  mask-image: linear-gradient(105deg, black 35%, transparent 82%);
+}
+
+.dataSectionLayout {
+  position: relative;
+  z-index: 1;
   display: grid;
-  gap: 1rem;
+  gap: 1.25rem 2rem;
   grid-template-columns: 1fr;
-  margin-top: 0.25rem;
+}
+
+@media (min-width: 996px) {
+  .dataSectionLayout {
+    grid-template-columns: auto 1fr;
+    align-items: start;
+    gap: 2rem 2.5rem;
+  }
+}
+
+.dataRail {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 0.25rem;
+}
+
+@media (min-width: 996px) {
+  .dataRail {
+    display: flex;
+  }
+}
+
+.dataRailNum {
+  font-size: 2.75rem;
+  font-weight: 900;
+  line-height: 1;
+  letter-spacing: -0.06em;
+  color: color-mix(in srgb, var(--ifm-color-primary) 35%, var(--ifm-heading-color));
+  font-family: var(--ifm-font-family-monospace), ui-monospace, monospace;
+}
+
+.dataRailLine {
+  width: 2px;
+  flex: 1;
+  min-height: 3rem;
+  margin: 0.65rem 0;
+  background: linear-gradient(
+    180deg,
+    var(--ifm-color-primary),
+    transparent
+  );
+}
+
+.dataRailLabel {
+  font-size: 0.62rem;
+  font-weight: 800;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.dataChipGrid {
+  list-style: none;
+  margin: 1.1rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+  grid-template-columns: 1fr;
 }
 
 @media (min-width: 576px) {
-  .capabilityGrid {
+  .dataChipGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (min-width: 996px) {
-  .capabilityGrid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1.1rem;
+  .dataChipGrid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.6rem;
   }
 }
 
-.capabilityCard {
+.dataChip {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  min-height: 10.5rem;
   height: 100%;
-  padding: 1.25rem 1.2rem 1.1rem;
-  border: 1px solid var(--ifm-color-emphasis-400);
+  min-height: 4.6rem;
+  padding: 0.85rem 0.9rem 0.85rem 1rem;
   border-radius: 2px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-left: 3px solid var(--ifm-color-primary);
   background: var(--ifm-background-surface-color);
-  font-family: var(--ifm-font-family-base);
   text-decoration: none !important;
   color: inherit;
   transition:
     border-color 0.15s ease,
     box-shadow 0.15s ease,
     background-color 0.15s ease;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.05);
 }
 
-.capabilityCard:hover {
+.dataChip:hover {
   border-color: var(--ifm-color-primary);
-  box-shadow: 0 0 0 1px var(--ifm-color-primary);
-  background: color-mix(
-    in srgb,
-    var(--ifm-color-primary) 6%,
-    var(--ifm-background-surface-color)
+  box-shadow: 4px 4px 0 color-mix(in srgb, var(--ifm-color-primary) 28%, transparent);
+}
+
+.dataChipLabel {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--ifm-heading-color);
+  margin-bottom: 0.2rem;
+  letter-spacing: -0.01em;
+}
+
+.dataChipHint {
+  font-size: 0.77rem;
+  line-height: 1.35;
+  color: var(--ifm-color-emphasis-700);
+}
+
+/* ═══ 2 INTERFACES — skew stripes + panel ────────────────── */
+.bandInterfaces {
+  position: relative;
+  background: var(--ifm-color-emphasis-100);
+  border-bottom-color: var(--ifm-color-emphasis-300);
+}
+
+.bandInterfacesStripes {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  opacity: 0.22;
+  background: repeating-linear-gradient(
+    -18deg,
+    transparent,
+    transparent 14px,
+    color-mix(in srgb, var(--ifm-color-primary) 45%, transparent) 14px,
+    color-mix(in srgb, var(--ifm-color-primary) 45%, transparent) 15px
   );
 }
 
-.capabilityCard:active {
-  transform: translateY(1px);
+.interfacesIntro {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  margin-bottom: 1.25rem;
 }
 
-.cardTitle {
-  font-size: 1.0625rem;
-  font-weight: 700;
-  margin: 0 0 0.5rem;
-  line-height: 1.25;
-  color: var(--ifm-heading-color);
-  letter-spacing: -0.015em;
-}
-
-.cardBody {
+.interfacesIntro .sectionHeader {
   flex: 1;
-  margin: 0 0 0.85rem;
-  font-size: 0.9375rem;
-  line-height: 1.55;
+  margin-bottom: 0;
+}
+
+.interfacesPanel {
+  position: relative;
+  z-index: 1;
+  border-radius: 4px 18px 18px 4px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-left-width: 4px;
+  border-left-color: var(--ifm-color-primary);
+  background: var(--ifm-background-surface-color);
+  box-shadow: 12px 16px 40px rgba(0, 0, 0, 0.09);
+  overflow: hidden;
+}
+
+.interfacesPanelHd {
+  padding: 0.75rem 1rem 0.65rem;
+  background: color-mix(
+    in srgb,
+    var(--ifm-color-primary) 8%,
+    var(--ifm-background-surface-color)
+  );
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.interfacesPanelAccent {
+  display: none;
+}
+
+.interfacesPanelTag {
+  margin: 0;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.apiVersionCta {
+  position: relative;
+  z-index: 1;
+  margin-top: 1.25rem;
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem 1.25rem;
+  border-radius: 12px;
+  border: 1px dashed var(--ifm-color-emphasis-300);
+  background: color-mix(
+    in srgb,
+    var(--ifm-background-surface-color) 88%,
+    var(--ifm-color-primary)
+  );
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.05);
+}
+
+.apiVersionCtaText {
+  margin: 0;
+  flex: 1 1 16rem;
+  font-size: 0.92rem;
+  line-height: 1.5;
   color: var(--ifm-color-emphasis-800);
 }
 
-.cardCta {
-  font-size: 0.8125rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--ifm-color-primary);
-  margin-top: auto;
-}
-
-/* Dark theme: lift cards off page for readability */
-:global(html[data-theme="dark"]) .capabilityCard {
-  background: #1c2128;
-  border-color: #3d4a5c;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
-}
-
-:global(html[data-theme="dark"]) .capabilityCard:hover {
-  background: #222a35;
-  border-color: var(--ifm-color-primary);
-  box-shadow: 0 0 0 1px var(--ifm-color-primary), 0 4px 14px rgba(0, 0, 0, 0.35);
-}
-
-:global(html[data-theme="dark"]) .cardTitle {
-  color: #f0f3f6;
-}
-
-:global(html[data-theme="dark"]) .cardBody {
-  color: #c4cdd5;
-}
-
-:global(html[data-theme="dark"]) .cardIconBox {
-  background: color-mix(in srgb, var(--ifm-color-primary) 22%, #0d1117);
-  border-color: var(--ifm-color-primary-light);
-}
-
-.interfaceLabelRow {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin: 1.25rem 0 0.65rem;
-}
-
-.interfaceHeading {
-  margin: 0;
-  flex-shrink: 0;
-  font-size: 0.72rem;
-  font-weight: 800;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+.apiVersionCtaText strong {
   color: var(--ifm-heading-color);
+  font-weight: 800;
 }
 
-.squareRule {
-  flex: 1;
-  height: 1px;
-  background: var(--ifm-color-emphasis-300);
-  max-height: 1px;
-}
-
-/* small square accents on rules */
-.interfaceLabelRow .squareRule {
-  flex: 1;
-  height: 3px;
-  max-height: none;
-  background: repeating-linear-gradient(
-    to right,
-    var(--ifm-color-emphasis-400) 0,
-    var(--ifm-color-emphasis-400) 3px,
-    transparent 3px,
-    transparent 7px
-  );
+.apiVersionBtn {
+  flex-shrink: 0;
+  --ifm-button-border-width: 2px;
+  font-weight: 700;
 }
 
 .interfaceGrid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 0;
-  border: 1px solid var(--ifm-color-emphasis-300);
+  gap: 1px;
+  background: var(--ifm-color-emphasis-200);
+  border: 1px solid var(--ifm-color-emphasis-200);
 }
 
-@media (min-width: 768px) {
+@media (min-width: 640px) {
+  .interfaceGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 996px) {
   .interfaceGrid {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
+}
 
-  .interfaceCell {
-    border-right: 1px solid var(--ifm-color-emphasis-300);
-  }
-
-  .interfaceCell:last-child {
-    border-right: none;
+@media (min-width: 1200px) {
+  .interfaceGrid {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
   }
 }
 
@@ -295,35 +373,37 @@
   display: flex;
   align-items: flex-start;
   gap: 0.65rem;
-  padding: 0.65rem 0.75rem;
+  padding: 0.75rem 0.8rem;
+  min-height: 4.75rem;
   text-decoration: none !important;
   color: inherit;
-  background: var(--ifm-background-surface-color);
-  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  background: color-mix(
+    in srgb,
+    var(--ifm-background-surface-color) 94%,
+    var(--ifm-background-color)
+  );
+  border: none;
   transition: background 0.12s ease;
 }
 
-@media (min-width: 768px) {
-  .interfaceCell {
-    border-bottom: none;
-    min-height: 4.75rem;
-  }
-}
-
 .interfaceCell:hover {
-  background: color-mix(in srgb, var(--ifm-color-primary) 8%, var(--ifm-background-surface-color));
+  background: color-mix(
+    in srgb,
+    var(--ifm-color-primary) 10%,
+    var(--ifm-background-surface-color)
+  );
 }
 
 .abbrSquare {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 34px;
+  height: 34px;
   flex-shrink: 0;
+  border-radius: 6px;
   border: 2px solid var(--ifm-color-primary);
-  border-radius: 0;
-  font-size: 0.62rem;
+  font-size: 0.55rem;
   font-weight: 800;
   letter-spacing: 0.02em;
   color: var(--ifm-color-primary);
@@ -340,95 +420,656 @@
 
 .interfaceHint {
   display: block;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   line-height: 1.35;
   color: var(--ifm-color-emphasis-700);
 }
 
-.twoCol {
+/* ═══ 3 TOOLS — product tiles ═════════════════════════════ */
+.bandTools {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--ifm-color-primary) 6%, var(--ifm-background-color)) 0%,
+    var(--ifm-background-color) 100%
+  );
+  border-bottom-color: var(--ifm-color-emphasis-200);
+}
+
+.toolsIntro {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  margin-bottom: 1.2rem;
+}
+
+.toolsIntro .sectionHeader {
+  flex: 1;
+  margin: 0;
+}
+
+.toolsGrid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: grid;
-  gap: 1rem 1.5rem;
+  gap: 0.75rem;
   grid-template-columns: 1fr;
 }
 
+@media (min-width: 640px) {
+  .toolsGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (min-width: 996px) {
-  .twoCol {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  .toolsGrid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.85rem;
+  }
+}
+
+.toolCard {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  height: 100%;
+  min-height: 6.75rem;
+  padding: 1rem 1.05rem;
+  border-radius: 12px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
+  text-decoration: none !important;
+  color: inherit;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.toolCard:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.1);
+}
+
+.toolCardTitleRow {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+  margin-bottom: 0.45rem;
+}
+
+.toolCardTitle {
+  font-size: 0.95rem;
+  font-weight: 800;
+  color: var(--ifm-heading-color);
+  letter-spacing: -0.015em;
+  line-height: 1.2;
+}
+
+.toolCardOutbound {
+  flex-shrink: 0;
+  font-size: 0.85rem;
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.toolCardHint {
+  font-size: 0.8rem;
+  line-height: 1.45;
+  color: var(--ifm-color-emphasis-700);
+}
+
+/* ═══ 4 CHAINS — matrix ═══════════════════════════════════ */
+.bandChains {
+  background: var(--ifm-background-color);
+  border-bottom: 3px double var(--ifm-color-emphasis-300);
+}
+
+.chainsHeaderRow {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  margin-bottom: 1.1rem;
+}
+
+.chainsHeaderRow .sectionHeader {
+  flex: 1;
+  margin: 0;
+}
+
+.chainMatrix {
+  padding: 0.35rem;
+  border-radius: 2px;
+  background: linear-gradient(
+    135deg,
+    var(--ifm-color-emphasis-100),
+    var(--ifm-background-surface-color)
+  );
+  border: 1px solid var(--ifm-color-emphasis-300);
+}
+
+.chainMatrixInner {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  padding: 0.65rem;
+  background: var(--ifm-background-surface-color);
+  border: 1px dashed var(--ifm-color-emphasis-300);
+}
+
+.chainTag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.42rem 0.75rem;
+  border-radius: 2px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  font-family: var(--ifm-font-family-monospace), ui-monospace, monospace;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  text-decoration: none !important;
+  transition:
+    border-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.chainTag:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary-darker);
+}
+
+.chainTagEm {
+  border-style: solid;
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+  font-weight: 800;
+}
+
+/* ═══ 4 PERSONAS — wave + alternating ═══════════════════ */
+.bandPersonas {
+  position: relative;
+  overflow: hidden;
+  background: color-mix(
+    in srgb,
+    var(--ifm-color-primary) 4%,
+    var(--ifm-background-color)
+  );
+  border-bottom-color: var(--ifm-color-emphasis-200);
+}
+
+.bandPersonasWaves {
+  pointer-events: none;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 56%;
+  opacity: 0.12;
+  background: repeating-radial-gradient(
+    circle at 70% 120%,
+    transparent 0,
+    transparent 28px,
+    var(--ifm-color-primary) 28px,
+    var(--ifm-color-primary) 29px
+  );
+}
+
+.personasIntro {
+  position: relative;
+  z-index: 1;
+}
+
+.personaGrid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: 1fr;
+  margin-top: 1.35rem;
+}
+
+@media (min-width: 768px) {
+  .personaGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.personaCard {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 1.15rem 1.2rem 1.1rem;
+  min-height: 10rem;
+  border-radius: 14px;
+  border: 2px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
+  text-decoration: none !important;
+  color: inherit;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.06);
+  transition:
+    border-color 0.15s ease,
+    transform 0.12s ease;
+}
+
+.personaCardDashed {
+  border-style: dashed;
+  border-width: 2px;
+  border-radius: 4px;
+  box-shadow: none;
+  background: color-mix(
+    in srgb,
+    var(--ifm-background-surface-color) 88%,
+    var(--ifm-color-primary) 4%
+  );
+}
+
+.personaCard:hover {
+  border-color: var(--ifm-color-primary);
+  transform: translateY(-3px);
+}
+
+.personaCardDashed:hover {
+  transform: translateY(-2px);
+}
+
+.personaNum {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.82rem;
+  font-weight: 900;
+  color: #fff;
+  background: var(--ifm-color-primary-darker);
+  margin-bottom: 0.6rem;
+}
+
+.personaTitle {
+  margin: 0 0 0.4rem;
+  font-size: 1.06rem;
+  font-weight: 800;
+  color: var(--ifm-heading-color);
+  letter-spacing: -0.018em;
+}
+
+.personaBody {
+  margin: 0;
+  flex: 1;
+  font-size: 0.87rem;
+  line-height: 1.52;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.personaCta {
+  margin-top: 0.75rem;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+}
+
+/* ═══ 5 TRENDING — even 3× grid ═══════════════════════════ */
+.bandTrending {
+  background: var(--ifm-background-color);
+  border-bottom-color: var(--ifm-color-emphasis-200);
+}
+
+.trendingBento {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: 1fr;
+  margin-top: 1.25rem;
+}
+
+@media (min-width: 768px) {
+  .trendingBento {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 996px) {
+  .trendingBento {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-auto-rows: minmax(11rem, auto);
+    gap: 1rem;
+    align-items: stretch;
+  }
+}
+
+.trendingCard {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1.05rem 1.1rem;
+  min-height: 10.25rem;
+  border-radius: 10px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
+  text-decoration: none !important;
+  color: inherit;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.trendingCard:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+}
+
+.trendingCardFeatured {
+  border-width: 2px;
+  border-color: var(--ifm-color-primary);
+  background: linear-gradient(
+    145deg,
+    color-mix(in srgb, var(--ifm-color-primary) 10%, var(--ifm-background-surface-color)),
+    var(--ifm-background-surface-color) 65%
+  );
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--ifm-color-primary) 12%, transparent);
+}
+
+.trendingFeaturedLabel {
+  align-self: flex-start;
+  margin-bottom: 0.45rem;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #fff;
+  background: var(--ifm-color-primary);
+  border-radius: 4px;
+}
+
+.trendingTitle {
+  margin: 0 0 0.4rem;
+  font-size: 0.97rem;
+  font-weight: 800;
+  color: var(--ifm-heading-color);
+  line-height: 1.22;
+}
+
+.trendingBody {
+  margin: 0;
+  flex: 1;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.trendingCta {
+  margin-top: auto;
+  padding-top: 0.65rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+}
+
+/* ═══ 6 USE CASES — terminal ══════════════════════════════ */
+.bandUseCases {
+  background: var(--ifm-color-emphasis-100);
+  border-bottom-color: var(--ifm-color-emphasis-300);
+}
+
+.useCasesSplit {
+  display: grid;
+  gap: 1.35rem;
+}
+
+@media (min-width: 996px) {
+  .useCasesSplit {
+    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.25fr);
+    gap: 2rem;
     align-items: start;
   }
 }
 
-.panel {
-  border: 1px solid var(--ifm-color-emphasis-300);
-  padding: 0.85rem 1rem;
+.useCaseTerminal {
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--ifm-color-emphasis-400);
   background: var(--ifm-background-surface-color);
-  border-radius: 0;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.1);
 }
 
-.bandAlt .panel {
-  background: var(--ifm-background-color);
-}
-
-.panelTitle {
-  margin: 0 0 0.6rem;
-  font-size: 0.92rem;
-  font-weight: 800;
+.useCaseTerminalBar {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  color: var(--ifm-heading-color);
+  gap: 0.45rem;
+  padding: 0.5rem 0.75rem;
+  background: color-mix(in srgb, var(--ifm-color-emphasis-800) 12%, #1a1f26);
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
 }
 
-.panelTitle .squareMark {
-  margin-top: 2px;
+.useCaseDot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--ifm-color-emphasis-500);
 }
 
-.compactList,
-.useCaseDense {
+.useCaseDot:first-child {
+  background: #ff5f57;
+}
+
+.useCaseDot:nth-child(2) {
+  background: #febc2e;
+}
+
+.useCaseDot:nth-child(3) {
+  background: #28c840;
+}
+
+.useCaseTerminalTitle {
+  margin-left: 0.5rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  font-family: var(--ifm-font-family-monospace), ui-monospace, monospace;
+  color: var(--ifm-color-emphasis-600);
+  letter-spacing: 0.06em;
+}
+
+.useCaseTerminal .useCaseCols {
+  padding: 0.65rem 1rem 0.85rem;
+}
+
+.useCaseCols {
+  display: grid;
+  gap: 0 1.5rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 520px) {
+  .useCaseCols {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.useCaseList {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.compactList li,
-.useCaseDense li {
-  margin: 0;
-  padding: 0;
+.useCaseList li {
   border-top: 1px solid var(--ifm-color-emphasis-200);
 }
 
-.compactList li:first-child,
-.useCaseDense li:first-child {
+.useCaseList li:first-child {
   border-top: none;
 }
 
-.conceptLink {
+.useCaseLink {
   display: block;
-  padding: 0.42rem 0;
+  padding: 0.45rem 0.15rem 0.45rem 1.1rem;
+  margin: 0;
   font-size: 0.84rem;
   font-weight: 500;
+  font-family: var(--ifm-font-family-monospace), ui-monospace, monospace;
+  border-radius: 0;
+  position: relative;
+  color: var(--ifm-font-color-base);
+  text-decoration: none !important;
+  transition: background-color 0.12s ease;
 }
 
-.useCaseDenseLink {
-  display: block;
-  padding: 0.42rem 0;
-  font-size: 0.84rem;
-  font-weight: 500;
+.useCaseLink::before {
+  content: "›";
+  position: absolute;
+  left: 0.15rem;
+  color: var(--ifm-color-primary);
+  font-weight: 900;
 }
 
-.browseMore {
-  margin: 0.5rem 0 0;
-  font-size: 0.82rem;
+.useCaseLink:hover {
+  background: color-mix(in srgb, var(--ifm-color-primary) 9%, transparent);
+}
+
+/* ═══ 7 TRUST — inverted ═════════════════════════════════ */
+.bandTrust {
+  background: var(--ifm-color-primary-darkest);
+  color: rgba(255, 255, 255, 0.92);
+  border-bottom: none;
+  padding: 2.5rem 0 2.75rem;
+}
+
+.trustSplit {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 996px) {
+  .trustSplit {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+  }
+}
+
+.trustCopy {
+  max-width: 38rem;
+}
+
+.trustKicker {
+  margin: 0 0 0.4rem;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary-lighter);
+}
+
+.trustTitle {
+  margin: 0 0 0.55rem;
+  font-size: 1.45rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: #fff;
+  line-height: 1.15;
+}
+
+.trustLead {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.trustActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  justify-content: flex-start;
+}
+
+@media (min-width: 996px) {
+  .trustActions {
+    justify-content: flex-end;
+    flex-shrink: 0;
+  }
+}
+
+.trustBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.2rem;
+  border-radius: var(--ifm-button-border-radius);
+  font-size: 0.86rem;
   font-weight: 700;
+  background: #fff;
+  color: var(--ifm-color-primary-darkest) !important;
+  text-decoration: none !important;
+  border: 1px solid #fff;
+}
+
+.trustBtn:hover {
+  filter: brightness(0.96);
+  color: var(--ifm-color-primary-darkest) !important;
+}
+
+.trustBtnGhost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.15rem;
+  border-radius: var(--ifm-button-border-radius);
+  font-size: 0.86rem;
+  font-weight: 600;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: transparent;
+  color: #fff !important;
+  text-decoration: none !important;
+}
+
+.trustBtnGhost:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.75);
+  color: #fff !important;
+}
+
+/* ═══ VIDEO ═══════════════════════════════════════════════ */
+.bandVideo {
+  background: color-mix(
+    in srgb,
+    var(--ifm-color-emphasis-100) 35%,
+    var(--ifm-background-color)
+  );
+  border-bottom: none;
+  padding-bottom: 2.25rem;
 }
 
 .videoRow {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.65rem;
+  gap: 0.85rem;
   flex-wrap: wrap;
-  padding-bottom: 0.65rem;
+  padding-bottom: 0.75rem;
+}
+
+.videoChip {
+  padding: 0.28rem 0.65rem;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary-darker);
+  background: color-mix(in srgb, var(--ifm-color-primary) 16%, transparent);
+  border: 1px solid var(--ifm-color-primary);
+  border-radius: 6px;
 }
 
 .videoCaption {
@@ -445,14 +1086,14 @@
   justify-content: center;
 }
 
-.videoSquareFrame {
-  border: 2px solid var(--ifm-color-emphasis-400);
+.videoFrame {
+  border-radius: 14px;
+  overflow: hidden;
+  border: 3px solid var(--ifm-color-emphasis-400);
   background: #000;
   max-width: 560px;
   width: 100%;
-  padding: 0;
-  margin: 0;
-  border-radius: 0;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.2);
   box-sizing: border-box;
 }
 
@@ -462,18 +1103,143 @@
   height: auto;
 }
 
+/* ── Dark theme ────────────────────────────────────────── */
+:global(html[data-theme="dark"]) .sectionLead {
+  color: var(--ifm-color-emphasis-600);
+}
+
+:global(html[data-theme="dark"]) .bandData {
+  background: #0d1117;
+}
+
+:global(html[data-theme="dark"]) .bandDataDecor {
+  opacity: 0.35;
+}
+
+:global(html[data-theme="dark"]) .dataChip {
+  background: #161d27;
+  border-color: #2f3d4f;
+}
+
+:global(html[data-theme="dark"]) .bandInterfaces {
+  background: #141c24;
+}
+
+:global(html[data-theme="dark"]) .interfacesPanel {
+  background: #1a2330;
+  border-color: #3d4f63;
+  box-shadow: 14px 18px 50px rgba(0, 0, 0, 0.45);
+}
+
+:global(html[data-theme="dark"]) .interfaceGrid {
+  background: #2a3544;
+  border-color: #354556;
+}
+
+:global(html[data-theme="dark"]) .interfaceCell {
+  background: rgba(10, 14, 20, 0.65);
+}
+
+:global(html[data-theme="dark"]) .interfaceCell:hover {
+  background: color-mix(in srgb, var(--ifm-color-primary) 14%, #151d28);
+}
+
+:global(html[data-theme="dark"]) .apiVersionCta {
+  border-color: #354556;
+  background: color-mix(in srgb, #151d26 90%, var(--ifm-color-primary));
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.35);
+}
+
+:global(html[data-theme="dark"]) .apiVersionCtaText {
+  color: var(--ifm-color-emphasis-600);
+}
+
+:global(html[data-theme="dark"]) .bandTools {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--ifm-color-primary) 10%, #141c24) 0%,
+    #121920 100%
+  );
+  border-bottom-color: #2f3d4f;
+}
+
+:global(html[data-theme="dark"]) .toolCard {
+  background: #151d26;
+  border-color: #354556;
+  box-shadow: 0 8px 26px rgba(0, 0, 0, 0.35);
+}
+
+:global(html[data-theme="dark"]) .toolCard:hover {
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.45);
+}
+
+:global(html[data-theme="dark"]) .chainMatrixInner {
+  background: #121920;
+  border-color: #2f3d4f;
+}
+
+:global(html[data-theme="dark"]) .chainTag {
+  background: #151d26;
+  border-color: #354556;
+}
+
+:global(html[data-theme="dark"]) .bandPersonas {
+  background: linear-gradient(
+    180deg,
+    #0f151c 0%,
+    color-mix(in srgb, var(--ifm-color-primary) 6%, #0f151c) 100%
+  );
+}
+
+:global(html[data-theme="dark"]) .personaCard {
+  background: #151d26;
+  border-color: #334558;
+}
+
+:global(html[data-theme="dark"]) .personaCardDashed {
+  background: rgba(21, 29, 38, 0.65);
+}
+
+:global(html[data-theme="dark"]) .trendingCard {
+  background: #151d26;
+  border-color: #2f4052;
+}
+
+:global(html[data-theme="dark"]) .bandUseCases {
+  background: #121920;
+}
+
+:global(html[data-theme="dark"]) .useCaseTerminalBar {
+  background: #0a0e12;
+  border-color: #2a3544;
+}
+
+:global(html[data-theme="dark"]) .useCaseTerminal {
+  border-color: #354556;
+  background: #151d26;
+}
+
+:global(html[data-theme="dark"]) .bandTrust {
+  background: linear-gradient(
+    135deg,
+    #062e26 0%,
+    var(--ifm-color-primary-darkest) 50%
+  );
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .capabilityCard,
-  .interfaceCell {
+  .dataChip,
+  .interfaceCell,
+  .personaCard,
+  .trendingCard,
+  .chainTag,
+  .toolCard {
     transition: none;
   }
 
-  .capabilityCard:active {
+  .personaCard:hover,
+  .trendingCard:hover,
+  .dataChip:hover {
     transform: none;
   }
-}
-
-.featureSvg {
-  height: 200px;
-  width: 200px;
 }

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -1,26 +1,90 @@
 .features {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  padding: 2rem 0 3rem;
   width: 100%;
 }
 
-.sectionHeading {
+.taglineStrip {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--ifm-color-primary) 14%, var(--ifm-background-color)),
+    color-mix(in srgb, var(--ifm-color-primary) 8%, var(--ifm-background-color))
+  );
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  padding: 0.85rem 0;
+}
+
+.taglineInner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
   text-align: center;
-  font-size: 1.75rem;
-  margin-bottom: 0.5rem;
+}
+
+.taglineInner p {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--ifm-color-emphasis-800);
+  max-width: 48rem;
+  line-height: 1.45;
+}
+
+.taglineMark {
+  color: var(--ifm-color-primary);
+  font-size: 0.65rem;
+  opacity: 0.9;
+  flex-shrink: 0;
+}
+
+.section {
+  padding: 3rem 0;
+}
+
+.sectionAlt {
+  background: var(--ifm-color-emphasis-100);
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.sectionHeader {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.kicker {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+  margin: 0 0 0.5rem;
+}
+
+.sectionHeading {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.75rem;
+  color: var(--ifm-heading-color);
 }
 
 .sectionLead {
-  text-align: center;
-  max-width: 42rem;
-  margin: 0 auto 1.5rem;
+  max-width: 40rem;
+  margin: 0 auto;
   color: var(--ifm-color-emphasis-700);
+  font-size: 1.05rem;
+  line-height: 1.6;
 }
 
-.sectionBlock {
-  margin-top: 2.5rem;
+.sectionLead p {
+  margin: 0;
+}
+
+.inlineBrowse {
+  display: inline-block;
+  margin-left: 0.35rem;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .cardCol {
@@ -28,87 +92,316 @@
 }
 
 .capabilityCard {
-  height: 100%;
-  padding: 1.25rem 1rem;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: var(--ifm-global-radius);
-  background: var(--ifm-background-surface-color);
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  text-align: left;
+  height: 100%;
+  padding: 1.35rem 1.25rem 1.15rem;
+  border-radius: 14px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-background-surface-color);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
+  text-decoration: none !important;
+  color: inherit;
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.capabilityCard::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    var(--ifm-color-primary),
+    color-mix(in srgb, var(--ifm-color-primary) 55%, transparent)
+  );
+  opacity: 0.85;
+  transform: scaleX(0.35);
+  transform-origin: left;
+  transition: transform 0.25s ease;
+}
+
+.capabilityCard:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.1);
+  border-color: color-mix(in srgb, var(--ifm-color-primary) 35%, var(--ifm-color-emphasis-200));
+}
+
+.capabilityCard:hover::before {
+  transform: scaleX(1);
+}
+
+.cardIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 12px;
+  font-size: 1.35rem;
+  line-height: 1;
+  margin-bottom: 0.85rem;
+  background: color-mix(in srgb, var(--ifm-color-primary) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ifm-color-primary) 22%, transparent);
 }
 
 .cardTitle {
-  font-size: 1.15rem;
-  margin-bottom: 0.5rem;
-}
-
-.cardTitle a {
+  font-size: 1.12rem;
+  font-weight: 700;
+  margin: 0 0 0.45rem;
   color: var(--ifm-heading-color);
-}
-
-.cardTitle a:hover {
-  text-decoration: none;
 }
 
 .cardBody {
   flex: 1;
-  margin-bottom: 0.75rem;
-  font-size: 0.95rem;
+  margin: 0 0 1rem;
+  font-size: 0.92rem;
+  line-height: 1.5;
   color: var(--ifm-color-emphasis-700);
 }
 
-.cardLink {
-  font-size: 0.9rem;
+.cardCta {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+}
+
+.interfaceCol {
+  margin-bottom: 1rem;
+}
+
+.interfaceCard {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  height: 100%;
+  padding: 1.15rem 1.2rem;
+  border-radius: 12px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-background-surface-color);
+  text-decoration: none !important;
+  color: inherit;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.04);
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.interfaceCard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
+  border-color: color-mix(in srgb, var(--ifm-color-primary) 30%, var(--ifm-color-emphasis-200));
+}
+
+.interfaceIcon {
+  font-size: 1.5rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.interfaceBody {
+  min-width: 0;
+}
+
+.interfaceName {
+  font-size: 1.02rem;
+  font-weight: 700;
+  margin: 0 0 0.25rem;
+  color: var(--ifm-heading-color);
+}
+
+.interfaceHint {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.45;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.conceptGrid {
+  display: grid;
+  gap: 0.85rem;
+  max-width: 52rem;
+  margin: 0 auto 1.25rem;
+}
+
+@media (min-width: 768px) {
+  .conceptGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.conceptTile {
+  display: flex;
+  align-items: center;
+  gap: 0.95rem;
+  padding: 1rem 1.1rem;
+  border-radius: 12px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-background-surface-color);
+  text-decoration: none !important;
+  color: inherit;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.conceptTile:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.07);
+  transform: translateX(4px);
+}
+
+.conceptIcon {
+  font-size: 1.35rem;
+  line-height: 1;
+  flex-shrink: 0;
+  width: 2.35rem;
+  text-align: center;
+}
+
+.conceptTitle {
+  font-size: 0.98rem;
+  font-weight: 700;
+  margin: 0 0 0.2rem;
+  color: var(--ifm-heading-color);
+}
+
+.conceptDesc {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.conceptArrow {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+  opacity: 0;
+  transform: translateX(-6px);
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+
+.conceptTile:hover .conceptArrow {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.datasetLinks {
+  text-align: center;
+  margin: 0;
+  font-size: 0.92rem;
   font-weight: 600;
 }
 
-.interfaceTableWrap {
-  overflow-x: auto;
-  max-width: 48rem;
-  margin: 0 auto;
+.datasetLink {
+  color: var(--ifm-color-primary);
+  font-weight: 700;
 }
 
-.interfaceTable {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.95rem;
+.datasetLink:hover {
+  color: var(--ifm-color-primary-dark);
 }
 
-.interfaceTable th,
-.interfaceTable td {
-  border: 1px solid var(--ifm-color-emphasis-200);
-  padding: 0.65rem 0.85rem;
-  text-align: left;
-}
-
-.interfaceTable th {
-  background: var(--ifm-color-emphasis-100);
-}
-
-.linkList {
-  max-width: 40rem;
-  margin: 0 auto;
-  line-height: 1.8;
+.dot {
+  margin: 0 0.4rem;
+  color: var(--ifm-color-emphasis-600);
+  font-weight: 700;
 }
 
 .useCaseCol {
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.85rem;
 }
 
 .useCaseLink {
-  display: block;
-  padding: 0.6rem 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: 12px;
   border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: var(--ifm-global-radius);
-  font-weight: 500;
-  text-align: center;
+  background: var(--ifm-background-surface-color);
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none !important;
+  color: var(--ifm-font-color-base);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .useCaseLink:hover {
   border-color: var(--ifm-color-primary);
-  text-decoration: none;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--ifm-color-primary) 35%, transparent),
+    0 10px 24px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+}
+
+.useCaseArrow {
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.useCaseLink:hover .useCaseArrow {
+  transform: translateX(4px);
+}
+
+.videoSection {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.videoFrame {
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  box-shadow:
+    0 4px 6px rgba(0, 0, 0, 0.04),
+    0 24px 48px rgba(0, 0, 0, 0.1);
+  background: #000;
+}
+
+.video {
+  display: block;
+  width: 100%;
+  height: auto;
+  vertical-align: bottom;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .capabilityCard,
+  .interfaceCard,
+  .conceptTile,
+  .useCaseLink,
+  .capabilityCard::before {
+    transition: none;
+  }
+
+  .capabilityCard:hover,
+  .interfaceCard:hover,
+  .conceptTile:hover,
+  .useCaseLink:hover {
+    transform: none;
+  }
 }
 
 .featureSvg {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -68,3 +68,34 @@ button.copy-md {
 button.copy-md:hover {
   background: var(--ifm-color-primary);
 }
+
+/* Supported chains matrix — sticky header while scrolling the doc */
+.supportedChainsStickyTable {
+  margin-bottom: 1rem;
+}
+
+.supportedChainsStickyTable table {
+  margin-bottom: 0;
+}
+
+.supportedChainsStickyTable thead th {
+  position: sticky;
+  /* Stay below fixed doc navbar + small gap */
+  top: calc(var(--ifm-navbar-height, 60px) + 4px);
+  z-index: 5;
+  background: var(--ifm-background-color);
+  box-shadow: inset 0 -1px 0 var(--ifm-table-border-color);
+  white-space: nowrap;
+}
+
+[data-theme="dark"] .supportedChainsStickyTable thead th {
+  background: var(--ifm-background-color);
+  box-shadow: inset 0 -1px 0 var(--ifm-table-border-color);
+}
+
+@media (max-width: 996px) {
+  .supportedChainsStickyTable thead th {
+    /* Mobile nav / Less room — keep flush under navbar */
+    top: calc(var(--ifm-navbar-height, 50px) + 2px);
+  }
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import clsx from 'clsx';
-import { Helmet } from 'react-helmet'; // Import react-helmet
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
@@ -19,18 +18,23 @@ function HomepageHeader() {
       <div className={styles.buttonGroup}>
         <Link
           className="button button--secondary button--lg"
-          to="/docs/start/first-query">
+          to="/docs/start/first-query/">
           Getting Started - 5min ⏱️
         </Link>
         <Link
           className="button button--secondary button--lg"
-          to="/docs/start/starter-queries">
+          to="/docs/start/starter-queries/">
           Popular APIs 📂
         </Link>
         <Link
           className="button button--secondary button--lg"
-          to="/docs/start/starter-subscriptions">
+          to="/docs/start/starter-subscriptions/">
           Popular Streams 📂
+        </Link>
+        <Link
+          className="button button--secondary button--lg"
+          to="/docs/intro/">
+          Docs overview 📖
         </Link>
       </div>
     </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,57 +1,66 @@
-import React from 'react';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
+import React from "react";
+import clsx from "clsx";
+import Link from "@docusaurus/Link";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import Layout from "@theme/Layout";
+import HomepageFeatures from "@site/src/components/HomepageFeatures";
 
-import styles from './index.module.css';
+import styles from "./index.module.css";
 
 function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
   return (
-    <div className={clsx('hero hero--primary', styles.heroBanner)}>
-    <div className="container">
-      {/* <h1 className="hero__title">{siteConfig.title}</h1> */}
-      <h1 className="hero__title" style={{fontSize: '3.5rem', fontWeight: 'bold', marginBottom: '1rem'}}>Bitquery Streaming API Docs</h1>
-      <p className="hero__subtitle">{siteConfig.tagline}</p>
-      <div className={styles.buttonGroup}>
-        <Link
-          className="button button--secondary button--lg"
-          to="/docs/start/first-query/">
-          Getting Started - 5min ⏱️
-        </Link>
-        <Link
-          className="button button--secondary button--lg"
-          to="/docs/start/starter-queries/">
-          Popular APIs 📂
-        </Link>
-        <Link
-          className="button button--secondary button--lg"
-          to="/docs/start/starter-subscriptions/">
-          Popular Streams 📂
-        </Link>
-        <Link
-          className="button button--secondary button--lg"
-          to="/docs/intro/">
-          Docs overview 📖
-        </Link>
+    <div className={clsx("hero hero--primary", styles.heroBanner)}>
+      <div className={clsx("container", styles.heroInner)}>
+        <p className={styles.eyebrow}>V2 · GraphQL · 40+ chains</p>
+        <h1 className={clsx("hero__title", styles.heroTitle)}>
+          Bitquery Streaming API Docs
+        </h1>
+        <p className={clsx("hero__subtitle", styles.heroSubtitle)}>
+          Query and stream historical and real-time blockchain data through
+          GraphQL, WebSocket, Kafka, and cloud exports—one schema, multiple
+          interfaces.
+        </p>
+        <div className={styles.buttonGroup}>
+          <Link
+            className="button button--primary button--lg"
+            to="/docs/start/first-query/"
+          >
+            Getting started — 5 min
+          </Link>
+          <Link
+            className="button button--secondary button--lg"
+            to="/docs/start/starter-queries/"
+          >
+            Starter queries
+          </Link>
+          <Link
+            className="button button--secondary button--lg"
+            to="/docs/start/starter-subscriptions/"
+          >
+            Live streams
+          </Link>
+          <Link
+            className="button button--secondary button--lg"
+            to="/docs/intro/"
+          >
+            Platform overview
+          </Link>
+        </div>
       </div>
     </div>
-  </div>
-  
   );
 }
 
 export default function Home() {
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={`Bitquery V2 API Docs`}
-      description= "Blockchain Streaming APIs docs (V2 docs) to query real-time and historical transactions, balances, transfers, NFTs, tokens, Dex trades, Smart contract calls, events, etc. We support 40+ blockchains, including Bitcoin, Ethereum, Solana, Polygon, Arbitrum, Optimism, etc.">
+      title="Bitquery V2 API Docs"
+      description="Blockchain Streaming APIs (V2) for real-time and historical transactions, balances, transfers, NFTs, DEX trades, smart contract calls, and events across 40+ blockchains."
+    >
       <HomepageHeader />
-      <main>
-        <HomepageFeatures />
+      <main className={styles.main}>
+        <HomepageFeatures tagline={siteConfig.tagline} />
       </main>
     </Layout>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,6 +4,7 @@ import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import HomepageFeatures from "@site/src/components/HomepageFeatures";
+import { prodDocsPath } from "@site/src/utils/productionUrl";
 
 import styles from "./index.module.css";
 
@@ -23,25 +24,25 @@ function HomepageHeader() {
         <div className={styles.buttonGroup}>
           <Link
             className="button button--primary button--lg"
-            to="/docs/start/first-query/"
+            to={prodDocsPath("/docs/start/first-query/")}
           >
             Getting started — 5 min
           </Link>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/start/starter-queries/"
+            to={prodDocsPath("/docs/start/starter-queries/")}
           >
             Starter queries
           </Link>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/start/starter-subscriptions/"
+            to={prodDocsPath("/docs/start/starter-subscriptions/")}
           >
             Live streams
           </Link>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro/"
+            to={prodDocsPath("/docs/intro/")}
           >
             Platform overview
           </Link>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -1,30 +1,113 @@
 /**
- * CSS files with the .module.css suffix will be treated as CSS modules
- * and scoped locally.
+ * Homepage hero + shell
  */
 
+.main {
+  background: linear-gradient(
+    180deg,
+    var(--ifm-background-color) 0%,
+    var(--ifm-color-emphasis-100) 12%,
+    var(--ifm-background-color) 35%
+  );
+}
+
 .heroBanner {
-  padding: 4rem 0;
+  padding: 3.5rem 0 4rem;
   text-align: center;
   position: relative;
   overflow: hidden;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
 }
 
-@media screen and (max-width: 996px) {
-  .heroBanner {
-    padding: 2rem;
-  }
+/* Soft mesh / depth behind hero text */
+.heroBanner::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+      ellipse 80% 60% at 50% -20%,
+      color-mix(in srgb, var(--ifm-color-primary) 28%, transparent) 0%,
+      transparent 65%
+    ),
+    radial-gradient(
+      ellipse 50% 40% at 100% 50%,
+      color-mix(in srgb, var(--ifm-color-primary) 12%, transparent) 0%,
+      transparent 55%
+    ),
+    radial-gradient(
+      ellipse 45% 35% at 0% 80%,
+      color-mix(in srgb, var(--ifm-color-primary) 10%, transparent) 0%,
+      transparent 50%
+    );
+  pointer-events: none;
 }
 
-.buttons {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.heroInner {
+  position: relative;
+  z-index: 1;
+}
+
+.eyebrow {
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--ifm-hero-text-color) 85%, transparent);
+  margin-bottom: 0.75rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ifm-hero-text-color) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ifm-hero-text-color) 18%, transparent);
+}
+
+.heroTitle {
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  font-weight: 800;
+  line-height: 1.12;
+  margin-bottom: 1rem;
+  letter-spacing: -0.02em;
+}
+
+.heroSubtitle {
+  font-size: 1.2rem;
+  max-width: 38rem;
+  margin: 0 auto 1.75rem;
+  opacity: 0.95;
+  line-height: 1.5;
 }
 
 .buttonGroup {
   display: flex;
-  gap: 1rem; /* space between buttons */
-  justify-content: center; /* optional: center them horizontally */
-  flex-wrap: wrap; /* optional: wrap on small screens */
+  gap: 0.75rem 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.buttonGroup :global(.button) {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  border: none;
+}
+
+.buttonGroup :global(.button--primary) {
+  box-shadow: 0 4px 14px color-mix(in srgb, var(--ifm-color-primary) 45%, transparent);
+}
+
+.buttonGroup :global(.button--secondary) {
+  background: color-mix(in srgb, var(--ifm-hero-text-color) 14%, transparent);
+  color: var(--ifm-hero-text-color);
+}
+
+.buttonGroup :global(.button--secondary:hover) {
+  background: color-mix(in srgb, var(--ifm-hero-text-color) 22%, transparent);
+}
+
+@media screen and (max-width: 996px) {
+  .heroBanner {
+    padding: 2.25rem 0 2.75rem;
+  }
+
+  .heroSubtitle {
+    font-size: 1.05rem;
+  }
 }

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -3,42 +3,39 @@
  */
 
 .main {
-  background: linear-gradient(
-    180deg,
-    var(--ifm-background-color) 0%,
-    var(--ifm-color-emphasis-100) 12%,
-    var(--ifm-background-color) 35%
-  );
+  padding-bottom: 1.5rem;
+  background: var(--ifm-background-color);
 }
 
 .heroBanner {
-  padding: 3.5rem 0 4rem;
+  padding: 2.75rem 0 2.85rem;
   text-align: center;
   position: relative;
   overflow: hidden;
   border-bottom: 1px solid var(--ifm-color-emphasis-200);
 }
 
-/* Soft mesh / depth behind hero text */
+/* Light grid accents (square-aligned) */
 .heroBanner::before {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(
-      ellipse 80% 60% at 50% -20%,
-      color-mix(in srgb, var(--ifm-color-primary) 28%, transparent) 0%,
-      transparent 65%
+  background-image:
+    linear-gradient(
+      color-mix(in srgb, var(--ifm-color-primary) 8%, transparent) 1px,
+      transparent 1px
     ),
-    radial-gradient(
-      ellipse 50% 40% at 100% 50%,
-      color-mix(in srgb, var(--ifm-color-primary) 12%, transparent) 0%,
-      transparent 55%
-    ),
-    radial-gradient(
-      ellipse 45% 35% at 0% 80%,
-      color-mix(in srgb, var(--ifm-color-primary) 10%, transparent) 0%,
-      transparent 50%
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--ifm-color-primary) 8%, transparent) 1px,
+      transparent 1px
     );
+  background-size: 48px 48px;
+  mask-image: radial-gradient(
+    ellipse 70% 70% at 50% 30%,
+    black 18%,
+    transparent 72%
+  );
   pointer-events: none;
 }
 
@@ -48,17 +45,27 @@
 }
 
 .eyebrow {
-  display: inline-block;
-  font-size: 0.8rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--ifm-hero-text-color) 85%, transparent);
-  margin-bottom: 0.75rem;
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--ifm-hero-text-color) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--ifm-hero-text-color) 18%, transparent);
+  color: color-mix(in srgb, var(--ifm-hero-text-color) 88%, transparent);
+  margin-bottom: 0.65rem;
+  padding: 0.32rem 0.65rem;
+  border-radius: 0;
+  background: color-mix(in srgb, var(--ifm-hero-text-color) 11%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ifm-hero-text-color) 22%, transparent);
+}
+
+.eyebrow::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  flex-shrink: 0;
+  background: var(--ifm-color-primary-light);
 }
 
 .heroTitle {
@@ -70,9 +77,9 @@
 }
 
 .heroSubtitle {
-  font-size: 1.2rem;
-  max-width: 38rem;
-  margin: 0 auto 1.75rem;
+  font-size: 1.05rem;
+  max-width: 36rem;
+  margin: 0 auto 1.35rem;
   opacity: 0.95;
   line-height: 1.5;
 }

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -8,7 +8,7 @@
 }
 
 .heroBanner {
-  padding: 2.75rem 0 2.85rem;
+  padding: 2.75rem 0 3.35rem;
   text-align: center;
   position: relative;
   overflow: hidden;
@@ -52,12 +52,13 @@
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--ifm-hero-text-color) 88%, transparent);
+  color: var(--ifm-color-primary-darkest);
   margin-bottom: 0.65rem;
-  padding: 0.32rem 0.65rem;
-  border-radius: 0;
-  background: color-mix(in srgb, var(--ifm-hero-text-color) 11%, transparent);
-  border: 1px solid color-mix(in srgb, var(--ifm-hero-text-color) 22%, transparent);
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--ifm-button-border-radius);
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.98);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .eyebrow::before {
@@ -65,6 +66,17 @@
   width: 8px;
   height: 8px;
   flex-shrink: 0;
+  background: var(--ifm-color-primary);
+}
+
+:global(html[data-theme="dark"]) .eyebrow {
+  background: rgba(0, 0, 0, 0.22);
+  color: #f2faf8;
+  border-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
+}
+
+:global(html[data-theme="dark"]) .eyebrow::before {
   background: var(--ifm-color-primary-light);
 }
 
@@ -91,27 +103,91 @@
   flex-wrap: wrap;
 }
 
-.buttonGroup :global(.button) {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-  border: none;
+/*
+ * Infima buttons use background-color: var(--ifm-button-background-color).
+ * Setting only `background:` is often overridden — drive the official variables.
+ */
+.heroBanner .buttonGroup :global(.button) {
+  font-weight: 600;
+  border-radius: var(--ifm-button-border-radius);
 }
 
-.buttonGroup :global(.button--primary) {
-  box-shadow: 0 4px 14px color-mix(in srgb, var(--ifm-color-primary) 45%, transparent);
+.heroBanner .buttonGroup :global(.button.button--primary) {
+  --ifm-button-background-color: var(--ifm-color-primary-darkest);
+  --ifm-button-border-color: color-mix(
+    in srgb,
+    #000 20%,
+    var(--ifm-color-primary-darkest)
+  );
+  --ifm-button-color: #fff;
+  box-shadow:
+    0 1px 0 color-mix(in srgb, #fff 16%, transparent) inset,
+    0 4px 16px rgba(0, 0, 0, 0.24);
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
 }
 
-.buttonGroup :global(.button--secondary) {
-  background: color-mix(in srgb, var(--ifm-hero-text-color) 14%, transparent);
-  color: var(--ifm-hero-text-color);
+.heroBanner .buttonGroup :global(.button.button--primary:hover) {
+  --ifm-button-background-color: var(--ifm-color-primary-darker);
+  --ifm-button-border-color: color-mix(
+    in srgb,
+    #000 14%,
+    var(--ifm-color-primary-darker)
+  );
+  --ifm-button-color: #fff;
 }
 
-.buttonGroup :global(.button--secondary:hover) {
-  background: color-mix(in srgb, var(--ifm-hero-text-color) 22%, transparent);
+.heroBanner .buttonGroup :global(.button.button--secondary) {
+  --ifm-button-background-color: #ffffff;
+  --ifm-button-border-color: rgba(255, 255, 255, 0.9);
+  --ifm-button-color: var(--ifm-color-primary-darkest);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.85) inset,
+    0 2px 12px rgba(0, 0, 0, 0.15);
+}
+
+.heroBanner .buttonGroup :global(.button.button--secondary:hover) {
+  --ifm-button-background-color: #f4fffb;
+  --ifm-button-border-color: #ffffff;
+  --ifm-button-color: var(--ifm-color-primary-darkest);
+  box-shadow:
+    0 1px 0 #fff inset,
+    0 4px 16px rgba(0, 0, 0, 0.12);
+}
+
+:global(html[data-theme="dark"]) .heroBanner .buttonGroup :global(.button.button--primary) {
+  --ifm-button-background-color: #052f27;
+  --ifm-button-border-color: rgba(255, 255, 255, 0.22);
+  --ifm-button-color: #fff;
+  box-shadow:
+    0 1px 0 color-mix(in srgb, #fff 14%, transparent) inset,
+    0 4px 20px rgba(0, 0, 0, 0.35);
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.25);
+}
+
+:global(html[data-theme="dark"]) .heroBanner .buttonGroup :global(.button.button--primary:hover) {
+  --ifm-button-background-color: var(--ifm-color-primary-darkest);
+  --ifm-button-border-color: rgba(255, 255, 255, 0.35);
+  --ifm-button-color: #fff;
+}
+
+:global(html[data-theme="dark"]) .heroBanner .buttonGroup :global(.button.button--secondary) {
+  --ifm-button-background-color: rgba(255, 255, 255, 0.16);
+  --ifm-button-border-color: rgba(255, 255, 255, 0.38);
+  --ifm-button-color: #fafcfb;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.1) inset,
+    0 2px 12px rgba(0, 0, 0, 0.18);
+}
+
+:global(html[data-theme="dark"]) .heroBanner .buttonGroup :global(.button.button--secondary:hover) {
+  --ifm-button-background-color: rgba(255, 255, 255, 0.26);
+  --ifm-button-border-color: rgba(255, 255, 255, 0.5);
+  --ifm-button-color: #ffffff;
 }
 
 @media screen and (max-width: 996px) {
   .heroBanner {
-    padding: 2.25rem 0 2.75rem;
+    padding: 2.25rem 0 2.95rem;
   }
 
   .heroSubtitle {

--- a/src/utils/productionUrl.js
+++ b/src/utils/productionUrl.js
@@ -1,0 +1,12 @@
+/** Canonical production URLs (not staging / localhost). */
+
+export const PRODUCTION_DOCS_SITE = "https://docs.bitquery.io";
+export const PRODUCTION_MARKETING_SITE = "https://bitquery.io";
+
+/**
+ * @param {string} path Absolute path on docs.bitquery.io (e.g. `/docs/intro/` or `/img/x.mp4`)
+ */
+export function prodDocsPath(path) {
+  const p = path.startsWith("/") ? path : `/${path}`;
+  return `${PRODUCTION_DOCS_SITE}${p}`;
+}


### PR DESCRIPTION
## Summary

This PR delivers a refreshed marketing-style homepage, a dedicated **Supported chains** doc with product coverage across V1/V2 GraphQL, Kafka, Solana gRPC, ClickHouse, and cloud exports, and consistent use of **canonical production doc URLs** on the homepage.

## Changes

- **Homepage**: Multi-section layout (data, interfaces, V1 vs V2 CTA, tools, chains, personas, trending, use cases, trust, video), Infima-aligned hero buttons, production `prodDocsPath` links, and **Supported chains** CTA in the chains band.
- **New doc**: `docs/blockchain/supported-chains.mdx` — matrix, SEO (meta + JSON-LD), sticky table header (no inner horizontal scroll), bitquery.io product links alongside docs where appropriate.
- **Sidebar**: Blockchains category lists **Supported chains** first.
- **Utilities**: `src/utils/productionUrl.js` for `https://docs.bitquery.io` / marketing base URLs.
- **CSS**: Homepage band styles; sticky table header; removed table wrapper horizontal overflow.

## Testing

- `npm run build` succeeds locally.

## Notes

- Homepage and several homepage links intentionally target **production** docs URLs when running the site locally.

Made with [Cursor](https://cursor.com)