### PR TITLE
Docs: fix contradictions found auditing #229

### DIFF
--- a/docs/blockchain/Solana/solana-dextrades.mdx
+++ b/docs/blockchain/Solana/solana-dextrades.mdx
@@ -8,7 +8,11 @@ import FAQ from "@site/src/components/FAQ";
 # Solana DEX Trades API
 
 :::tip Need real-time Solana DEX data or anything from the last ~30 days?
-For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trading-data-overview) — [`Trading.Trades`](/docs/trading/crypto-trades-api/trades-api) gives you clean, MEV-filtered swaps with **USD price, market cap, and supply on every row** across **9 chains in one API** (filter with `Pair.Market.Network: Solana`). Use this page when you need **historical Solana data older than ~30 days** (with `dataset: combined` or `archive`), raw per-swap detail, or call / event context.
+For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trading-data-overview) — [`Trading.Trades`](/docs/trading/crypto-trades-api/trades-api) gives you clean, MEV-filtered swaps with **USD price, market cap, and supply on every row** across **9 chains in one API** (filter with `Pair.Market.Network: Solana`). Use this page when you need **historical Solana data older than ~30 days** (with `dataset: archive`), raw per-swap detail, or call / event context.
+
+:::caution `dataset: combined` currently fails on Solana
+Every `Solana(dataset: combined)` query tested returns a ClickHouse 500, on both the `/graphql` and `/eap` endpoints. Use `dataset: archive` for history and realtime for recent data. Several queries further down this page still use `combined` and will error until that is resolved — swap `combined` for `archive` to run them. See [data coverage & retention](/docs/graphql/data-coverage-retention/).
+:::
 :::
 
 Bitquery provides Solana DEX trade data through APIs, Streams, and Data Dumps.  
