### PR TITLE
Fix: git in Docker builder (page dates) + serve raw .md as text/markdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,14 @@ ENV NODE_OPTIONS=--max_old_space_size=16000
 
 WORKDIR /app
 
+# Docusaurus derives per-page dates from git history: sitemap <lastmod>,
+# the "Last updated" footer (showLastUpdateTime/Author), and the
+# TechArticle JSON-LD dates. node:20-alpine ships without git, so these are
+# silently dropped from production builds unless git is installed here.
+# NOTE: the build context must include the .git directory (do not add .git to
+# .dockerignore) and the checkout must not be shallow, or dates will be partial.
+RUN apk add --no-cache git
+
 COPY . .
 
 RUN yarn install && yarn build

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -52,6 +52,16 @@ server {
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
     }
 
+    # Raw markdown twins (/docs/**/index.md) emitted by plugins/llms-txt.js for
+    # LLM/agent consumption. nginx has no mime type for .md, so they were served
+    # as application/octet-stream — browsers download them instead of displaying,
+    # and some crawlers skip non-text types.
+    location ~ \.md$ {
+        default_type text/markdown;
+        charset utf-8;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    }
+
     # Doc images/videos are updated in place — cache hard but allow revalidation
     location /img/ {
         try_files $uri =404;


### PR DESCRIPTION
Two production issues found by testing the deployed site after #223/#224.

## 1. Docker builder has no `git` → all page dates are missing

`node:20-alpine` ships without git, and Docusaurus derives several things by shelling out to `git log`:

| Feature | Live site | Same commit built locally (git present) |
|---|---|---|
| sitemap `<lastmod>` | ❌ 0 of 573 URLs | ✅ 532 entries |
| "Last updated on … by …" footer (`showLastUpdateTime`/`Author`) | ❌ missing on **all** pages | ✅ present |
| TechArticle `datePublished`/`dateModified` (JSON-LD) | ❌ missing | ✅ present |

The "Last updated" footer has been silently missing in production on every page — **pre-existing**, not caused by recent work. Adding `lastmod` in #224 is what made it visible.

**Fix:** `RUN apk add --no-cache git` in the builder stage.

**Requires** the build context to include `.git` (there is no `.dockerignore`, so it does today) and a non-shallow checkout. If `.git` were absent the failure mode is simply that dates stay missing — the build does not break.

## 2. Raw `.md` twins served as `application/octet-stream`

The raw markdown twins at `/docs/**/index.md` (emitted by `plugins/llms-txt.js` for LLM/agent consumption) had no mime type, so browsers download them instead of displaying and some crawlers skip them — defeating the purpose.

```
curl -sI https://docs.bitquery.io/docs/graphql/data-coverage-retention/index.md
-> content-type: application/octet-stream
```

**Fix:** nginx regex location setting `default_type text/markdown` + `charset utf-8`.

## Testing note

I could not build the Docker image locally (no Docker in my environment) and nginx isn't installed to run `nginx -t` — the config was checked structurally (balanced braces, all directives terminated). Please confirm the image builds and nginx starts cleanly on deploy.

## Verification after deploy

```bash
curl -s https://docs.bitquery.io/sitemap.xml | grep -c "<lastmod>"          # expect ~530, currently 0
curl -sI https://docs.bitquery.io/docs/graphql/data-coverage-retention/index.md | grep -i content-type   # expect text/markdown
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)