### PR TITLE
Add Flap.sh & token supply APIs; move Robinhood docs under /blockchain/robinhood

### DIFF
--- a/docs/blockchain/robinhood/flap-sh-api.md
+++ b/docs/blockchain/robinhood/flap-sh-api.md
@@ -1,0 +1,490 @@
+---
+title: "Flap.sh API on Robinhood"
+description: "Track Flap.sh newly launched tokens and trades on Robinhood with Bitquery. Detect TokenCreated events, mint transfers, and stream Flap.sh market trades via EVM and Trading APIs."
+sidebar_position: 4
+keywords:
+  - Flap.sh API
+  - Flap.sh Robinhood API
+  - Flap.sh newly launched tokens
+  - Flap.sh TokenCreated event
+  - Flap.sh trades API
+  - Flap.sh token launch Robinhood
+  - Robinhood launchpad API
+  - Bitquery Flap.sh Events API
+  - Bitquery Flap.sh Trading API
+  - Flap.sh new token created
+  - Flap.sh market trades
+  - Flap.sh LaunchedToDEX graduation
+  - Flap.sh bonding curve progress
+  - Flap.sh FlapTokenProgressChanged
+  - Flap.sh circulating supply API
+  - Flap.sh tax paid event
+  - Flap.sh VanityTokenCreated
+  - Flap.sh MsgSent social event
+---
+
+# Flap.sh API on Robinhood
+
+**Flap.sh** is a token launchpad on the **Robinhood** network. This guide shows how to track **newly launched Flap.sh tokens**, **Flap.sh trades**, and **lifecycle events** — token graduations, bonding-curve progress, supply changes, tax paid, vanity tokens, and social messages — with Bitquery GraphQL APIs, using the `EVM(network: robinhood)` and `Trading` cubes.
+
+:::note API Key Required
+To query or stream data outside the Bitquery IDE, you need an API access token.
+
+Follow the steps here: [How to generate Bitquery API token ➤](/docs/authorisation/how-to-generate/)
+:::
+
+:::tip Related docs
+- [Robinhood Trades API](/docs/blockchain/robinhood/robinhood-trades)
+- [Robinhood Meme Coin Launches API](/docs/blockchain/robinhood/robinhood-meme-coin-launches)
+- [Robinhood Transfers](/docs/blockchain/robinhood/robinhood-transfers)
+- [WebSocket subscriptions](/docs/subscriptions/websockets/)
+:::
+
+---
+
+## Flap.sh contract
+
+| Field | Value |
+| --- | --- |
+| **Flap.sh contract** | `0x26605f322f7ff986f381bb9a6e3f5dab0beaeb09` |
+| **Launch mint `Amount`** | `1000000000` (1 billion, decimal-normalized) |
+
+The contract address is used as the `Log`/`LogHeader` address for events, as `Transaction.To` for mint transfers, and as the `Pair.Market.Program` for trades.
+
+---
+
+## Newly launched tokens
+
+Flap.sh launches can be detected via decoded **`TokenCreated`** events or via **mint transfers** from the zero address.
+
+### Flap.sh newly created tokens using logs (`TokenCreated`)
+
+Filter Flap.sh `TokenCreated` events and decode argument values (token address, metadata fields, and related parameters).
+
+▶️ [Run in IDE](https://ide.bitquery.io/Flap-sh-Newly-created-tokens-using-logs-TokenCreated) · [WebSocket stream](https://ide.bitquery.io/Flap-sh-Newly-created-tokens-using-logs-TokenCreated---Websocket)
+
+```graphql
+{
+  EVM(network: robinhood) {
+    Events(
+      limit: {count: 10}
+      where: {
+        Log: {Signature: {Name: {is: "TokenCreated"}}}
+        LogHeader: {Address: {is: "0x26605f322f7ff986f381bb9a6e3f5dab0beaeb09"}}
+      }
+    ) {
+      Transaction {
+        Hash
+        From
+        To
+      }
+      Log {
+        Signature {
+          Name
+        }
+        SmartContract
+      }
+      Arguments {
+        Name
+        Value {
+          ... on EVM_ABI_Integer_Value_Arg {
+            integer
+          }
+          ... on EVM_ABI_String_Value_Arg {
+            string
+          }
+          ... on EVM_ABI_Address_Value_Arg {
+            address
+          }
+          ... on EVM_ABI_BigInt_Value_Arg {
+            bigInteger
+          }
+          ... on EVM_ABI_Bytes_Value_Arg {
+            hex
+          }
+          ... on EVM_ABI_Boolean_Value_Arg {
+            bool
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Flap.sh newly created tokens using transfer data
+
+Track Flap.sh mints as transfers from the zero address with amount `1000000000` in transactions sent to the Flap.sh contract.
+
+▶️ [Run in IDE](https://ide.bitquery.io/Flap-Sh-Newly-created-tokens-using-transfer-data) · [WebSocket stream](https://ide.bitquery.io/Flap-Sh-Newly-created-tokens-using-transfer-data---Websocket)
+
+```graphql
+{
+  EVM(network: robinhood) {
+    Transfers(
+      orderBy: {descending: Block_Time}
+      limit: {count: 50}
+      where: {
+        Transaction: {To: {is: "0x26605f322f7ff986f381bb9a6e3f5dab0beaeb09"}}
+        Transfer: {
+          Amount: {eq: "1000000000"}
+          Sender: {is: "0x0000000000000000000000000000000000000000"}
+        }
+      }
+    ) {
+      Block {
+        Time
+        Number
+      }
+      Transaction {
+        Hash
+        From
+        To
+      }
+      TransactionStatus {
+        Success
+      }
+      Transfer {
+        Amount
+        AmountInUSD
+        Sender
+        Receiver
+        Currency {
+          Name
+          Symbol
+          SmartContract
+          Decimals
+          Fungible
+          Native
+          ProtocolName
+        }
+      }
+    }
+  }
+}
+```
+
+:::note Amounts are decimal-normalized
+Bitquery's `Transfer.Amount` is already adjusted for the token's `Decimals`, so `1000000000` means 1 billion whole tokens — not the raw on-chain integer. Compare against the normalized value, not the raw one.
+:::
+
+---
+
+## Flap.sh trades
+
+Query trades on Flap.sh markets using the `Trading.Trades` cube, scoped by the Flap.sh contract as `Pair.Market.Program`. This example returns trades from the last hour.
+
+```graphql
+{
+  Trading {
+    Trades(
+      limit: {count: 10}
+      where: {Pair: {Market: {Program: {is: "0x26605f322f7ff986f381bb9a6e3f5dab0beaeb09"}}}, Block: {Time: {since_relative: {hours_ago: 1}}}}
+    ) {
+      Side
+      Supply {
+        CirculatingSupply
+        MarketCap
+      }
+      Trader {
+        Address
+      }
+      TransactionHeader {
+        Fee
+        FeePayer
+        Sender
+        To
+      }
+      Amounts {
+        Base
+        Quote
+      }
+      AmountsInUsd {
+        Base
+        Quote
+      }
+      Block {
+        Date
+        Time
+        Timestamp
+      }
+      Pair {
+        Market {
+          Protocol
+          ProtocolFamily
+          Address
+          Program
+          Network
+        }
+        Token {
+          Address
+          Id
+          IsNative
+          Symbol
+          TokenId
+          Network
+        }
+        QuoteToken {
+          Address
+          Id
+          IsNative
+          Symbol
+          TokenId
+          Network
+        }
+      }
+    }
+  }
+}
+```
+
+:::tip Stream the same query
+Change the operation type from a query to a `subscription` in the Bitquery IDE to receive Flap.sh trades in real time over WebSocket.
+:::
+
+---
+
+## Event-specific APIs
+
+Beyond buy/sell trades, Flap.sh emits lifecycle events across several contracts (bonding-curve engine, factories, and the router). Because a given event is emitted by more than one contract, filter these queries by `Log.Signature.Name` rather than a single address. Each event includes a `token` argument identifying the affected token, so you can add `Arguments: {includes: {Name: {is: "token"}, Value: {Address: {is: "0x..."}}}}` to scope any query to one token.
+
+:::tip Stream any event
+Every query below can be run as a real-time stream — change the operation type to `subscription` in the Bitquery IDE.
+:::
+
+### Token graduations (`LaunchedToDEX`)
+
+The most important lifecycle signal: a token completed its bonding curve and was **launched to a DEX**. The event returns the new `pool` address (use it with the [Robinhood Trades API](/docs/blockchain/robinhood/robinhood-trades) to follow post-graduation trading), the migrated token `amount`, and the `eth` seeded into the pool.
+
+```graphql
+{
+  EVM(network: robinhood) {
+    Events(
+      limit: {count: 20}
+      orderBy: {descending: Block_Time}
+      where: {Log: {Signature: {Name: {is: "LaunchedToDEX"}}}}
+    ) {
+      Block {
+        Time
+      }
+      Transaction {
+        Hash
+      }
+      Arguments {
+        Name
+        Value {
+          ... on EVM_ABI_Address_Value_Arg {
+            address
+          }
+          ... on EVM_ABI_BigInt_Value_Arg {
+            bigInteger
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Arguments: `token` (graduated token), `pool` (new DEX pool address), `amount` (tokens moved to the pool), `eth` (native seeded into the pool).
+
+### Bonding-curve progress (`FlapTokenProgressChanged`)
+
+Track how close a token is to graduation. `newProgress` is scaled to `1e18`, so `562290208719467141` ≈ **56.2%**. Great for progress bars and "about to graduate" alerts.
+
+```graphql
+{
+  EVM(network: robinhood) {
+    Events(
+      limit: {count: 20}
+      orderBy: {descending: Block_Time}
+      where: {Log: {Signature: {Name: {is: "FlapTokenProgressChanged"}}}}
+    ) {
+      Block {
+        Time
+      }
+      Arguments {
+        Name
+        Value {
+          ... on EVM_ABI_Address_Value_Arg {
+            address
+          }
+          ... on EVM_ABI_BigInt_Value_Arg {
+            bigInteger
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Arguments: `token`, `newProgress` (fraction of the curve completed, scaled by `1e18` → divide by `1e18` for a `0–1` ratio, or `×100` for a percentage).
+
+### Circulating supply changes (`FlapTokenCirculatingSupplyChanged`)
+
+Live circulating-supply updates for a token — useful for accurate off-chain market-cap math. `newSupply` is the raw on-chain integer (divide by the token's `1e18` decimals).
+
+```graphql
+{
+  EVM(network: robinhood) {
+    Events(
+      limit: {count: 20}
+      orderBy: {descending: Block_Time}
+      where: {Log: {Signature: {Name: {is: "FlapTokenCirculatingSupplyChanged"}}}}
+    ) {
+      Block {
+        Time
+      }
+      Arguments {
+        Name
+        Value {
+          ... on EVM_ABI_Address_Value_Arg {
+            address
+          }
+          ... on EVM_ABI_BigInt_Value_Arg {
+            bigInteger
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Arguments: `token`, `newSupply` (new circulating supply, raw integer).
+
+### Bonding-curve tax paid (`TaxV2OnBondingCurvePaid`)
+
+Tax/fee revenue paid on the bonding curve, per token. Aggregate `amount` over time (or per token) for fee analytics.
+
+```graphql
+{
+  EVM(network: robinhood) {
+    Events(
+      limit: {count: 20}
+      orderBy: {descending: Block_Time}
+      where: {Log: {Signature: {Name: {is: "TaxV2OnBondingCurvePaid"}}}}
+    ) {
+      Block {
+        Time
+      }
+      Arguments {
+        Name
+        Value {
+          ... on EVM_ABI_Address_Value_Arg {
+            address
+          }
+          ... on EVM_ABI_BigInt_Value_Arg {
+            bigInteger
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Arguments: `token`, `amount` (tax paid in native units, raw integer).
+
+### Vanity tokens created (`VanityTokenCreated`)
+
+A separate creation channel for **vanity tokens** — those with custom address suffixes (`8888`, `7777`). Complements the standard `TokenCreated` event on the [launches page](/docs/blockchain/robinhood/robinhood-meme-coin-launches).
+
+```graphql
+{
+  EVM(network: robinhood) {
+    Events(
+      limit: {count: 20}
+      orderBy: {descending: Block_Time}
+      where: {Log: {Signature: {Name: {is: "VanityTokenCreated"}}}}
+    ) {
+      Block {
+        Time
+      }
+      Transaction {
+        Hash
+      }
+      Arguments {
+        Name
+        Value {
+          ... on EVM_ABI_Address_Value_Arg {
+            address
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Arguments: `token` (new vanity token), `creator`, `beneficiary`.
+
+### Social messages (`MsgSent`)
+
+Flap.sh links social content to tokens through `MsgSent`. The `message` string carries structured commands such as `ADD_TWEET::<tweet_id>`, tying a token to a tweet or other social metadata.
+
+```graphql
+{
+  EVM(network: robinhood) {
+    Events(
+      limit: {count: 20}
+      orderBy: {descending: Block_Time}
+      where: {Log: {Signature: {Name: {is: "MsgSent"}}}}
+    ) {
+      Block {
+        Time
+      }
+      Transaction {
+        Hash
+      }
+      Arguments {
+        Name
+        Value {
+          ... on EVM_ABI_Address_Value_Arg {
+            address
+          }
+          ... on EVM_ABI_String_Value_Arg {
+            string
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Arguments: `sender`, `token`, `message` (e.g. `ADD_TWEET::2077406373457871178`).
+
+---
+
+## FAQ
+
+### How do I detect a newly launched Flap.sh token?
+
+Use the **`TokenCreated`** event on the Flap.sh contract (`0x26605f322f7ff986f381bb9a6e3f5dab0beaeb09`) for decoded arguments, or the **mint-transfer** pattern — a transfer from the zero address with `Amount` `1000000000` where `Transaction.To` is the Flap.sh contract.
+
+### How do I get Flap.sh trades?
+
+Query `Trading.Trades` filtered by `Pair.Market.Program: "0x26605f322f7ff986f381bb9a6e3f5dab0beaeb09"`. Add a `Block.Time` filter to scope to a time window, or switch the operation to `subscription` to stream trades live.
+
+### How do I know when a Flap.sh token graduates to a DEX?
+
+Filter events by `Log.Signature.Name: "LaunchedToDEX"`. Each event gives the graduated `token`, the new `pool` address, and the token/native `amount` seeded into the pool. Run it as a `subscription` for real-time graduation alerts.
+
+### How do I track a token's bonding-curve progress?
+
+Use the `FlapTokenProgressChanged` event. `newProgress` is scaled by `1e18`, so divide by `1e18` for a `0–1` ratio (or `×100` for a percentage). Scope to a single token by matching the `token` argument.
+
+### Why do the event queries filter by `Log.Signature.Name` instead of a contract address?
+
+Flap.sh emits the same event from several contracts (the bonding-curve engine, factories, and router). Filtering by the signature name captures the event across all of them. Add an `Arguments.includes` filter on the `token` argument to scope to one token.
+
+---
+
+## Next steps
+
+- Stream **`LaunchedToDEX`** for real-time graduation alerts, then follow the new pool with the [Robinhood Trades API](/docs/blockchain/robinhood/robinhood-trades).
+- Track other Robinhood launchpads and bots with the [Robinhood Meme Coin Launches API](/docs/blockchain/robinhood/robinhood-meme-coin-launches).
+- Explore prices, OHLCV, whale trades, and top traders in the [Robinhood Trades API](/docs/blockchain/robinhood/robinhood-trades).
+- Inspect holder and wallet flows with [Robinhood Transfers](/docs/blockchain/robinhood/robinhood-transfers).

--- a/docs/blockchain/robinhood/robinhood-meme-coin-launches.md
+++ b/docs/blockchain/robinhood/robinhood-meme-coin-launches.md
@@ -30,8 +30,8 @@ Follow the steps here: [How to generate Bitquery API token ➤](/docs/authorisat
 :::
 
 :::tip Related docs
-- [Robinhood Trades API](/docs/examples/robinhood/robinhood-trades)
-- [Robinhood Transfers](/docs/examples/robinhood/robinhood-transfers)
+- [Robinhood Trades API](/docs/blockchain/robinhood/robinhood-trades)
+- [Robinhood Transfers](/docs/blockchain/robinhood/robinhood-transfers)
 - [WebSocket subscriptions](/docs/subscriptions/websockets/)
 :::
 
@@ -565,5 +565,5 @@ Use **Events** when a launchpad emits a decoded creation event (like Flap.sh's `
 
 - Use the **WebSocket stream** links above (or switch the query to `subscription` in the IDE) for real-time launch alerts.
 - Track a launchpad not listed here by swapping `Transaction.To` and `Amount` per the [contract map](#launchpad-and-bot-contract-map).
-- Follow new tokens into markets with the [Robinhood Trades API](/docs/examples/robinhood/robinhood-trades).
-- Inspect holder and wallet flows with [Robinhood Transfers](/docs/examples/robinhood/robinhood-transfers).
+- Follow new tokens into markets with the [Robinhood Trades API](/docs/blockchain/robinhood/robinhood-trades).
+- Inspect holder and wallet flows with [Robinhood Transfers](/docs/blockchain/robinhood/robinhood-transfers).

--- a/docs/blockchain/robinhood/robinhood-token-supply.md
+++ b/docs/blockchain/robinhood/robinhood-token-supply.md
@@ -1,0 +1,205 @@
+---
+title: "Robinhood Token Supply API"
+description: "Get the latest total supply of a token, stream real-time supply updates, and fetch supply for all active tokens on Robinhood with Bitquery's EVM TransactionBalances API."
+sidebar_position: 5
+keywords:
+  - Robinhood token supply API
+  - Robinhood total supply
+  - Robinhood token supply stream
+  - Robinhood TransactionBalances API
+  - Robinhood real-time supply
+  - Robinhood active tokens supply
+  - token total supply Robinhood
+  - Bitquery Robinhood supply API
+  - Robinhood token circulating supply
+---
+
+# Robinhood Token Supply API
+
+Get **token total supply** on the **Robinhood** network with Bitquery's `EVM.TransactionBalances` API. This guide covers the **latest supply of a token**, a **real-time supply stream**, and the **supply of all active tokens**.
+
+:::note API Key Required
+To query or stream data outside the Bitquery IDE, you need an API access token.
+
+Follow the steps here: [How to generate Bitquery API token ➤](/docs/authorisation/how-to-generate/)
+:::
+
+:::tip Related docs
+- [Robinhood Trades API](/docs/blockchain/robinhood/robinhood-trades)
+- [Robinhood Transfers](/docs/blockchain/robinhood/robinhood-transfers)
+- [Flap.sh API on Robinhood](/docs/blockchain/robinhood/flap-sh-api)
+- [WebSocket subscriptions](/docs/subscriptions/websockets/)
+:::
+
+:::note Supply is decimal-normalized
+`TokenBalance.TotalSupply` is already adjusted for the token's decimals, so it returns whole-token values (e.g. `100000000.000000000000000000`) — not the raw on-chain integer.
+:::
+
+---
+
+## Latest Supply of a Token
+
+Get the most recent total supply for a single token by filtering on its contract address and taking the newest balance record.
+
+```graphql
+{
+  EVM(network: robinhood) {
+    TransactionBalances(
+      limit: {count: 1}
+      orderBy: {descending: Block_Time}
+      where: {TokenBalance: {Currency: {SmartContract: {is: "0x0bd7d308f8e1639fab988df18a8011f41eacad73"}}}}
+    ) {
+      TokenBalance {
+        Currency {
+          Symbol
+          HasURI
+          SmartContract
+        }
+        TotalSupply
+      }
+    }
+  }
+}
+```
+
+<details>
+<summary>Sample response</summary>
+
+```json
+{
+  "EVM": {
+    "TransactionBalances": [
+      {
+        "TokenBalance": {
+          "Currency": {
+            "Symbol": "WETH",
+            "HasURI": false,
+            "SmartContract": "0x0bd7d308f8e1639fab988df18a8011f41eacad73"
+          },
+          "TotalSupply": "18584.722713864831985195"
+        }
+      }
+    ]
+  }
+}
+```
+
+</details>
+
+---
+
+## Real-Time Supply Stream for Tokens on Robinhood
+
+Subscribe to live total-supply updates across Robinhood tokens. The `SmartContract: {not: "0x"}` filter excludes the native coin so only token supply changes stream through.
+
+```graphql
+subscription {
+  EVM(network: robinhood) {
+    TransactionBalances(
+      where: {
+        TokenBalance: {
+          Currency: {
+            SmartContract: {not: "0x"}
+          }
+        }
+      }
+    ) {
+      TokenBalance {
+        Currency {
+          Symbol
+          HasURI
+          SmartContract
+        }
+        TotalSupply
+      }
+    }
+  }
+}
+```
+
+---
+
+## Supply of All Active Tokens
+
+Fetch the latest total supply for every recently active token in a single query. `limitBy` collapses results to the newest record per token contract, so each token appears once with its current supply.
+
+```graphql
+{
+  EVM(network: robinhood) {
+    TransactionBalances(
+      limitBy: {by: TokenBalance_Currency_SmartContract, count: 1}
+      orderBy: {descending: Block_Time}
+      where: {TokenBalance: {Currency: {SmartContract: {not: "0x"}}}}
+    ) {
+      TokenBalance {
+        Currency {
+          Symbol
+          HasURI
+          SmartContract
+        }
+        TotalSupply
+      }
+    }
+  }
+}
+```
+
+<details>
+<summary>Sample response</summary>
+
+```json
+{
+  "EVM": {
+    "TransactionBalances": [
+      {
+        "TokenBalance": {
+          "Currency": { "Symbol": "HEIST", "HasURI": false, "SmartContract": "0xfbb3171fc52fca9f8ff10b2494a6055a51f68717" },
+          "TotalSupply": "100000000.000000000000000000"
+        }
+      },
+      {
+        "TokenBalance": {
+          "Currency": { "Symbol": "ROBINHOOD", "HasURI": false, "SmartContract": "0x217b7013e00c13ce4f3bc968238e0b13ce297382" },
+          "TotalSupply": "100000000000.000000000000000000"
+        }
+      },
+      {
+        "TokenBalance": {
+          "Currency": { "Symbol": "BabyJugger", "HasURI": false, "SmartContract": "0xd8e25ced04f51efa18fa94b460f6e924c3aa23ae" },
+          "TotalSupply": "1000000000.000000000000000000"
+        }
+      }
+    ]
+  }
+}
+```
+
+</details>
+
+---
+
+## FAQ
+
+### How do I get the current total supply of a Robinhood token?
+
+Query `EVM.TransactionBalances` filtered by the token's `Currency.SmartContract`, ordered by `descending: Block_Time` with `limit: 1`. The newest record holds the latest `TotalSupply`.
+
+### How do I stream supply changes in real time?
+
+Run the `subscription` on `TransactionBalances` with `Currency.SmartContract: {not: "0x"}`. Each supply change on a token is pushed to your client as it is indexed.
+
+### How do I list supply for all active tokens at once?
+
+Use `limitBy: {by: TokenBalance_Currency_SmartContract, count: 1}` with `orderBy: {descending: Block_Time}`. This returns one row — the latest supply — per token contract.
+
+### Is `TotalSupply` raw or decimal-adjusted?
+
+It is decimal-normalized (whole tokens), already divided by the token's decimals. Use it directly for market-cap math without further scaling.
+
+---
+
+## Next steps
+
+- Combine supply with price from the [Robinhood Trades API](/docs/blockchain/robinhood/robinhood-trades) for market-cap and FDV calculations.
+- Track newly launched tokens with the [Robinhood Meme Coin Launches API](/docs/blockchain/robinhood/robinhood-meme-coin-launches) and [Flap.sh API](/docs/blockchain/robinhood/flap-sh-api).
+- Inspect holder and wallet flows with [Robinhood Transfers](/docs/blockchain/robinhood/robinhood-transfers).

--- a/docs/blockchain/robinhood/robinhood-trades.md
+++ b/docs/blockchain/robinhood/robinhood-trades.md
@@ -43,8 +43,9 @@ Follow the steps here: [How to generate Bitquery API token ➤](https://docs.bit
 :::
 
 :::tip Related docs
-- [Robinhood Transfers](/docs/examples/robinhood/robinhood-transfers)
-- [Robinhood Meme Coin Launches API](/docs/examples/robinhood/robinhood-meme-coin-launches)
+- [Robinhood Transfers](/docs/blockchain/robinhood/robinhood-transfers)
+- [Robinhood Token Supply API](/docs/blockchain/robinhood/robinhood-token-supply)
+- [Robinhood Meme Coin Launches API](/docs/blockchain/robinhood/robinhood-meme-coin-launches)
 - [Trading data overview](https://docs.bitquery.io/docs/trading/trading-data-overview/)
 - [Crypto Trades API](https://docs.bitquery.io/docs/trading/crypto-trades-api/trades-api/)
 - [Crypto Price API](https://docs.bitquery.io/docs/trading/crypto-price-api/introduction/)
@@ -696,6 +697,91 @@ Get the latest market cap, fully-diluted valuation, supply, and price for a sing
       }
       Volume {
         Usd
+      }
+    }
+  }
+}
+```
+
+---
+
+## Token Supply on Robinhood
+
+While `Trading.Tokens` (above) returns supply alongside price and market cap, you can also read **total supply** directly from the `EVM.TransactionBalances` cube. `TokenBalance.TotalSupply` is decimal-normalized (whole tokens). See the full guide in the [Robinhood Token Supply API](/docs/blockchain/robinhood/robinhood-token-supply).
+
+### Latest Supply of a Token
+
+Get the most recent total supply for a single token by filtering on its contract address.
+
+```graphql
+{
+  EVM(network: robinhood) {
+    TransactionBalances(
+      limit: {count: 1}
+      orderBy: {descending: Block_Time}
+      where: {TokenBalance: {Currency: {SmartContract: {is: "0x0bd7d308f8e1639fab988df18a8011f41eacad73"}}}}
+    ) {
+      TokenBalance {
+        Currency {
+          Symbol
+          HasURI
+          SmartContract
+        }
+        TotalSupply
+      }
+    }
+  }
+}
+```
+
+### Real-Time Supply Stream
+
+Stream live total-supply updates across Robinhood tokens. The `SmartContract: {not: "0x"}` filter excludes the native coin.
+
+```graphql
+subscription {
+  EVM(network: robinhood) {
+    TransactionBalances(
+      where: {
+        TokenBalance: {
+          Currency: {
+            SmartContract: {not: "0x"}
+          }
+        }
+      }
+    ) {
+      TokenBalance {
+        Currency {
+          Symbol
+          HasURI
+          SmartContract
+        }
+        TotalSupply
+      }
+    }
+  }
+}
+```
+
+### Supply of All Active Tokens
+
+Fetch the latest total supply for every recently active token. `limitBy` returns one row — the newest supply — per token contract.
+
+```graphql
+{
+  EVM(network: robinhood) {
+    TransactionBalances(
+      limitBy: {by: TokenBalance_Currency_SmartContract, count: 1}
+      orderBy: {descending: Block_Time}
+      where: {TokenBalance: {Currency: {SmartContract: {not: "0x"}}}}
+    ) {
+      TokenBalance {
+        Currency {
+          Symbol
+          HasURI
+          SmartContract
+        }
+        TotalSupply
       }
     }
   }

--- a/docs/blockchain/robinhood/robinhood-transfers.md
+++ b/docs/blockchain/robinhood/robinhood-transfers.md
@@ -18,7 +18,7 @@ Bitquery exposes **Robinhood** transfer data through the **EVM Transfers** APIs.
 :::tip Related docs
 - [ERC20 Token Transfers API (Ethereum)](https://docs.bitquery.io/docs/blockchain/Ethereum/transfers/erc20-token-transfer-api/)
 - [EVM Transfers](https://docs.bitquery.io/docs/evm/transfers/)
-- [Robinhood Trades](/docs/examples/robinhood/robinhood-trades)
+- [Robinhood Trades](/docs/blockchain/robinhood/robinhood-trades)
 :::
 
 ---

--- a/docs/blockchain/supported-chains.mdx
+++ b/docs/blockchain/supported-chains.mdx
@@ -79,6 +79,7 @@ This guide lists **which blockchains Bitquery indexes** and how that lines up wi
 | Arbitrum | — | ✓ | ✓ | ✓ | ✓ |
 | Optimism | — | ✓ | ✓ | ✓ | ✓ |
 | Base | — | ✓ | ✓ | ✓ | ✓ |
+| Robinhood | — | ✓ | ✓ | ✓ | ✓ |
 
 :::note More networks
 

--- a/docs/examples/robinhood/_category_.json
+++ b/docs/examples/robinhood/_category_.json
@@ -1,8 +1,0 @@
-{
-  "label": "Robinhood",
-  "position": 6,
-  "link": {
-    "type": "generated-index",
-    "description": "API guides for Robinhood trades, transfers, balances, and meme coin token launches via Bitquery Trading and EVM APIs."
-  }
-}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -187,6 +187,30 @@ const config = {
             to: "/docs/authorisation/how-to-generate",
             from: "/docs/category/authorization/",
           },
+          {
+            to: "/docs/blockchain/robinhood/",
+            from: "/docs/category/robinhood/",
+          },
+          {
+            to: "/docs/blockchain/robinhood/robinhood-trades/",
+            from: "/docs/examples/robinhood/robinhood-trades/",
+          },
+          {
+            to: "/docs/blockchain/robinhood/robinhood-transfers/",
+            from: "/docs/examples/robinhood/robinhood-transfers/",
+          },
+          {
+            to: "/docs/blockchain/robinhood/robinhood-meme-coin-launches/",
+            from: "/docs/examples/robinhood/robinhood-meme-coin-launches/",
+          },
+          {
+            to: "/docs/blockchain/robinhood/flap-sh-api/",
+            from: "/docs/examples/robinhood/flap-sh-api/",
+          },
+          {
+            to: "/docs/blockchain/robinhood/robinhood-token-supply/",
+            from: "/docs/examples/robinhood/robinhood-token-supply/",
+          },
 
           {
             to: "/docs/authorisation/how-to-generate",

--- a/sidebars.js
+++ b/sidebars.js
@@ -844,14 +844,17 @@ const sidebars = {
           label: "Robinhood",
           link: {
             type: "generated-index",
+            slug: "/blockchain/robinhood",
             title: "Robinhood APIs",
             description:
               "APIs for accessing Robinhood trades, transfers, balances, and meme coin token launches via Bitquery Trading and EVM APIs.",
           },
           items: [
-            "examples/robinhood/robinhood-trades",
-            "examples/robinhood/robinhood-transfers",
-            "examples/robinhood/robinhood-meme-coin-launches",
+            "blockchain/robinhood/robinhood-trades",
+            "blockchain/robinhood/robinhood-transfers",
+            "blockchain/robinhood/robinhood-meme-coin-launches",
+            "blockchain/robinhood/flap-sh-api",
+            "blockchain/robinhood/robinhood-token-supply",
           ],
         },
         {

--- a/src/components/HomepageFeatures/icons.js
+++ b/src/components/HomepageFeatures/icons.js
@@ -259,6 +259,15 @@ export function ChainIcon({ id }) {
           </text>
         </svg>
       );
+    case "rh":
+      return (
+        <svg viewBox="0 0 24 24" width={23} height={23} aria-hidden>
+          <circle cx="12" cy="12" r="10" fill="#00C805" />
+          <text x="12" y="16.5" fontSize="12" fontWeight="700" fill="#fff" textAnchor="middle" fontFamily="Arial">
+            R
+          </text>
+        </svg>
+      );
     default:
       return null;
   }

--- a/src/components/HomepageFeatures/sectionsData.js
+++ b/src/components/HomepageFeatures/sectionsData.js
@@ -204,6 +204,7 @@ export const chains = [
   { label: "Optimism", to: "/docs/blockchain/Optimism/", id: "op" },
   { label: "Tron", to: "/docs/blockchain/Tron/", id: "tron" },
   { label: "Bitcoin", to: "/docs/blockchain/Bitcoin/", id: "btc" },
+  { label: "Robinhood", to: "/docs/blockchain/robinhood/", id: "rh" },
 ];
 
 export const personas = [


### PR DESCRIPTION
## Summary
- Add **Flap.sh API** page (newly launched tokens, trades, and event-specific APIs: `LaunchedToDEX`, `FlapTokenProgressChanged`, `FlapTokenCirculatingSupplyChanged`, `TaxV2OnBondingCurvePaid`, `VanityTokenCreated`, `MsgSent`).
- Add **Robinhood Token Supply API** page (latest supply, real-time supply stream, supply of all active tokens) and a Token Supply section on the Robinhood Trades page.
- Move Robinhood docs from `/docs/examples/robinhood/` to `/docs/blockchain/robinhood/` — category slug, sidebar items, and internal links updated; client redirects added for all old URLs (pages + category).
- List **Robinhood** on the homepage chains strip and in the supported-chains matrix.

All GraphQL queries were validated against the live Bitquery API. Production build passes with no broken links; new URLs return 200 and old URLs redirect.

## Test plan
- [ ] `npm run build` succeeds with no broken links
- [ ] `/docs/blockchain/robinhood/` renders the category index with all 5 pages
- [ ] Old URLs (e.g. `/docs/examples/robinhood/flap-sh-api/`, `/docs/category/robinhood/`) redirect to the new paths on the deployed site
- [ ] Homepage "Robinhood" chip links to `/docs/blockchain/robinhood/`

Made with [Cursor](https://cursor.com)