### PR TITLE
docs: give the Address Labels API its own top-level nav section

### DIFF
--- a/docs/cubes/balances-cube.md
+++ b/docs/cubes/balances-cube.md
@@ -248,7 +248,7 @@ If you need to know *why* a balance moved rather than *what it became*, reconstr
 
 ## Related
 
-- [Address Labels API](/docs/cubes/address-labels-api) — identify which of those addresses are exchanges, contracts, or known entities
+- [Address Labels API](/docs/labels/address-labels-api) — identify which of those addresses are exchanges, contracts, or known entities
 - [Balance Updates cube](/docs/cubes/balance-updates-cube) — per-change history and change attribution
 - [Transfers cube](/docs/cubes/transfers-cube) — the transfers that drive most balance changes
 - [Token Holders API (Ethereum)](/docs/blockchain/Ethereum/token-holders/token-holder-api) — worked `EVM.Holders` examples

--- a/docs/labels/address-labels-api.md
+++ b/docs/labels/address-labels-api.md
@@ -1,5 +1,7 @@
 ---
 title: "Address Labels API — Identify Crypto Wallets"
+sidebar_label: "Overview"
+sidebar_position: 1
 description: "Identify wallets and contracts with the Bitquery Address Labels API: exchange hot and cold wallets, deposit addresses, token contracts and clones, any chain."
 keywords:
   - address labels API

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -198,6 +198,13 @@ const config = {
             to: "/docs/blockchain/Ethereum/token-holders/token-holder-api/",
             from: "/docs/examples/balances/tokenHolders-api/",
           },
+          // Labels moved out of the cubes section into their own top-level
+          // section. The cubes URL shipped in #236 and was live, so it keeps
+          // redirecting.
+          {
+            to: "/docs/labels/address-labels-api/",
+            from: "/docs/cubes/address-labels-api/",
+          },
           {
             to: "/docs/contribution-guidelines/",
             from: "/docs/contribution_guidelines/",

--- a/sidebars.js
+++ b/sidebars.js
@@ -389,7 +389,6 @@ const sidebars = {
           ],
         },
         "cubes/solana",
-        "cubes/address-labels-api",
       ],
     },
 
@@ -1071,6 +1070,17 @@ const sidebars = {
         "stablecoin-APIs/stablecoin-transfers-api",
         "stablecoin-APIs/usdt-api",
       ],
+    },
+    {
+      type: "category",
+      label: "Address Labels API",
+      link: {
+        type: "generated-index",
+        title: "Address Labels API",
+        description:
+          "Identify the real-world entity behind any wallet or contract address — exchange wallets, deposit addresses, token contracts, and issuer-blocked lists.",
+      },
+      items: ["labels/address-labels-api"],
     },
     {
       type: "category",


### PR DESCRIPTION
Follow-up to #236, which is already merged and deployed.

In #236 the page landed as a single item under **Understanding Cubes**, sitting next to the EVM and Solana cube pages. Labels are a distinct product surface rather than a cube variant, and the section needs room to grow.

## What changes

- page moves to `docs/labels/address-labels-api.md` → **`/docs/labels/address-labels-api`**
- new **top-level sidebar category "Address Labels API"**, following the Stablecoin APIs pattern (generated-index over its own folder), positioned with the other API product sections between Stablecoin APIs and MCP
- page carries `sidebar_label: "Overview"` so the nav reads `Address Labels API › Overview` instead of repeating the full page title
- inbound link from the Balances cube repointed

## Redirect (important)

#236 shipped and deployed the cubes URL — `https://docs.bitquery.io/docs/cubes/address-labels-api/` is **live and serving right now**. So this is not a free rename: it adds a client redirect from the old path rather than leaving it to 404.

Verified in the production build that the generated page at `build/docs/cubes/address-labels-api/index.html` redirects to `/docs/labels/address-labels-api/`.

## Verification

`npm run build` passes. At the new URL, re-confirmed the title still renders at exactly 60 chars (so the `| Bitquery Docs` suffix survives the trimmer), the description, the canonical, and the FAQPage / TechArticle / BreadcrumbList JSON-LD. Sidebar renders as a top-level folder with `Overview` beneath it, and the breadcrumb reads `Address Labels API › Overview`.

## Unrelated pre-existing issue spotted

`npm run build` on current main reports a broken anchor that this PR does not touch: `docs/mcp/build-a-trading-agent.mdx` links to `/docs/mcp/mcp-server/#authentication-via-query-token-less-secure`, an anchor removed by 2bfb9b3b. Worth a separate fix — the surrounding `?token=YOUR_TOKEN` instruction may be obsolete too, not just the anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)