### PR TITLE
Add twitter:site; retitle Polymarket child page

### DIFF
--- a/docs/examples/polymarket-api/polymarket-api.md
+++ b/docs/examples/polymarket-api/polymarket-api.md
@@ -1,6 +1,6 @@
 ---
-title: "Polymarket API - Trade, Prices & Market Data"
-description: "Polymarket API - Trade, Prices & Market Data: Bitquery documentation with GraphQL examples, real-time streams, and integration guidance."
+title: "Polymarket API Guide - Data & Query Reference"
+description: "Which Polymarket API to use for each job: trades and prices, positions and redemptions, market lifecycle, wallet activity and real-time streams."
 # Keep explicit slug so URL stays /polymarket-api/polymarket-api/ (folder basename
 # would otherwise collapse this doc onto /examples/polymarket-api/).
 slug: /examples/polymarket-api/polymarket-api
@@ -26,7 +26,7 @@ keywords:
 ---
 import FAQ from "@site/src/components/FAQ";
 
-# Polymarket API - Trade, Prices & Market Data
+# Polymarket API Guide - Data & Query Reference
 
 The Bitquery Polymarket API provides prediction market data on Polygon via GraphQL. Use **`dataset: realtime`** on `EVM` queries for **`PredictionTrades`**, **`PredictionSettlements`**, and related prediction-market APIs—this dataset retains roughly the **last 7 days**. Use it to query trades, settlements, market metadata, and volume; filter by condition_id, outcome token, or trade size; and access data via REST, WebSocket subscriptions, or Kafka streams. Filter by Polymarket using `ProtocolName: "polymarket"` or `Marketplace.ProtocolName` in your queries.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -129,6 +129,16 @@ const config = {
         content: "Bitquery Docs",
       },
     },
+    // Docusaurus emits twitter:card and twitter:image but not twitter:site, so X
+    // could not attribute cards to the account. Handle taken from this config's
+    // own footer link (https://twitter.com/Bitquery_io), not guessed.
+    {
+      tagName: "meta",
+      attributes: {
+        name: "twitter:site",
+        content: "@Bitquery_io",
+      },
+    },
   ],
 
   scripts: [


### PR DESCRIPTION
Two small, fully verified SEO fixes. Follows #226 and #227.

## `twitter:site`

Docusaurus emits `twitter:card` and `twitter:image` but never `twitter:site`, so X had no account to attribute cards to.

**The handle is not a guess.** It is taken from this repo's own footer config — `docusaurus.config.js` → Community → "Twitter / X" → `https://twitter.com/Bitquery_io`. I had left this out of the earlier phases specifically because putting a wrong `@handle` on 573 pages would credit someone else's account; finding it in-repo resolved that.

Now present on **1016 built pages / 574 of 574 sitemap pages**, completing the card block:

```html
<meta name="twitter:card" content="summary_large_image">
<meta name="twitter:image" content="https://docs.bitquery.io/img/heroImage4.png">
<meta name="twitter:site" content="@Bitquery_io">
```

Worth noting this was **not** an Ahrefs finding for our pages — the only "X card missing" row in the crawl was the tax-calculator app, which lives in another repo. This is completeness, not a defect fix.

## Polymarket child retitle

The `generated-index` at `/docs/examples/polymarket-api/` is what actually ranks — position 2 for `polymarket api`, ~1,050 organic — and #226 gave it a keyword-led title. Its child page at `/examples/polymarket-api/polymarket-api` still carried a near-identical one.

The underlying problem is that **both pages are overview routers**, which is the real duplication rather than just the title string:

| Page | Title | Change |
| --- | --- | --- |
| hub (ranks) | `Polymarket API - Prediction Market Data` | unchanged — keeps the head term |
| child | `Polymarket API Guide - Data & Query Reference` | was `Polymarket API - Trade, Prices & Market Data` |

H1 updated to match, and the templated description (`"<exact title>: Bitquery documentation with GraphQL examples…"`) replaced with one describing what the page really is — a "which API do I use for each job" router.

No URL changed, so the ranking page is untouched.

## Verification

| Check | Result |
| --- | --- |
| Sitemap pages | 574 |
| Titles > 60 chars | **0** |
| Descriptions > 160 chars | **0** |
| Duplicate titles among the 574 | **0** |
| Missing `og:type` | **0** |
| Missing `twitter:site` | **0** |
| `yarn build` | ✅ |
| `scripts/check-links.mjs` | ✅ no link errors (533 pages, 1295 routes, strict) |

## Deliberately not in this PR: `pepe-api.md`

The third item on the same list was cleaning up 6 HTML-commented regions in `docs/blockchain/Ethereum/pepe-api.md` — 388 lines and 10 GraphQL blocks (price on Uniswap V3, price change %, whale transfers, whale net flow, volume across pairs, largest trades, holder count, wallet balance, new-wallet engagement, first-time buyers).

Investigation changed what the right fix is:

- The queries use **current, non-deprecated cubes** — `Pairs`, `Tokens`, `Transfers`, `DEXTradeByTokens`, `Trades`, `Holders`. They were not disabled because an API broke.
- They have been commented **since the page was created** on 2026-05-11 (`00655f16`), so they look like unverified drafts shipped commented rather than working content someone turned off.

Restoring them means publishing 10 GraphQL examples that cannot currently be executed — this session exhausted the account's API query points. That is exactly the failure mode corrected in #227, where a 16-site migration was asserted as verified after running one query and 7 turned out broken. Not repeating it on an indexable page.

Deleting 388 lines targeting current APIs would also throw away probably-good material.

**Recommendation:** restore after running the 10 queries, once the quota resets. Roughly a 20-minute job. Delete is the alternative if the content is not wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
