### PR TITLE
docs: drop the removed MCP query-token auth guidance

### DIFF
--- a/docs/mcp/build-a-trading-agent.mdx
+++ b/docs/mcp/build-a-trading-agent.mdx
@@ -26,7 +26,7 @@ Pick your runtime:
 | Cursor | `.cursor/mcp.json` with `mcp-remote` → `https://mcp.bitquery.io/mcp` |
 | Claude Code | `claude mcp add bitquery -- npx -y mcp-remote https://mcp.bitquery.io/mcp` |
 
-Sign in with a [Bitquery account](https://account.bitquery.io/) on first tool call. For headless servers, append `?token=YOUR_TOKEN` (see [MCP overview](/docs/mcp/mcp-server/#authentication-via-query-token-less-secure)).
+Sign in with a [Bitquery account](https://account.bitquery.io/) on first tool call. The client opens a browser once for OAuth 2.1, then caches and refreshes the token for you (see [MCP overview](/docs/mcp/mcp-server/#first-connection-and-permissions)).
 
 ## Step 2 — Discovery loop
 

--- a/docs/mcp/cursor.mdx
+++ b/docs/mcp/cursor.mdx
@@ -45,6 +45,6 @@ More detail: [MCP server overview](/docs/mcp/mcp-server/).
   items={[
     { q: "How do I add Bitquery MCP to Cursor?", a: "Add https://mcp.bitquery.io in Cursor MCP settings, or use mcp-remote in .cursor/mcp.json as shown on this page." },
     { q: "Which chains can I query through MCP?", a: "Solana, Ethereum, BSC, Base, Arbitrum, Optimism, Polygon, and Tron — ask in plain English, no GraphQL required." },
-    { q: "Can I use an API token instead of OAuth?", a: "Yes for headless setups — append ?token=YOUR_TOKEN to the MCP URL. OAuth is safer for daily interactive use." },
+    { q: "Can I use an API token instead of OAuth?", a: "No. The Bitquery MCP server authenticates with OAuth 2.1 — Cursor opens a browser once on the first tool call, then caches and refreshes the token for you." },
   ]}
 />


### PR DESCRIPTION
## What

Fixes the broken anchor `npm run build` reports:

```
Broken anchor on source page path = /docs/mcp/build-a-trading-agent/:
 -> linking to /docs/mcp/mcp-server/#authentication-via-query-token-less-secure
```

## Why not just re-anchor it

Commit 2bfb9b3b removed the "Authentication via query token (less secure)" section from `docs/mcp/mcp-server.mdx` as an **incorrect** auth method. The sentence holding the dangling link didn't just link to that section — it repeated its instruction:

> For headless servers, append `?token=YOUR_TOKEN`

Re-pointing the link would have left users following a method that was deliberately deleted. Both the link and the instruction are gone; the text now describes the OAuth 2.1 flow `mcp-server.mdx` actually documents, and links to the `#first-connection-and-permissions` section.

**Confirmed with the docs owner: removing query-token auth from the docs is intended.** OAuth 2.1 is the supported path. This PR finishes that removal rather than reviving it.

## Second occurrence, not build-visible

`docs/mcp/cursor.mdx:48` carried the same claim in an FAQ answer:

> Can I use an API token instead of OAuth? → "Yes for headless setups — append `?token=YOUR_TOKEN` to the MCP URL."

It has no link, so the build never flagged it, but it is the same instruction that was removed from the overview page. Fixed here so the method is gone from the MCP docs entirely rather than surviving in the one place the link checker can't see.

`?token=YOUR_TOKEN` elsewhere in the docs refers to `streaming.bitquery.io` WebSockets, which does support it — untouched. That's also the likely origin of the error: the deleted section explicitly reasoned by analogy from the WebSocket behaviour.

## Side note for whoever runs the MCP server (not a docs issue)

The server's RFC 9728 metadata still advertises query-parameter bearer auth, which is now inconsistent with the documented position:

```
$ curl -s https://mcp.bitquery.io/.well-known/oauth-protected-resource
{"resource":"https://mcp.bitquery.io","authorization_servers":["https://account.bitquery.io"],
 "bearer_methods_supported":["header","query"], ...}
```

Flagging only so it isn't a surprise later — a client that reads this metadata may try query auth. Nothing in this PR depends on it, and it needs no action here.

## Verification

`npm run build` passes; the broken-anchor warning is gone, and grepping the full log for `broken|anchor` returns nothing. Confirmed in the built HTML that `id="first-connection-and-permissions"` exists on the mcp-server page and that no `token=YOUR_TOKEN` survives under `build/docs/mcp/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)