### PR TITLE
Post-deploy fixes: BreadcrumbList dedupe, relative 301s, sitemap lastmod

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1154,6 +1154,7 @@ const config = {
         sitemap: {
           changefreq: "weekly",
           priority: 0.5,
+          lastmod: "date",
           ignorePatterns: [
             "/docs/graphql-reference/**",
             "/markdown-page/**",

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -5,6 +5,10 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Behind TLS termination nginx sees plain http; emit relative Location headers
+    # so 301s keep the client's https scheme (no extra http->https upgrade hop).
+    absolute_redirect off;
+
     # --- Compression (WP-0.1) ---
     # The base image gzips text/html only; add JS/CSS/SVG/JSON so bundles ship
     # compressed. Brotli is intentionally NOT enabled: nginx:stable-alpine ships

--- a/plugins/tech-article-jsonld.js
+++ b/plugins/tech-article-jsonld.js
@@ -69,33 +69,6 @@ function gitDate(siteDir, filePath, first) {
   }
 }
 
-function humanize(seg) {
-  return seg
-    .replace(/[-_]+/g, " ")
-    .replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
-function breadcrumb(base, permalink, title) {
-  const parts = permalink.split("/").filter(Boolean); // e.g. ["docs","blockchain","Solana","x"]
-  const items = [];
-  let acc = "";
-  parts.forEach((seg, i) => {
-    acc += `/${seg}`;
-    const isLast = i === parts.length - 1;
-    items.push({
-      "@type": "ListItem",
-      position: i + 1,
-      name: isLast ? title || humanize(seg) : seg === "docs" ? "Docs" : humanize(seg),
-      item: `${base}${acc}/`,
-    });
-  });
-  return {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: items,
-  };
-}
-
 /** @type {import('@docusaurus/types').PluginModule} */
 module.exports = function techArticleJsonLdPlugin(context) {
   return {
@@ -142,11 +115,9 @@ module.exports = function techArticleJsonLdPlugin(context) {
           },
         };
 
-        const crumbs = breadcrumb(base, permalink, title);
-
-        const tag =
-          `<script type="application/ld+json">${JSON.stringify(techArticle)}</script>` +
-          `<script type="application/ld+json">${JSON.stringify(crumbs)}</script>`;
+        // BreadcrumbList is emitted natively by the Docusaurus theme's breadcrumbs,
+        // so we inject only TechArticle here to avoid duplicate structured data.
+        const tag = `<script type="application/ld+json">${JSON.stringify(techArticle)}</script>`;
 
         let html = fs.readFileSync(htmlPath, "utf8");
         if (html.includes('"@type":"TechArticle"')) {


### PR DESCRIPTION
Three cleanups found by testing the live site after the docs-audit deploy.

**1. Duplicate `BreadcrumbList` JSON-LD.** The Docusaurus theme already emits a BreadcrumbList for its visual breadcrumbs, so `plugins/tech-article-jsonld.js` was adding a second one on every page. Keep only TechArticle in the plugin (removes the dead `breadcrumb`/`humanize` helpers). Verified: BreadcrumbList per page 2 → 1, TechArticle unchanged.

**2. Internal 301s emitted `http://` Location.** Behind TLS termination nginx sees plain http, so `rewrite … permanent` produced `http://docs.bitquery.io/…` Location headers (old PumpFun casing, legacy `/docs/usecases/MCP`), causing an extra http→https upgrade hop. `absolute_redirect off;` makes Location relative so the client keeps https.

**3. Sitemap `<lastmod>`.** Set `lastmod: "date"` so every doc URL carries a `<lastmod>` from its last git commit (`showLastUpdateTime` is already on). 532/573 URLs now have lastmod (the rest are auto-generated category routes). lastmod is the one sitemap field Google actually uses for recrawl.

Everything else from the audit deploy tested clean (real 404s, gzip, redirects resolve to 200, new pages, robots/llms/sitemap, favicon, GA4 dedupe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)