### PR TITLE
SEO Phase 3/4 + fix broken Holders queries shipped in #226

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ keywords/
 aeo/
 lead_lag_btc_chainlink_vs_bitquery.py
 v1_to_v2_plan.md
+V1_DOCS_SEO_HANDOFF.md
 docs/streams/solana-rpc-websocket-vs-bitquery-streams.md

--- a/docs/API-Blog/what-are-internal-transactions-how-to-get-them.md
+++ b/docs/API-Blog/what-are-internal-transactions-how-to-get-them.md
@@ -1,6 +1,6 @@
 ---
 title: "What are Internal Transactions & How to Get Them?"
-description: "What are Internal Transactions & How to Get Them?: Bitquery documentation with GraphQL examples, real-time streams, and integration guidance."
+description: "What internal transactions are, how they differ from internal transfers, and how to trace both on EVM chains using Bitquery Calls and Transfers queries."
 ---
 import FAQ from "@site/src/components/FAQ";
 

--- a/docs/blockchain/BSC/four-meme-api.mdx
+++ b/docs/blockchain/BSC/four-meme-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: "BNB Chain Four Meme API"
+title: "Four Meme API — BSC Trades, Bonding Curve & Prices"
 description: "BNB Chain Four Meme API: query and stream BNB Chain on-chain data with Bitquery GraphQL examples for developers. Keep queries fast with indexed filters."
 keywords:
   - Four Meme API

--- a/docs/blockchain/BSC/pancake-swap-api.md
+++ b/docs/blockchain/BSC/pancake-swap-api.md
@@ -1,6 +1,6 @@
 ---
 title: "BNB Chain Pancake Swap API"
-description: "BNB Chain Pancake Swap API: query and stream BNB Chain on-chain data with Bitquery GraphQL examples for developers. Keep queries fast with indexed filters."
+description: "Query and stream PancakeSwap trades on BNB Chain with Bitquery GraphQL: latest swaps, live subscriptions, token prices, OHLC and trader activity."
 ---
 import FAQ from "@site/src/components/FAQ";
 

--- a/docs/blockchain/Base/aerodrome-base-api.mdx
+++ b/docs/blockchain/Base/aerodrome-base-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Base Aerodrome Base API"
+title: "Aerodrome Finance API — Base DEX Trades & Liquidity"
 description: "Base Aerodrome Base API: query and stream Base on-chain data with Bitquery GraphQL examples for developers. See examples in the Bitquery IDE."
 sidebar_position: 7
 ---

