### PR TITLE
docs: fix Solana aggregate queries that filter on USD-denominated fields

### DIFF
--- a/docs/blockchain/Solana/historical-aggregate-data.mdx
+++ b/docs/blockchain/Solana/historical-aggregate-data.mdx
@@ -110,7 +110,7 @@ query MyQuery {
 
 ## Historical OHLC on Solana
 
-[This](https://ide.bitquery.io/historical-ohlc-for-solana_3) query returns the historical OHLC data for a given pair along with volume
+[This](https://ide.bitquery.io/Historical-OHLC-for-Solana-archive) query returns the historical OHLC data for a given pair along with volume
 and number of trades in the given interval.
 
 For this example the pair between the tokens listed below is considered.
@@ -363,7 +363,7 @@ You can run the query [here](https://ide.bitquery.io/Price-ATH-query)
 ## Get ATH Price, ATH Date, Price Change percentage in 24h, 7d, 30d
 
 Fetches a Solana token’s ATH price, ATH date, and price change percentages over the past 24h, 7d, and 30d using Bitquery Solana APIs.
-Try the [query to get ATH price, ATH date, price change](https://ide.bitquery.io/ath-with-price-delta_1).
+Try the [query to get ATH price, ATH date, price change](https://ide.bitquery.io/ATH-with-price-delta-Solana).
 
 ```graphql
 query ($token: String) {
@@ -441,7 +441,7 @@ query ($token: String) {
 
 ## Get ATH of Multiple Tokens
 
-You can run it [here](https://ide.bitquery.io/ATH-of-multiple-tokens-using-quantile-on-Solana)
+You can run it [here](https://ide.bitquery.io/ATH-of-multiple-tokens-quantile-Solana)
 
 ```graphql
 {

--- a/docs/blockchain/Solana/historical-aggregate-data.mdx
+++ b/docs/blockchain/Solana/historical-aggregate-data.mdx
@@ -17,6 +17,30 @@ However the options to use the historical data are quite limited and currently o
 `Trade Side Account` field will not be available for aggregate queries in Archive and Combined Datasets
 :::
 
+## Filter limitations on aggregate datasets
+
+On `Solana` with `dataset: archive` or `dataset: combined`, `DEXTradeByTokens` is served from
+pre-aggregated tables. **USD-denominated fields and `PriceAsymmetry` cannot be used inside `where:`.**
+A query that filters on them fails outright with an error such as
+`no table can query DEXTradeByToken` or `database schema not defined for archive cube` — it does not
+silently return different numbers. The same USD fields work normally as **output measures**.
+
+| Field | As a `where:` filter | As a measure / projection |
+|---|---|---|
+| `Trade.Amount`, `Trade.Side.Amount` | works | works |
+| `Trade.Price` | works | works |
+| `Trade.Currency`, `Trade.Side.Currency` | works | works |
+| `Trade.Account.Address` | works | works |
+| `Trade.Side.Type`, `Trade.Dex`, `Block.Time` | works | works |
+| `Trade.PriceAsymmetry` | **error** | — |
+| `Trade.Side.AmountInUSD`, `Trade.AmountInUSD` | **error** | works — `sum(of: Trade_Side_AmountInUSD)` |
+| `Trade.PriceInUSD` | **error** | works — `quantile(of: Trade_PriceInUSD)` |
+| `Trade.Side.Account` | **error** | **error** |
+
+All of these filters work on `dataset: realtime`, which covers a rolling recent window (hours).
+To filter by USD amount or `PriceAsymmetry` over history, use the
+[Trading API](/docs/trading/crypto-trades-api/trades-api/), which carries USD price and supply on every row.
+
 ## Historical Trades for Solana
 
 **Historical trades for upto past 30 days could be retrieved via Trading API. Docs available [here](/docs/trading/crypto-trades-api/trades-api/).**
@@ -107,7 +131,6 @@ For this example the pair between the tokens listed below is considered.
               MintAddress: { is: "So11111111111111111111111111111111111111112" }
             }
           }
-          PriceAsymmetry: { lt: 0.1 }
         }
       }
       limit: { count: 10 }
@@ -137,6 +160,11 @@ For this example the pair between the tokens listed below is considered.
     These would represent the _close_ of April 14 and _open_ of April 15 respectively, leaving a gap in between.
 
 - **Derived from block time**: All time-based grouping (daily, hourly, etc.) depends on block timestamps.
+
+- **No `PriceAsymmetry` filter on archive/combined**: this query cannot exclude asymmetric prints, so
+  `high` and `low` take raw extremes and may include outlier trades. For cleaner candles over the last
+  ~30 days use the [Trading API](/docs/trading/crypto-price-api/crypto-ohlc-candle-k-line-api/), which
+  serves USD OHLC directly. See [Filter limitations](#filter-limitations-on-aggregate-datasets).
 
 **Alternative approach**: You can get all trades and calculate OHLC locally in your own system. Complete guide [here](/docs/usecases/ohlcv-complete-guide/)
 
@@ -310,7 +338,10 @@ query MyQuery {
 ## Get ATH (All-Time High) of a Token
 
 In this query we use the 95th percentile (`level: 0.95`) to find the highest price of a token.
-We also use `PriceAsymmetry` and `AmountInUSD` in combination to filter outliers as much as possible.
+The 95th percentile is itself outlier-resistant, which matters here because `PriceAsymmetry` and
+`AmountInUSD` **cannot be used as filters** on aggregate datasets — see
+[Filter limitations on aggregate datasets](#filter-limitations-on-aggregate-datasets). On
+`dataset: realtime` you can add both filters for stricter outlier control.
 
 Read more about quantiles [here](/docs/graphql/metrics/quantile/)
 You can run the query [here](https://ide.bitquery.io/Price-ATH-query)
@@ -319,7 +350,7 @@ You can run the query [here](https://ide.bitquery.io/Price-ATH-query)
 {
   Solana(dataset: combined) {
     DEXTradeByTokens(
-      where: {Trade: {Side: {Currency: {MintAddress: {in: ["11111111111111111111111111111111", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", "So11111111111111111111111111111111111111112"]}}, AmountInUSD: {gt: "10"}}, Currency: {MintAddress: {is: "2tnA2ZmwmgUZLyYLi97zbwsFBXAqpMEcHu9Cv9JW6m26"}}, PriceAsymmetry: {lt: 0.01}}}
+      where: {Trade: {Side: {Currency: {MintAddress: {in: ["11111111111111111111111111111111", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", "So11111111111111111111111111111111111111112"]}}}, Currency: {MintAddress: {is: "2tnA2ZmwmgUZLyYLi97zbwsFBXAqpMEcHu9Cv9JW6m26"}}}}
       limit: {count: 1}
       orderBy: {descendingByField: "aATH"}
     ) {
@@ -338,7 +369,7 @@ Try the [query to get ATH price, ATH date, price change](https://ide.bitquery.io
 query ($token: String) {
   Solana(dataset: combined) {
     DEXTradeByTokens(
-      where: {Trade: {Side: {Currency: {MintAddress: {in: ["11111111111111111111111111111111", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", "So11111111111111111111111111111111111111112"]}}, AmountInUSD: {gt: "10"}}, Currency: {MintAddress: {is: $token}}, PriceAsymmetry: {lt: 0.01}}, Transaction: {Result: {Success: true}}}
+      where: {Trade: {Side: {Currency: {MintAddress: {in: ["11111111111111111111111111111111", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", "So11111111111111111111111111111111111111112"]}}}, Currency: {MintAddress: {is: $token}}}, Transaction: {Result: {Success: true}}}
       limit: {count: 1}
     ) {
       Trade {
@@ -423,8 +454,6 @@ You can run it [here](https://ide.bitquery.io/ATH-of-multiple-tokens-using-quant
               in: ["token mint address-1", "token mint address-2"]
             }
           }
-          PriceAsymmetry: { lt: 0.01 }
-          AmountInUSD: { gt: "10" }
         }
       }
       limit: { count: 2 }
@@ -456,7 +485,6 @@ query GetAthMarketCap($tokens: [String!]!) {
       where: {
         Trade: {
           Currency: { MintAddress: { in: $tokens } }
-          Side: { AmountInUSD: { gt: "1" } }
         }
       }
     ) {

--- a/docs/blockchain/Solana/solana-dextrades.mdx
+++ b/docs/blockchain/Solana/solana-dextrades.mdx
@@ -869,7 +869,6 @@ query GetAthMarketCap($tokens: [String!]!) {
       where: {
         Trade: {
           Currency: { MintAddress: { in: $tokens } }
-          Side: { AmountInUSD: { gt: "1" } }
         }
       }
     ) {

--- a/docs/graphql/dataset/combined.md
+++ b/docs/graphql/dataset/combined.md
@@ -33,3 +33,15 @@ Also Check [Archive](/docs/graphql/dataset/archive) and [RealTime](/docs/graphql
 ## Why does dataset: combined return fewer fields than dataset: realtime on Solana?
 
 On Solana, some projections (for example certain **`Trade.Side`** / account-level fields) are only populated in the **realtime** slice. **Combined** and **archive** historical aggregates may **omit** those columns, which triggers “columns not available” errors if you request them. Use fields documented for **archive/combined** (e.g. `DEXTradeByTokens` aggregates) or switch to **`dataset: realtime`** for debugging. See [Historical Solana aggregate data](/docs/blockchain/Solana/historical-aggregate-data/) and [Pump.fun combined-dataset note](/docs/blockchain/Solana/Pumpfun/Pump-Fun-API/#why-does-my-pumpfun-query-return-columns-not-available-in-combined-dataset).
+
+
+## Why do some filters error out on dataset: combined or archive?
+
+On Solana, `DEXTradeByTokens` on **archive** and **combined** is served from pre-aggregated tables that do
+not carry USD-denominated columns. Using `Trade.PriceAsymmetry`, `Trade.AmountInUSD`,
+`Trade.Side.AmountInUSD`, or `Trade.PriceInUSD` inside `where:` fails with
+`no table can query DEXTradeByToken` or `database schema not defined for archive cube`. The failure is a
+hard error, not a silently dropped filter. The same fields still work as **output measures** — for example
+`sum(of: Trade_Side_AmountInUSD)` and `quantile(of: Trade_PriceInUSD)` return correct values on archive.
+Native-unit equivalents (`Trade.Amount`, `Trade.Side.Amount`, `Trade.Price`) filter normally. See
+[Filter limitations on aggregate datasets](/docs/blockchain/Solana/historical-aggregate-data/#filter-limitations-on-aggregate-datasets).

--- a/docs/graphql/dataset/options.md
+++ b/docs/graphql/dataset/options.md
@@ -25,3 +25,10 @@ Top level element of the query has 3 attributes, defining what is the source for
 For example, the dataset for subscription is always real time and not controlled.
 :::
 
+
+## What is the default dataset if I do not set one?
+
+If you omit `dataset`, the query behaves as **`dataset: realtime`** — the rolling recent window, with all
+filters available. Set `dataset: archive` or `dataset: combined` explicitly when you need history, and note
+that aggregate datasets restrict which fields can be filtered: see
+[Filter limitations on aggregate datasets](/docs/blockchain/Solana/historical-aggregate-data/#filter-limitations-on-aggregate-datasets).

--- a/docs/usecases/ohlcv-complete-guide.md
+++ b/docs/usecases/ohlcv-complete-guide.md
@@ -107,6 +107,12 @@ Bitquery also supports non-EVM chains, such as **Solana** and **Tron**, enabling
 For a detailed guide, visit:  
 [Historical OHLC on Solana](/docs/blockchain/Solana/historical-aggregate-data/#historical-ohlc-on-solana).
 
+:::note
+On `dataset: combined` / `archive`, `PriceAsymmetry` and USD amount fields cannot be used as filters —
+they return an error. The query below therefore takes raw `high`/`low` extremes. See
+[Filter limitations on aggregate datasets](/docs/blockchain/Solana/historical-aggregate-data/#filter-limitations-on-aggregate-datasets).
+:::
+
 #### **Sample Query**
 
 ```graphql
@@ -124,7 +130,6 @@ For a detailed guide, visit:
               MintAddress: { is: "So11111111111111111111111111111111111111112" }
             }
           }
-          PriceAsymmetry: { lt: 0.1 }
         }
       }
       limit: { count: 10 }
@@ -328,7 +333,7 @@ Take this query [https://ide.bitquery.io/quantile](https://ide.bitquery.io/quant
   Solana(dataset: combined) {
     DEXTradeByTokens(
       orderBy: {descendingByField: "Block_Timefield"}
-      where: {Trade: {Currency: {MintAddress: {is: "J3TqbUgHurQGNxWtT88UQPcMNVmrL875pToQZdrkpump"}}, Side: {Currency: {MintAddress: {is: "So11111111111111111111111111111111111111112"}}, AmountInUSD: {gt: "10"}}}}
+      where: {Trade: {Currency: {MintAddress: {is: "J3TqbUgHurQGNxWtT88UQPcMNVmrL875pToQZdrkpump"}}, Side: {Currency: {MintAddress: {is: "So11111111111111111111111111111111111111112"}}, Amount: {gt: "0.05"}}}}
       limit: {count: 10}
     ) {
       Block {


### PR DESCRIPTION
## Problem

On Solana, `DEXTradeByTokens` with `dataset: archive` or `combined` is served from pre-aggregated tables that carry no USD-denominated columns. Filtering on them fails with a **hard GraphQL error**:

```
no table can query DEXTradeByToken (map[aggregates:yes dataset:combined ...])
database schema not defined for archive cube DEXTradeByToken solana[mainnet-beta.solana.com]
```

Eight documented examples did this, so they did not run at all — including the flagship OHLC example on the Historical Solana Data page.

## Verified behaviour

Tested live against `streaming.bitquery.io/graphql` (fixed historical window, each filter compared against its own no-filter baseline):

| Filter | realtime | archive / combined |
|---|---|---|
| `Trade.Amount`, `Trade.Side.Amount` | works | **works** |
| `Trade.Price`, `Trade.Account.Address` | works | **works** |
| `Trade.Side.Type`, `Trade.Dex`, `Block.Time` | works | **works** |
| `Trade.PriceAsymmetry` | works | **error** |
| `Trade.Side.AmountInUSD`, `Trade.AmountInUSD` | works | **error** |
| `Trade.PriceInUSD` | works | **error** |

USD fields work fine as **output measures** on aggregates — `sum(of: Trade_Side_AmountInUSD)` and `quantile(of: Trade_PriceInUSD)` both return correct values. Only `where:` filters are affected.

Causally confirmed: deleting only the `Side.AmountInUSD` line from an otherwise unchanged failing query makes it return data.

## Changes

**8 query fixes** — 7 filter removals plus one substitution (`Side.AmountInUSD {gt "10"}` → `Side.Amount {gt "0.05"}`, the native-unit equivalent, used only where a single quote currency is pinned). All 8 now execute successfully.

**Documentation** — a filter-limitation table on the Solana historical aggregate page, a matching Q&A on the combined-dataset page, and the previously undocumented default dataset (`realtime`) on the dataset options page. The existing warning only covered the `Trade Side Account` *projection*; nothing documented the filter restriction.

**Three IDE links repointed** — the linked saved queries were owned by other accounts and still carried the broken filters, so the "run it here" links errored even with the markdown fixed. Corrected copies now exist under the docs account.

## Deliberately unchanged

- `Transaction: {Result: {Success: true}}` (21 queries) — verified working; it is a documented default filter and is ignored on every dataset, realtime included.
- `Trade.Account` filters (4 queries) — verified working on aggregates.
- 28 Solana queries with no `dataset:` argument — the default behaves as `realtime`, where all filters work.

## Known limitation

The originals owned by other accounts still carry the broken filters and remain in the public Query Library; a one-line fix by their owners would retire the duplicates.

## Verification

All 8 edited queries executed against the live API and returned data. Full-tree rescan: 42 Solana aggregate query blocks, **0 residual broken filters**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)