@@ -49,7 +53,7 @@ Query `Solana.DEXTrades` (or `DEXTradeByTokens`) with `where` on the wallet as *
 
 For **OHLC**, use the **[Crypto Price API](/docs/trading/crypto-price-api/introduction/)** first (`Trading.Tokens` / `Pairs` with **`Token.Network: solana`**) and [second-level OHLC](#solana-second-level-ohlc-k-line-api) on this page when you want **1-second-style** streams.
 
-For **historical OHLC** from on-chain DEX trades, use **`Solana(dataset: combined)`** or **`Solana(dataset: archive)`** with **`DEXTradeByTokens`**: filter **`Trade.Currency.MintAddress`** (and usually **`Trade.Side.Currency`** for the quote, e.g. WSOL/USDC), set **`Block.Time`** range, and bucket with **`Block { Time(interval: { count, in: minutes | hours | days }) }`**. Compute OHLC with **`PriceInUSD`** / **`Trade_Price`** minima and maxima or **`median`/`quantile`** as in [Solana OHLC API](#solana-ohlc-api).
+For **historical OHLC** from on-chain DEX trades, use **`Solana(dataset: archive)`** with **`DEXTradeByTokens`**: filter **`Trade.Currency.MintAddress`** (and usually **`Trade.Side.Currency`** for the quote, e.g. WSOL/USDC), set **`Block.Time`** range, and bucket with **`Block { Time(interval: { count, in: minutes | hours | days }) }`**. Compute OHLC with **`PriceInUSD`** / **`Trade_Price`** minima and maxima or **`median`/`quantile`** as in [Solana OHLC API](#solana-ohlc-api).
 
 :::note
 To query or stream data via GraphQL **outside the Bitquery IDE**, you need to generate an API access token.

--- a/docs/graphql/capabilities/joins.md
+++ b/docs/graphql/capabilities/joins.md
@@ -353,10 +353,10 @@ query PoolLiquidityAndPrice {
 - The join then pulls a `DEXTradeByTokens` row for the same token to attach a USD price.
 
 :::caution Do not use this join to read a price
-`Balances` is current-state and carries no block dimension, so `orderBy: { descending: Block_Time }`
-on the joined `DEXTradeByTokens` is rejected. With no ordering available, the joined row is an
-**arbitrary** match — successive runs of this query return different values, including
-`PriceInUSD: 0`.
+`Balances` is daily-grained: it exposes `Block.Date` but not `Block.Time`, so
+`orderBy: { descending: Block_Time }` on the joined `DEXTradeByTokens` is rejected. With no
+time ordering available, the joined row is an **arbitrary** match — successive runs of this
+query return different values, including `PriceInUSD: 0`.
 
 The join is shown here because it demonstrates matching on `Currency_SmartContract` across
 cubes. For an actual price, query `DEXTradeByTokens` directly with an explicit

--- a/docs/graphql/data-coverage-retention.mdx
+++ b/docs/graphql/data-coverage-retention.mdx
@@ -51,7 +51,7 @@ query RetentionFloor {
 
 `Time(minimum: Block_Time)` returns the oldest row the dataset currently holds. Swap the cube, the `dataset:` and the chain root to fill in the matrix for your own account.
 
-Note that `Balances` and `Holders` have no `Block.Time`, so this query errors against them — they are current-state cubes, not time series. For a past balance use `Holders(date: …)`, see [end-of-day balances](/docs/usecases/end-of-day-balances/).
+Note that `Balances` and `Holders` expose `Block.Date` but **not** `Block.Time`, so the query above errors against them. Their grain is daily rather than per-block, so "how far back" is answered by ordering on `Block_Date` instead. See [end-of-day balances](/docs/usecases/end-of-day-balances/).
 :::
 
 Rule of thumb: reach for `realtime` for live/streaming use cases, `combined` for "recent history + now", and `archive` for pure backfills — but only where the matrix below says archive exists.
@@ -129,9 +129,9 @@ Contact [sales@bitquery.io](mailto:sales@bitquery.io) for custom export ranges.
 
 <FAQ
   items={[
-    { q: "How far back does Solana DEX trade data go?", a: "Raw individual Solana DEX trades are available for roughly the last 30 days via the API; OHLC/price aggregates go back much further. For older raw trades, use a cloud/S3 export. Confirm the current window with support as coverage expands." },
-    { q: "Why does my query return empty results for old dates?", a: "Usually the date range is outside the retention window for that cube/dataset, or the cube isn't deployed on that chain's archive. Check the coverage matrix above, verify you're using combined (not realtime) for history, and confirm the chain supports it." },
-    { q: "What is the difference between realtime, archive and combined datasets?", a: "realtime is the most recent data (about the last few hours); archive is deep history; combined merges both into one continuous result. Availability differs per chain and per cube." },
+    { q: "How far back does Solana DEX trade data go?", a: "It depends which cube you ask. Solana.DEXTrades keeps roughly the last 12 hours on realtime, while Solana.DEXTradeByTokens keeps roughly 7 days and reaches back to mid-2024 on archive — the same trades, very different depth. The cross-chain Trading.Trades cube keeps about 30 days. OHLC/price aggregates go back further still. For older raw trades, use a cloud/S3 export." },
+    { q: "Why does my query return empty results for old dates?", a: "Usually the date range is outside the retention window for that cube/dataset, or the cube isn't deployed on that chain's archive. Realtime does not error when you ask beyond its window — it silently returns fewer rows, so a chart just starts late. Check the coverage matrix above and switch to archive for history. On Solana use archive rather than combined, which currently fails." },
+    { q: "What is the difference between realtime, archive and combined datasets?", a: "realtime is the most recent data — roughly 12 hours on Solana raw cubes, about a day on EVM Events/Calls and a few days on EVM Transfers and DEX cubes, and about 2 days on Tron. archive is deep history. combined merges both, but it is not available everywhere: it currently returns a 500 on all Solana cubes and on EVM Events and Calls. Availability differs per chain and per cube." },
     { q: "Does Kafka include historical data?", a: "No. Kafka streams realtime data plus a few hours of backfill. For history, use GraphQL (within retention) or a cloud/S3 export." },
     { q: "How do I get data older than the API retention window?", a: "Use a cloud/S3 Parquet export, or an enterprise historical export. See the Cloud datasets page and contact sales for custom ranges." },
   ]}


### PR DESCRIPTION
Follow-up to #229, which merged at `8bcb8a16`. This is the single commit pushed after that merge.

Auditing the merged diff as a reviewer turned up five places where pages disagreed with each other. **Four were introduced by #229**, and three are live contradictions inside what was just merged.

## Fixes

**`data-coverage-retention.mdx` contradicted itself.** #229 added a measured Solana table (`DEXTrades` ~12h, `DEXTradeByTokens` ~7 days) but left an FAQ on the same page answering *"How far back does Solana DEX trade data go?"* with *"roughly the last 30 days"*. Two different answers on one page. Now names the cube, since the answer depends entirely on which one you ask, and points at `Trading.Trades` for the 30-day figure that number actually refers to.

**Same page, two more stale FAQ answers.** One advised using `combined` for history, which currently returns a 500 on every Solana cube — documented three sections above it. One described realtime as *"about the last few hours"* against measured windows of ~12h on Solana to ~4 days on EVM Transfers.

**An overstatement I introduced, in two places.** I wrote that `Balances`/`Holders` are *"current-state cubes, not time series"* and *"carry no block dimension"*. They expose `Block.Date` but not `Block.Time` — daily grain, not no grain. As written it contradicted the daily-series query on the end-of-day balances page from the same PR.

**`solana-dextrades.mdx` recommended `dataset: combined` for historical OHLC** (pre-existing, not from #229). Changed to `archive`, plus a caution that several queries further down that page still use `combined` and will error until the backend issue is fixed, with the workaround.

## Also verified while auditing

- No scratch or harness files committed
- No unintended deletions — all 46 deleted lines are intentional replacements
- `<details>` / `</details>` balanced across every changed file
- No `BalanceUpdates` left inside a block labelled "Migrated query"
- #229's "21/44 migrated" claim matches the tree exactly

Build passes with `onBrokenLinks: throw`, 0 broken links.

## Note on the failure mode

Every one of these came from editing a page section-by-section without re-reading the whole page afterwards. The queries were each verified individually; the prose around them drifted out of agreement. No query-execution audit would have caught it.

## Still open from #229, unchanged

- The mempool `BalanceUpdate.Type` subscription has **no replacement** after the 10 August sunset — `Balances` does not stream and has no `Type`
- `Balances`/`Holders` are currently **less reliable** than the cube they replace (retried 3x per chain: `Balances` bsc 0/3, matic 1/3, base 3/3, eth 3/3, while `BalanceUpdates` answered 2/2 on the same runs)
- 23 of 44 sunset migrations remain, none mechanical