--- a/docs/blockchain/Base/ai-agent-base-data.mdx
+++ b/docs/blockchain/Base/ai-agent-base-data.mdx
@@ -273,9 +273,6 @@ query BaseTokenHolders($tokenAddress: String!) {
       limit: { count: 50 }
       where: { Currency: { SmartContract: { is: $tokenAddress } } }
     ) {
-      BalanceUpdate {
-        Address
-      }
       Currency {
         Name
         Symbol

--- a/docs/blockchain/Base/base-dextrades.mdx
+++ b/docs/blockchain/Base/base-dextrades.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 title: "Base Chain DEX Trades API"
-description: "Base Chain DEX Trades API: get Base DEX swaps, prices, and OHLC with Bitquery GraphQL queries and live streams. Keep queries fast with indexed filters."
+description: "Query and stream Base chain DEX trades with Bitquery GraphQL: live swap streams, real-time token prices, USD pricing and per-pair trade history."
 ---
 import FAQ from "@site/src/components/FAQ";
 

--- a/docs/blockchain/Ethereum/dextrades/uniswap-api.mdx
+++ b/docs/blockchain/Ethereum/dextrades/uniswap-api.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_label: Uniswap v1–v3 Trades
 title: "Ethereum Uniswap API"
-description: "Ethereum Uniswap API: get Ethereum DEX swaps, prices, and OHLC with Bitquery GraphQL queries and live streams. Works with WebSocket live subscriptions."
+description: "Query Uniswap v1-v4 on Ethereum with Bitquery GraphQL: real-time trades, TradingView-ready OHLC streams across chains, per-pair trades and top traders."
 ---
 import FAQ from "@site/src/components/FAQ";
 

--- a/docs/blockchain/Ethereum/pepe-api.md
+++ b/docs/blockchain/Ethereum/pepe-api.md
@@ -680,7 +680,7 @@ query MyQuery {
 
 <!-- ## PEPE Total Holder Count (Snapshot)
 
-Check how many unique wallets hold PEPE at a given date. Change the `snapshot` date to compare across time.
+Check how many unique wallets hold PEPE at a given date. Change the `date` argument to compare across time.
 
 [Run In IDE ➤](https://ide.bitquery.io/pepe-holder-count-snapshot)
 
@@ -688,7 +688,7 @@ Check how many unique wallets hold PEPE at a given date. Change the `snapshot` d
 {
   EVM(network: eth) {
     Holders(
-      snapshot: "2026-05-01",
+      date: "2026-05-01",
       where: { Currency: { SmartContract: { is: "0x6982508145454ce325ddbe47a25d4ec3d2311933" } } }
     ) {
       count(of: Holder_Address, distinct: true)

--- a/docs/blockchain/Ethereum/token-holders/token-holder-api.mdx
+++ b/docs/blockchain/Ethereum/token-holders/token-holder-api.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: "Ethereum Token Holder API"
-description: "Ethereum Token Holder API: query and stream Ethereum on-chain data with Bitquery GraphQL examples for developers. Scale further with Kafka or gRPC streams."
+description: "Rank Ethereum token holders with the Bitquery Holders cube: top holders, holder counts, dated snapshots, balance thresholds and distribution statistics."
 ---
 import FAQ from "@site/src/components/FAQ";
 

--- a/docs/blockchain/Ethereum/transfers/erc20-token-transfer-api.md
+++ b/docs/blockchain/Ethereum/transfers/erc20-token-transfer-api.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: "ERC20 Token Transfers API"
-description: "Query and stream Ethereum ERC-20 and native transfers: filter by contract or address, aggregate volume, rank top transfers, and backfill with deterministic pagination."
+description: "Query and stream Ethereum ERC-20 and native transfers: filter by contract or address, aggregate volume, rank top transfers and backfill deterministically."
 keywords:
   - ERC20 token transfers API
   - Ethereum token transfers

--- a/docs/blockchain/Ethereum/transfers/rwa-api.md
+++ b/docs/blockchain/Ethereum/transfers/rwa-api.md
@@ -26,10 +26,9 @@ You can view and execute the query for the top holders of an RWA using the follo
       orderBy: { descending: Balance_Amount },
       where: { Currency: { SmartContract: { is: "0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C" } } }
     ) {
-      BalanceUpdate {
-        transactions: Count
-      }
-      Holder {
+      Balance {
+        UpdateCount
+      }Holder {
         Address
       }
       Balance {

--- a/docs/blockchain/Ethereum/transfers/rwa-api.md
+++ b/docs/blockchain/Ethereum/transfers/rwa-api.md
@@ -26,10 +26,11 @@ You can view and execute the query for the top holders of an RWA using the follo
       orderBy: { descending: Balance_Amount },
       where: { Currency: { SmartContract: { is: "0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C" } } }
     ) {
+      Holder {
+        Address
+      }
       Balance {
         UpdateCount
-      }Holder {
-        Address
       }
       Balance {
         Amount

--- a/docs/blockchain/Matic/matic-balance-api.md
+++ b/docs/blockchain/Matic/matic-balance-api.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: "Polygon (MATIC) Address Balance API"
-description: "Polygon (MATIC) Address Balance API: fetch current and historical Polygon balances with Bitquery GraphQL balance queries."
+description: "Query Polygon address balances with the Bitquery Balances cube: token and native POL balances, balances on a given date, and per-token lookups."
 ---
 # Polygon (MATIC) Address Balance API
 

--- a/docs/blockchain/Solana/Solana-DexPools-API.md
+++ b/docs/blockchain/Solana/Solana-DexPools-API.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 title: "Solana DEX Pools API"
-description: "Solana DEX Pools API: query and stream Solana on-chain data with Bitquery GraphQL examples for developers. Works with WebSocket live subscriptions."
+description: "Query Solana liquidity pools with Bitquery GraphQL: pool updates in real time, tokens above a liquidity threshold, per-token pools and latest reserves."
 ---
 import FAQ from "@site/src/components/FAQ";
 

--- a/docs/blockchain/Solana/Solana-Lifinity-dex-api.mdx
+++ b/docs/blockchain/Solana/Solana-Lifinity-dex-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Solana Lifinity DEX API"
-description: "Solana Lifinity DEX API: query and stream Solana on-chain data with Bitquery GraphQL examples for developers. Includes filters and field selection tips."
+description: "Query Lifinity on Solana with Bitquery GraphQL: real-time trades, latest token prices, OHLC candles and the top traders of any token on the DEX."
 ---
 # Lifinity DEX API
 

--- a/docs/blockchain/Solana/Solana-OpenBook-api.mdx
+++ b/docs/blockchain/Solana/Solana-OpenBook-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Solana Openbook API"
-description: "Solana Openbook API: query and stream Solana on-chain data with Bitquery GraphQL examples for developers. Scale further with Kafka or gRPC streams."
+description: "Query OpenBook v2 on Solana with Bitquery GraphQL: real-time trades, pair price averages, and every instruction including placeOrder and placeTakeOrder."
 ---
 # OpenBook DEX API
 

--- a/docs/blockchain/Solana/Solana-Phoenix-api.md
+++ b/docs/blockchain/Solana/Solana-Phoenix-api.md
@@ -1,6 +1,6 @@
 ---
 title: "Solana Phoenix API"
-description: "Solana Phoenix API: query and stream Solana on-chain data with Bitquery GraphQL examples for developers. Includes filters and field selection tips."
+description: "Query the Phoenix order book on Solana with Bitquery GraphQL: real-time trades, latest and streaming token prices, and OHLC candles for any pair."
 ---
 # Phoenix DEX API
 

--- a/docs/blockchain/Solana/Solana-Raydium-DEX-API.mdx
+++ b/docs/blockchain/Solana/Solana-Raydium-DEX-API.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 7
 title: "Raydium DEX API - Solana Trades, Pools, OHLC"
-description: "Raydium DEX API - Solana Trades, Pools, OHLC: real-time Solana memecoin and DEX data via Bitquery GraphQL APIs and Kafka streams."
+description: "Query Raydium on Solana with Bitquery GraphQL: new liquidity pools over WebSocket, pair creation times, historical pairs, token prices and OHLC candles."
 ---
 import FAQ from "@site/src/components/FAQ";
 

--- a/docs/blockchain/Solana/solana-orca-dex-api.mdx
+++ b/docs/blockchain/Solana/solana-orca-dex-api.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 7
-title: "Solana Orca DEX API"
+title: "Orca DEX API — Solana Liquidity Pools & Trades"
 description: "Solana Orca DEX API: query and stream Solana on-chain data with Bitquery GraphQL examples for developers. Works with WebSocket live subscriptions."
 ---
 import FAQ from "@site/src/components/FAQ";

--- a/docs/blockchain/Solana/solana-photon-api.md
+++ b/docs/blockchain/Solana/solana-photon-api.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: "Solana Photon API"
-description: "Solana Photon API: query and stream Solana on-chain data with Bitquery GraphQL examples for developers. Keep queries fast with indexed filters."
+description: "Track Photon-routed Solana trades with Bitquery GraphQL: latest trades by pair, trader-level rows with USD price, market cap and supply, plus live streams."
 ---
 import FAQ from "@site/src/components/FAQ";
 

--- a/docs/blockchain/Solana/token-supply-cube.mdx
+++ b/docs/blockchain/Solana/token-supply-cube.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 title: "Solana Token Supply API"
-description: "Solana Token Supply API: stream Solana market cap, FDV, supply, and price using Bitquery Trading GraphQL APIs. Built for traders and analytics teams."
+description: "Track Solana token supply with Bitquery GraphQL: subscribe to supply changes, query mint and burn events, and read circulating supply for any SPL token."
 ---
 # Solana Token Supply API
 

--- a/docs/blockchain/Tron/sunswap-api.md
+++ b/docs/blockchain/Tron/sunswap-api.md
@@ -1,6 +1,6 @@
 ---
 title: "Tron Sunswap API"
-description: "Tron Sunswap API: query and stream Tron on-chain data with Bitquery GraphQL examples for developers. See examples in the Bitquery IDE."
+description: "Query SunSwap on Tron with Bitquery GraphQL: latest trades, per-token trade history, and new Sunpump tokens plus sell events from the Tron mempool."
 ---
 # Tron SunSwap API
 

--- a/docs/blockchain/robinhood/robinhood-calls-api.md
+++ b/docs/blockchain/robinhood/robinhood-calls-api.md
@@ -1,6 +1,6 @@
 ---
 title: "Robinhood Calls & Traces API — WebSocket Streams"
-description: "Stream Robinhood contract calls and internal traces over GraphQL WebSockets — decoded inputs, call trees, deployments, reverts. A debug_traceTransaction alternative."
+description: "Stream Robinhood contract calls and internal traces over GraphQL WebSockets: decoded inputs, call trees, deployments and reverts. No node required."
 sidebar_position: 5
 keywords:
   - Robinhood calls API

--- a/docs/blockchain/robinhood/robinhood-token-holders-api.md
+++ b/docs/blockchain/robinhood/robinhood-token-holders-api.md
@@ -1,6 +1,6 @@
 ---
-title: "Robinhood Token Holders API — Rankings, Counts & Distribution"
-description: "Query Robinhood token holders with Bitquery GraphQL: top-holder rankings, holder counts, distribution stats, whale floors, dormancy screens, and stock-token holders."
+title: "Robinhood Token Holders API — Rankings & Distribution"
+description: "Query Robinhood token holders with Bitquery GraphQL: top-holder rankings, holder counts, distribution stats, whale floors and dormancy screens."
 sidebar_position: 7
 keywords:
   - Robinhood token holders API

--- a/docs/blockchain/robinhood/robinhood-transactions-receipts-api.md
+++ b/docs/blockchain/robinhood/robinhood-transactions-receipts-api.md
@@ -1,6 +1,6 @@
 ---
-title: "Robinhood Transactions & Receipts API (eth_getBlockReceipts equivalent)"
-description: "Query Robinhood transactions and receipts with Bitquery GraphQL — block receipts, single-tx receipts, status, gas, and fees. A no-node eth_get*Receipt alternative."
+title: "Robinhood Transactions & Receipts API"
+description: "Query Robinhood transactions and receipts with Bitquery GraphQL: block receipts, single-tx receipts, status, gas and fees. No node required."
 sidebar_position: 6
 keywords:
   - Robinhood transactions API

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: "Bitquery API Documentation - Blockchain Data Platform"
-description: "Bitquery API Documentation - Blockchain Data Platform: Bitquery documentation with GraphQL examples, real-time streams, and integration guidance."
+description: "Start here for Bitquery's blockchain data platform: GraphQL query and WebSocket subscription APIs, the IDE, Kafka streams and cloud data delivery."
 ---
 # Overview
 

--- a/docs/stablecoin-APIs/stablecoin-payments-api.md
+++ b/docs/stablecoin-APIs/stablecoin-payments-api.md
@@ -236,7 +236,9 @@ For the full transfer schema (mint/burn detection, `Type`, dataset selection), s
 
 ## Compliance & Risk Checks
 
-For **AML/KYC and risk monitoring**, you can analyze a payment counterparty's full lifecycle on the asset — first/last activity dates, in/out counts, and current balance — in a single query.
+For **AML/KYC and risk monitoring**, you can analyze a payment counterparty's lifecycle on the asset — first and last activity dates, total change count, and current balance — in a single query.
+
+The `Holders` cube does not break activity down by direction. For separate inbound and outbound counts or amounts, aggregate the [Transfers cube](/docs/cubes/transfers-cube) by `Transfer.Sender` / `Transfer.Receiver` instead.
 
 🔗 [Example API](https://ide.bitquery.io/stats-for-an-adddress)
 
@@ -254,16 +256,10 @@ For **AML/KYC and risk monitoring**, you can analyze a payment counterparty's fu
       Holder {
         Address
       }
-      BalanceUpdate {
-        InCount
-        OutCount
-        Count
-        InAmount
-        OutAmount
-        FirstDate
-        LastDate
-      }
       Balance {
+        UpdateCount
+        FirstChangeTime
+        LastChangeTime
         Amount
       }
     }
@@ -319,11 +315,9 @@ Identify addresses that **last received USDT** on a specific date — useful for
       Holder {
         Address
       }
-      BalanceUpdate {
-        FirstDate
-        LastDate
-      }
       Balance {
+        FirstChangeTime
+        LastChangeTime
         Amount
       }
     }
@@ -333,7 +327,7 @@ Identify addresses that **last received USDT** on a specific date — useful for
 
 ### 3. Top Stablecoin Holders
 
-Find **top holders of USDT on Ethereum**, including inflows, outflows, and full activity history. The [Stablecoin Balance API](/docs/stablecoin-APIs/stablecoin-balance-api#get-top-100-holders-of-a-particular-stablecoin) covers the same pattern on Solana.
+Find **top holders of USDT on Ethereum**, with current balance and activity history (first change, last change, total change count). For directional inflow/outflow totals, aggregate the [Transfers cube](/docs/cubes/transfers-cube) by sender and receiver. The [Stablecoin Balance API](/docs/stablecoin-APIs/stablecoin-balance-api#get-top-100-holders-of-a-particular-stablecoin) covers the same pattern on Solana.
 
 🔗 [Query Example](https://ide.bitquery.io/Top-holders-of-usdt-on-specific-date)
 
@@ -349,16 +343,10 @@ Find **top holders of USDT on Ethereum**, including inflows, outflows, and full 
       Holder {
         Address
       }
-      BalanceUpdate {
-        InCount
-        OutCount
-        Count
-        InAmount
-        OutAmount
-        FirstDate
-        LastDate
-      }
       Balance {
+        UpdateCount
+        FirstChangeTime
+        LastChangeTime
         Amount
       }
     }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1154,6 +1154,10 @@ const config = {
     ],
     require.resolve("./plugins/llms-txt.js"),
     require.resolve("./plugins/tech-article-jsonld.js"),
+    // Must run after any plugin that writes <title>. Drops the " | Bitquery Docs"
+    // suffix only on titles that render over 60 chars, so keyword-loaded page
+    // titles do not have to shed keywords to make room for branding.
+    require.resolve("./plugins/title-suffix-trim.js"),
   ],
   presets: [
     [

--- a/plugins/title-suffix-trim.js
+++ b/plugins/title-suffix-trim.js
@@ -1,0 +1,88 @@
+/**
+ * Trims the " | <siteTitle>" suffix from <title> on built pages whose rendered
+ * title exceeds MAX_TITLE — a postBuild HTML pass.
+ *
+ * Why this exists
+ * ---------------
+ * Docusaurus composes every doc page's HTML title as `${frontMatter.title} | ${siteConfig.title}`,
+ * with no per-page way to opt out. With siteConfig.title = "Bitquery Docs" that
+ * suffix costs 16 characters, so a frontmatter title must be <= 44 chars to keep
+ * the rendered title under the ~60-char guideline. Our page titles are
+ * deliberately keyword-loaded and routinely run 45-70 chars, so the constraint
+ * would mean deleting keywords purely to make room for branding.
+ *
+ * Google truncates titles by pixel width and cuts the *tail* — i.e. the branding,
+ * not the keywords — so the practical SEO cost of a long title is small. This pass
+ * removes the cosmetic warning without touching a single keyword, and without
+ * changing site-wide branding.
+ *
+ * Scope, deliberately narrow:
+ *   - <title> only. og:title and twitter:title keep the full branded form, which
+ *     is what social cards should show.
+ *   - Only when the rendered title is over MAX_TITLE. Short titles keep the suffix.
+ *   - Only the exact " | <siteTitle>" suffix, anchored at the end.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const MAX_TITLE = 60;
+
+function walkHtml(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkHtml(full, acc);
+    } else if (entry.name.endsWith(".html")) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function decode(s) {
+  // <title> content is HTML-escaped; measure the length a SERP would see.
+  return s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;|&#39;/g, "'");
+}
+
+module.exports = function titleSuffixTrimPlugin() {
+  return {
+    name: "title-suffix-trim",
+    async postBuild({ siteConfig, outDir }) {
+      const suffix = ` ${siteConfig.titleDelimiter || "|"} ${siteConfig.title}`;
+      let trimmed = 0;
+      let scanned = 0;
+
+      for (const file of walkHtml(outDir)) {
+        const html = fs.readFileSync(file, "utf8");
+        const match = html.match(/<title([^>]*)>([^<]*)<\/title>/);
+        if (!match) continue;
+        scanned += 1;
+
+        const [full, attrs, raw] = match;
+        if (!raw.endsWith(suffix)) continue;
+        if (decode(raw).length <= MAX_TITLE) continue;
+
+        const shortened = raw.slice(0, -suffix.length);
+        // Never leave an empty title — the suffix is all there is on some pages.
+        if (!shortened.trim()) continue;
+
+        fs.writeFileSync(
+          file,
+          html.replace(full, `<title${attrs}>${shortened}</title>`),
+          "utf8"
+        );
+        trimmed += 1;
+      }
+
+      console.log(
+        `[title-suffix-trim] trimmed "${suffix}" from ${trimmed} of ${scanned} titles over ${MAX_TITLE} chars`
+      );
+    },
+  };
+};

--- a/sidebars.js
+++ b/sidebars.js
@@ -165,7 +165,7 @@ const sidebars = {
             slug: "/graphql/metrics",
             title: "Metrics",
             description:
-              "Metrics used to calculate statistics over results grouped by dimensions",
+              "Aggregate metrics for Bitquery GraphQL: sum, count, uniq, median, quantile and statistics computed over results grouped by any dimension.",
           },
           items: [
             "graphql/metrics/alias",
@@ -945,7 +945,7 @@ const sidebars = {
             slug: "/trading/crypto-price-api",
             title: "Crypto Price API",
             description:
-              "Access token and currency pricing data across chains.",
+              "Real-time and historical crypto price APIs: token and pair prices, OHLC candles, market cap and supply across 40+ chains via GraphQL and streams.",
           },
           items: [
             "trading/crypto-price-api/introduction",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -200,7 +200,7 @@ export default function Home() {
     <SearchProvider>
       <Layout
         title="Bitquery V2 API Docs"
-        description="Blockchain Streaming APIs (V2) for real-time and historical transactions, balances, transfers, NFTs, DEX trades, smart contract calls, and events across 40+ blockchains."
+        description="Blockchain Streaming APIs for real-time and historical trades, transfers, balances, NFTs, contract calls and events across 40+ chains."
       >
         <div className={homeStyles.pageShell}>
           <HomepageHero />


### PR DESCRIPTION
Follow-up to #226 (merged). Three commits that were not included in it.

**Read the first section before merging** — this PR repairs queries that #226 already shipped to `main`.

## 🔴 Fixes defects already live in main

`2a583a0c` (merged via #226) migrated 16 `TokenHolders` → `Holders` sites. That commit's message claimed the migration was verified; in fact **only 1 of the 16 had been executed**. Running the rest afterwards showed **7 failures** — the migration renamed the cube and rewrote its arguments but left selection sets and arguments that do not exist on `Holders`.

| Defect | Files | Fix |
| --- | --- | --- |
| `snapshot:` argument | `pepe-api` | → `date:`. `Holders` accepts only `where` / `orderBy` / `limitBy` / `limit` / `date`. |
| `BalanceUpdate { … }` selection set | `rwa-api`, `stablecoin-payments-api` ×3, `ai-agent-base-data` | That sub-object belongs to the old `TokenHolders` cube. Mapped `Count`→`UpdateCount`, `FirstDate`→`FirstChangeTime`, `LastDate`→`LastChangeTime` and merged into the existing `Balance` block. |
| `InCount` / `OutCount` / `InAmount` / `OutAmount` | same | **No `Holders` equivalent.** Removed. |
| Jammed braces `}Balance {` and `}Holder {` | `stablecoin-payments-api`, `rwa-api` | Formatting bugs from the repair script itself. Valid GraphQL, wrong in generated docs. |
| Stale prose | `pepe-api` | Told readers to "change the `snapshot` date". |

**Two prose claims were over-promising.** They advertised *"including inflows, outflows"* and *"in/out counts"* — precisely the fields with no `Holders` equivalent. Both now state what the query actually returns and point at the Transfers cube for directional totals.

Mitigating context: these queries were **already dead** before the migration, because `EVM.TokenHolders` itself fails on both realtime (`no table can query TokenHolder`) and archive (`Database eth does not exist`). Nothing working regressed. But they were left broken *while looking migrated*, which is worse than leaving the deprecation visible.

Also corrected: **2 of the 16 sites sit inside an HTML-commented region** of `pepe-api.md` (lines 681–800, one of 6 such regions), so they are not reader-visible. **Live migrations are 14, not 16.**

## Phase 3 — titles and descriptions

Every indexable page now passes both length checks:

| Metric | Before | After |
| --- | --- | --- |
| Sitemap pages with title > 60 | 21 | **0** |
| Sitemap pages with description > 160 | 5 | **0** |
| Duplicate titles among the 573 | — | **0** |
| Duplicate descriptions among the 573 | — | **0** |

**Titles.** Adopted Google's own framing on the three pages where it discarded ours and synthesised a better one (Orca, Four Meme, Aerodrome — the last also fixes a plain bug, the title read `Base Aerodrome Base API`). Shortened the two genuinely over-length Robinhood titles.

**Did not** adopt the other ten SERP rewrites: those are cases where Google stripped our chain prefix (`Ethereum Uniswap API` → `Uniswap API`) for one query in one country. Deleting a real qualifier on that evidence risks more than it gains, and those titles were already well within limits.

**New plugin — `plugins/title-suffix-trim.js`.** Docusaurus composes `<title>` as `${frontMatter.title} | ${siteConfig.title}` with no per-page opt-out. That suffix costs exactly 16 chars, so a frontmatter title must be ≤44 to render under 60 — which would mean deleting keywords purely to make room for branding. Branding stays as "Bitquery Docs", so this `postBuild` pass drops the suffix only from titles rendering over 60 chars. **Trims 175 of 1050 built titles.**

Deliberately narrow: `<title>` only — `og:title` and `twitter:title` keep the full branded form, which is what social cards should show. Only the exact suffix, anchored at the end. Never leaves an empty title. Verified it does not desync the JSON-LD: `tech-article-jsonld` derives `headline` from frontmatter, so it now matches the trimmed `<title>` exactly.

This turned out to be a dependency rather than a nice-to-have — enriching the three titles pushed them to 62/66/67 chars, so without the plugin the change would have traded one warning for another.

**Descriptions.** Trimmed the 4 over 160. Hand-wrote 15 for the highest-traffic pages still carrying a templated description, each grounded in that page's actual sections rather than boilerplate, prioritised by real Ahrefs traffic rather than guesswork. Rewrote two `generated-index` descriptions under 110 (Crypto Price API and Metrics hubs — both have explicit slugs, so unlike `/docs/category/*` auto-slugs they are intentional hub URLs).

**Scale correction.** The templated-description problem is larger than previously reported. An earlier regex covered only 3 of the 8 boilerplate tails and gave 145. The true figure was **282** files carrying `description: "<exact title>: <one of ~8 tails>"`; **267 remain**. Ahrefs never flags these because each passes the length check individually.

**Left alone deliberately:** `docs/chinese.md` (42 CJK characters carry far more than 42 Latin ones — Ahrefs' character rule miscounts CJK) · 34 `/docs/category/*` stubs (verified to rank for exactly one zero-volume keyword across all 34) · three pages at 104–109 chars (marginally under an arbitrary threshold, not flagged by Ahrefs, not padding for a counter) · 26 pages still over 60 after trimming, all `/docs/graphql-reference/`, which is `Disallow`ed in robots.txt and excluded from the sitemap.

## Phase 4 — V1 handoff

Deliverable is `V1_DOCS_SEO_HANDOFF.md`, gitignored alongside `v1_to_v2_plan.md` per this repo's convention for internal planning docs. All findings verified live.

| Priority | Finding |
| --- | --- |
| **P0** | All **409** `/v1/**` pages emit `canonical → /v1/`. Verified across 5 unrelated pages — identical tag. Self-inflicted de-indexing of the entire legacy set. |
| **P1** | One shared 108-char title and one shared 205-char description across all 409. Sampling 4 pages yields exactly **one** distinct title string. |
| **P2** | `/v1/sitemap.xml` (409 URLs) undeclared in robots.txt; `/v1/` has 624 internal inlinks but **0** entries in the main sitemap; `/v1/blog` is listed yet returns 301. |
| **P3** | **GA4 double-counts.** V1 loads `gtag.js` for `G-ZWB80TDH9J` *and* `GTM-5GC69JH6`; V2 loads only GTM. Any V1-vs-V2 traffic comparison is ~2× wrong on the V1 side. |

Includes a sequencing constraint (do not declare the V1 sitemap until P0 lands, or we advertise 409 de-indexed URLs), a 5-point verification checklist with a runnable one-liner, and the tax-calculator defects.

## Verification

- `yarn build` passes; build output confirmed to reflect the changes, not a cache hit
- `scripts/check-links.mjs`: **no link errors** (533 pages, 1295 routes, strict)
- 44 true `Holders(` call sites, **0** remaining invalid arguments or unknown fields
- 573/573 indexable pages carry `og:type` and `og:site_name`
- No Solana `BalanceUpdates` line was touched — verified against the diff. Solana has no `Balances` cube and its `BalanceUpdates` is **not** deprecated.
- Pumpfun cluster: 22 distinct keywords, none claimed by two pages
- The API token never entered tracked files or commit history

**Verification limit, stated plainly:** this session exhausted the account's API query points, so 36 extracted `Holders` queries could not be re-executed. 13 of the 20 run before the quota died passed; the two confirmed defect classes were verified fixed by targeted parsing rather than execution. Worth re-running when points reset — note the `token-holder-api.mdx` sites target USDT, which hits the large-token timeout documented in `docs/cubes/balances-cube.md` and may need a balance floor to return at all.

## Needs an owner outside this PR

1. **Eight pages claim APIs were removed that still work.** `EVM.BalanceUpdates` ("removed 15 June 2026") and `Tron.BalanceUpdates` ("removed 18 July 2026") both still execute — `EVM.BalanceUpdates` returned data stamped `2026-07-30T11:38:59Z`. The notices are right about `TokenHolders` and wrong about both `BalanceUpdates` variants. Not edited, because only the API team can say whether removal was reverted, delayed, or the notices were written ahead of a plan.
2. **`Tron.Holders` aggregate statistics return wrong values** — `sum(of: Balance_Amount)` and `median` both `0` for a token whose top holder holds 18M. The equivalent EVM query is correct (verified on PEPE: `total / holders` matched `average` exactly). Tron-specific; deliberately undocumented until confirmed.
3. **`pepe-api.md` has 6 HTML-commented regions** (170–265, 309–351, 353–392, 502–548, 610–651, 681–800) — a large share of an indexable page sitting dead. Someone should decide restore vs delete.
4. **`robots.txt` → `/v1/sitemap.xml`** is ready but blocked on V1 P0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
