### PR TITLE
Add ProductCTA cross-links from ranking docs pages to bitquery.io product pages

### DIFF
--- a/docs/API-Blog/what-are-internal-transactions-how-to-get-them.md
+++ b/docs/API-Blog/what-are-internal-transactions-how-to-get-them.md
@@ -3,14 +3,19 @@ title: "What are Internal Transactions & How to Get Them?"
 description: "What internal transactions are, how they differ from internal transfers, and how to trace both on EVM chains using Bitquery Calls and Transfers queries."
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 # What are Internal Transactions & How to Get Them?
 
 In blockchain a transaction is the transfer of value between two participants, recorded on a digital ledger. Not all transactions involve the direct sending of funds from one wallet to another, some transactions occur within smart contracts. These transactions are known as internal transactions.
 
+Internal transactions are decoded calls — the [Smart Contract API](https://bitquery.io/products/smart-contract-api) page covers decoded events and calls with plans and trial access.
+
 Internal transactions are important in smart contract interactions, and having an understanding of how they work and how to trace them is essential for ensuring the transparency and security of smart contracts.
 
 This article will explain what internal transactions are, how to trace them using [Bitquery](https://bitquery.io/) APIs, and how to use Bitquery's tools for detailed blockchain analysis.
+
+<ProductCTA href="https://bitquery.io/products/smart-contract-api" title="Smart Contract API" />
 
 ## What are Internal Transactions?
 

--- a/docs/blockchain/Arbitrum/gmx-api.mdx
+++ b/docs/blockchain/Arbitrum/gmx-api.mdx
@@ -3,12 +3,17 @@ title: "GMX Staking API on Arbitrum"
 description: "Query GMX staking positions, esGMX rewards, and related on-chain activity on Arbitrum with Bitquery GraphQL APIs. Works with WebSocket live subscriptions."
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 # GMX API
 
 This section covers how to retrieve staking information on GMX.
 
+GMX is one venue within our [Arbitrum API](https://bitquery.io/blockchains/arbitrum-blockchain-api) coverage — the page lists DEX trades, transfers, NFTs and balances on Arbitrum One.
+
 You can read more about the [GMX ecosystem in this blog](https://bitquery.io/blog/gmx).
+
+<ProductCTA href="https://bitquery.io/blockchains/arbitrum-blockchain-api" title="Arbitrum API" />
 
 ## Video Tutorial on GMX and esGMX
 

--- a/docs/blockchain/BSC/four-meme-api.mdx
+++ b/docs/blockchain/BSC/four-meme-api.mdx
@@ -10,6 +10,7 @@ keywords:
   - BSC memecoin API
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 import VideoPlayer from "../../../src/components/videoplayer.js";
 
@@ -17,6 +18,8 @@ import VideoPlayer from "../../../src/components/videoplayer.js";
 
 :::danger `BalanceUpdates` sunsets 10 August 2026
 Queries on this page that use **`BalanceUpdates`** will stop working on **10 August 2026**. Migrate to the **`Balances`** and **`Holders`** cubes, which return the current balance directly instead of summing deltas.
+
+For launch tracking, trades and graduation coverage with plans and trial access, see the [Four.meme API](https://bitquery.io/products/fourmeme-api) product page.
 
 See the [migration mapping](/docs/cubes/balances-cube/#migrating-from-balanceupdates) for the query-by-query translation.
 :::
@@ -46,6 +49,8 @@ To query or stream data via GraphQL outside the Bitquery IDE, you need to genera
 
 Follow the steps here to create one: [How to generate Bitquery API token](/docs/authorization/how-to-generate/)
 :::
+
+<ProductCTA href="https://bitquery.io/products/fourmeme-api" title="Four.meme API" />
 
 ## What is the Four Meme exchange contract address on BSC? {#what-is-the-four-meme-exchange-contract-address-on-bsc}
 

--- a/docs/blockchain/BSC/pancake-swap-api.md
+++ b/docs/blockchain/BSC/pancake-swap-api.md
@@ -3,6 +3,7 @@ title: "BNB Chain Pancake Swap API"
 description: "Query and stream PancakeSwap trades on BNB Chain with Bitquery GraphQL: latest swaps, live subscriptions, token prices, OHLC and trader activity."
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 import VideoPlayer from "../../../src/components/videoplayer.js";
 
@@ -10,6 +11,8 @@ import VideoPlayer from "../../../src/components/videoplayer.js";
 
 :::danger `BalanceUpdates` sunsets 10 August 2026
 Queries on this page that use **`BalanceUpdates`** will stop working on **10 August 2026**. Migrate to the **`Balances`** and **`Holders`** cubes, which return the current balance directly instead of summing deltas.
+
+For coverage, plans and streaming options on BNB Chain, see the [Binance Smart Chain API](https://bitquery.io/products/binance-smart-chain-api-post) page.
 
 See the [migration mapping](/docs/cubes/balances-cube/#migrating-from-balanceupdates) for the query-by-query translation.
 :::
@@ -21,6 +24,8 @@ For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trad
 
 In this section we will use APIs from Bitquery to get the on-chain trade related data, trade metrics, trades for a token or a trader on the Pancake Swap DEX.
 To get the trade activities of the Pancake Swap exclusively we have added a filter out trades based on `Factory Contract` address, `0x0bfbcf9fa4f9c56b0f40a671ad40e0805a091865` for the case of Pancake Swap V3. To get the trades and trade related data for Pancake Swap V1 or V2 you would need their respective addresses. Create your account and get started by following the [Quickstart instructions](/docs/start/first-query/).
+
+<ProductCTA href="https://bitquery.io/products/binance-smart-chain-api-post" title="Binance Smart Chain API" />
 
 ## Bitquery DEX Data Access Options
 

--- a/docs/blockchain/Base/base-dextrades.mdx
+++ b/docs/blockchain/Base/base-dextrades.mdx
@@ -4,16 +4,21 @@ title: "Base Chain DEX Trades API"
 description: "Query and stream Base chain DEX trades with Bitquery GraphQL: live swap streams, real-time token prices, USD pricing and per-pair trade history."
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 # Base Chain DEX Trades API
 
 :::tip Need real-time Base DEX data or anything from the last ~30 days?
 For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trading-data-overview) — [`Trading.Trades`](/docs/trading/crypto-trades-api/trades-api) gives you clean, MEV-filtered swaps with **USD price, market cap, and supply on every row** across **9 chains in one API** (filter with `Pair.Market.Network: Base`). Use this page when you need **historical Base data older than ~30 days** (with `dataset: combined` or `archive`), raw per-swap detail, or call / event context.
+
+For full-chain coverage — Aerodrome and Uniswap trades, transfers, balances and bridge flows — see the [Base API](https://bitquery.io/blockchains/base-blockchain-api) page.
 :::
 
 In this section we will see how to get Base DEX trades information using our API.
 
 import VideoPlayer from "../../../src/components/videoplayer.js";
+
+<ProductCTA href="https://bitquery.io/blockchains/base-blockchain-api" title="Base API" />
 
 ## Live DEX swap stream (Base) {#crypto-trades-live-stream}
 

--- a/docs/blockchain/Ethereum/dextrades/uniswap-api.mdx
+++ b/docs/blockchain/Ethereum/dextrades/uniswap-api.mdx
@@ -4,10 +4,13 @@ title: "Ethereum Uniswap API"
 description: "Query Uniswap v1-v4 on Ethereum with Bitquery GraphQL: real-time trades, TradingView-ready OHLC streams across chains, per-pair trades and top traders."
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 # Uniswap API
 
 Uniswap is a decentralized exchange on Ethereum for trading ERC-20 tokens. Bitquery’s APIs support Uniswap trades, pool creations, and active user metrics across v1, v2, v3 and v4 in real-time and across archive data since genesis.
+
+The same schema powers our multi-chain [DEX API](https://bitquery.io/products/dex), so every query below also works across PancakeSwap, Raydium and 300+ other venues.
 
 To get details on Uniswap v3 Positions, check the examples available in [this page](/docs/blockchain/Ethereum/dextrades/uniswap-position-api/)
 
@@ -18,6 +21,8 @@ You can also explore Uniswap APIs on other chains:
 - [Polygon](/docs/blockchain/Matic/matic-uniswap-api/)
 
 import VideoPlayer from "../../../../src/components/videoplayer.js";
+
+<ProductCTA href="https://bitquery.io/products/dex" title="DEX API" />
 
 ## Realtime Uniswap v1, v2, v3, v4 Trades
 

--- a/docs/blockchain/Ethereum/token-holders/token-holder-api.mdx
+++ b/docs/blockchain/Ethereum/token-holders/token-holder-api.mdx
@@ -4,11 +4,14 @@ title: "Ethereum Token Holder API"
 description: "Rank Ethereum token holders with the Bitquery Holders cube: top holders, holder counts, dated snapshots, balance thresholds and distribution statistics."
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 # Token Holders API
 
 :::caution Deprecated API
 `EVM.TokenHolders` was deprecated as of **20 May 2026** and removed on **15 June 2026**. Use **`EVM.Holders`** (this page) instead.
+
+Holder rankings, snapshots and distribution stats are productized in the [Token Holder API](https://bitquery.io/products/token-holder-api) — see the page for chains, plans and trial access.
 :::
 
 The **Holders** API returns token holder data for ERC-20 tokens on Ethereum: top holders, holder counts, and balance thresholds. Non-zero balances use `Amount(selectWhere: { gt: "0" })` on the `Balance` field (not in `where`). Use `dataset: combined` or `dataset: archive` as follows:
@@ -19,6 +22,8 @@ The **Holders** API returns token holder data for ERC-20 tokens on Ethereum: top
 | **`archive`** | Addresses not recently active (not in the realtime window). |
 
 Examples: [Top Holders](#top-holders-of-a-currency-current) · [Holder Count](#token-holder-count-for-an-erc-20-token) · [Whales](#holder-count-with-balance-above-a-threshold) · [Historical Top Holders](#historical-top-holders-by-date) · [Holder Activity](#token-holder-activity) · [Statistics](#token-holder-statistics)
+
+<ProductCTA href="https://bitquery.io/products/token-holder-api" title="Token Holder API" />
 
 ## Top Holders of a Currency (Current)
 

--- a/docs/blockchain/Matic/matic-balance-api.md
+++ b/docs/blockchain/Matic/matic-balance-api.md
@@ -3,10 +3,15 @@ sidebar_position: 1
 title: "Polygon (MATIC) Address Balance API"
 description: "Query Polygon address balances with the Bitquery Balances cube: token and native POL balances, balances on a given date, and per-token lookups."
 ---
+
+import ProductCTA from "@site/src/components/ProductCTA";
+
 # Polygon (MATIC) Address Balance API
 
 :::caution Deprecated APIs
 On EVM, **`BalanceUpdates`** and **`TokenHolders`** were deprecated as of **20 May 2026** and removed on **15 June 2026**. Use **`EVM.Balances`** (this page) and **[Token Holders API](/docs/blockchain/Ethereum/token-holders/token-holder-api)** (`EVM.Holders`) instead.
+
+Balance lookups like these are productized in the [Address & Balance API](https://bitquery.io/products/address-apis) — native and token balances, labels and history on 9 core chains.
 :::
 
 The **Balances** API returns current and historical token balances for an address on Polygon (MATIC). To return only non-zero balances, add `Amount(selectWhere: { gt: "0" })` on the `Balance` field (not in `where`). Use `dataset: combined` or `dataset: archive` as follows:
@@ -17,6 +22,8 @@ The **Balances** API returns current and historical token balances for an addres
 | **`archive`**  | Historical snapshots with `Block.Date`, and balances for **addresses not recently active**. |
 
 Examples: [All Token Balances](#balance-of-an-address) · [Native MATIC](#native-matic-balance) · [Balance on a Date](#balance-on-a-specific-date) · [Specific Token](#balance-for-a-specific-token)
+
+<ProductCTA href="https://bitquery.io/products/address-apis" title="Address & Balance API" />
 
 ## Balance of an Address
 

--- a/docs/blockchain/Solana/DEXScreener/solana_dexscreener.mdx
+++ b/docs/blockchain/Solana/DEXScreener/solana_dexscreener.mdx
@@ -15,7 +15,11 @@ keywords:
 Everything you see on the DEXScreener Solana dashboard—live pairs, trades, prices, volumes, makers/buyers/sellers, and more—can be accessed via APIs/Streams with Bitquery.
 We expose the same on-chain data via GraphQL APIs, real-time WebSocket streams, and enterprise Kafka topics, with optional cloud connectors (AWS, GCP, Snowflake) for analytics pipelines.
 
+To build a DEXScreener-style app on managed infrastructure, start from the [Solana DEX API](https://bitquery.io/products/solana-dex-api) product page.
+
 Checkout our [DEXScreener EVM API documentation](/docs/blockchain/Ethereum/dextrades/DEXScreener/evm_dexscreener/) if you are interested in getting EVM chains(Ethereum, Binance Smart Chain(BSC), Arbitrum, Base, Matic, Optimism, etc) data which DEXScreener shows.
+
+<ProductCTA href="https://bitquery.io/products/solana-dex-api" title="Solana DEX API" />
 
 ## Bitquery Solana Data Access Options
 
@@ -34,6 +38,7 @@ Checkout our [DEXScreener EVM API documentation](/docs/blockchain/Ethereum/dextr
 This guide shows how to retrieve the same Solana DEX data that DEXScreener displays—real-time trades, pair stats, volumes, buyers/sellers, and more—using Bitquery APIs, streams, and Kafka.
 
 import VideoPlayer from "../../../../src/components/videoplayer.js";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 ## Get Trade Transactions of DEXScreener for a particular pair in realtime
 

--- a/docs/blockchain/Solana/Pumpfun/pump-fun-to-pump-swap.md
+++ b/docs/blockchain/Solana/Pumpfun/pump-fun-to-pump-swap.md
@@ -8,10 +8,15 @@ keywords:
   - PumpSwap migration tracking
   - Solana token migration API
 ---
+
+import ProductCTA from "@site/src/components/ProductCTA";
+
 # Understanding Pump.fun: From Launchpad to PumpSwap
 
 :::tip Need real-time Pump.fun & PumpSwap data or anything from the last ~30 days?
 For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trading-data-overview) — [`Trading.Trades`](/docs/trading/crypto-trades-api/trades-api) gives you clean, MEV-filtered Pump.fun & PumpSwap swaps with **USD price, market cap, and supply on every row** across **9 chains in one API**. Use this page when you need **historical Pump.fun & PumpSwap data older than ~30 days**, raw per-swap detail, or call / event context.
+
+Post-migration AMM activity is covered end-to-end by the [PumpSwap API](https://bitquery.io/products/pumpswap-api) — the product page lists swaps, pools and OHLCV coverage with plans.
 :::
 
 Pump.fun is a Solana-based memecoin launchpad that has reshaped how tokens are created and traded. At its core is a bonding curve model that lets anyone launch a token with a fixed supply of 1 billion tokens, of which around 800 million are made available for bonding.
@@ -30,6 +35,8 @@ This helps identify tokens nearing sell-out, a common signal for tokens “about
 Once a token reaches full bonding (100%), it automatically migrates to PumpSwap, Pump.fun’s native AMM DEX. From there, it trades like any other Solana token—no manual listing is needed; the system handles everything.
 
 To help developers, traders, and analysts follow this journey, Bitquery offers a comprehensive real-time API suite that spans the entire lifecycle of a Pump.fun token. Let’s walk through it:
+
+<ProductCTA href="https://bitquery.io/products/pumpswap-api" title="PumpSwap API" />
 
 ## Track New Token Creations in Real-Time
 

--- a/docs/blockchain/Solana/Solana-DexPools-API.md
+++ b/docs/blockchain/Solana/Solana-DexPools-API.md
@@ -4,14 +4,19 @@ title: "Solana DEX Pools API"
 description: "Query Solana liquidity pools with Bitquery GraphQL: pool updates in real time, tokens above a liquidity threshold, per-token pools and latest reserves."
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 # Solana DEX Pools API
 
 :::tip Need real-time Solana DEX pool data or anything from the last ~30 days?
 For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trading-data-overview) — [`Trading.Trades`](/docs/trading/crypto-trades-api/trades-api) gives you clean, MEV-filtered Solana DEX pool swaps with **USD price, market cap, and supply on every row** across **9 chains in one API**. Use this page when you need **historical Solana DEX pool data older than ~30 days**, raw per-swap detail, or call / event context.
+
+Pool and liquidity data ships with the [Solana DEX API](https://bitquery.io/products/solana-dex-api) — the product page covers venues, plans and real-time delivery.
 :::
 
 In this section we will see how to get Solana DEX Pools information using our API.
+
+<ProductCTA href="https://bitquery.io/products/solana-dex-api" title="Solana DEX API" />
 
 ## Get all Liquidity Pools updates on Solana
 

--- a/docs/blockchain/Solana/Solana-Lifinity-dex-api.mdx
+++ b/docs/blockchain/Solana/Solana-Lifinity-dex-api.mdx
@@ -6,6 +6,8 @@ description: "Query Lifinity on Solana with Bitquery GraphQL: real-time trades, 
 
 :::tip Need real-time Lifinity data or anything from the last ~30 days?
 For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trading-data-overview) — [`Trading.Trades`](/docs/trading/crypto-trades-api/trades-api) gives you clean, MEV-filtered Lifinity swaps with **USD price, market cap, and supply on every row** across **9 chains in one API**. Use this page when you need **historical Lifinity data older than ~30 days**, raw per-swap detail, or call / event context.
+
+Lifinity trades ship as part of the [Solana DEX API](https://bitquery.io/products/solana-dex-api) — one schema across all major Solana venues.
 :::
 
 :::note
@@ -13,6 +15,9 @@ For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trad
 :::
 
 import VideoPlayer from "../../../src/components/videoplayer.js";
+import ProductCTA from "@site/src/components/ProductCTA";
+
+<ProductCTA href="https://bitquery.io/products/solana-dex-api" title="Solana DEX API" />
 
 ## Lifinity Trades in Real-Time
 

--- a/docs/blockchain/Solana/Solana-OpenBook-api.mdx
+++ b/docs/blockchain/Solana/Solana-OpenBook-api.mdx
@@ -6,6 +6,8 @@ description: "Query OpenBook v2 on Solana with Bitquery GraphQL: real-time trade
 
 :::tip Need real-time OpenBook data or anything from the last ~30 days?
 For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trading-data-overview) — [`Trading.Trades`](/docs/trading/crypto-trades-api/trades-api) gives you clean, MEV-filtered OpenBook swaps with **USD price, market cap, and supply on every row** across **9 chains in one API**. Use this page when you need **historical OpenBook data older than ~30 days**, raw per-swap detail, or call / event context.
+
+OpenBook markets are covered by the [Solana DEX API](https://bitquery.io/products/solana-dex-api) alongside Raydium, Orca and Jupiter.
 :::
 
 :::note
@@ -13,6 +15,9 @@ For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trad
 :::
 
 import VideoPlayer from "../../../src/components/videoplayer.js";
+import ProductCTA from "@site/src/components/ProductCTA";
+
+<ProductCTA href="https://bitquery.io/products/solana-dex-api" title="Solana DEX API" />
 
 ## OpenBook Trades in Real-Time
 

--- a/docs/blockchain/Solana/Solana-Phoenix-api.md
+++ b/docs/blockchain/Solana/Solana-Phoenix-api.md
@@ -9,6 +9,8 @@ This page covers the Phoenix **spot** order book. For perpetual futures — orde
 positions, realized PnL, liquidations, funding, mark price and open interest — see the
 [**Phoenix Perpetuals API**](/docs/perpetuals/solana/phoenix-perpetuals-api), also
 available as a [Kafka protobuf stream](/docs/streams/protobuf/chains/Solana-perpetual-protobuf).
+
+Phoenix order-book data is available as a product — see the [Phoenix Trades API](https://bitquery.io/products/phoenix-trades) page for coverage and plans.
 :::
 
 :::tip Need real-time Phoenix data or anything from the last ~30 days?
@@ -16,6 +18,9 @@ For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trad
 :::
 
 import VideoPlayer from "../../../src/components/videoplayer.js";
+import ProductCTA from "@site/src/components/ProductCTA";
+
+<ProductCTA href="https://bitquery.io/products/phoenix-trades" title="Phoenix Trades API" />
 
 ## Phoenix Trades in Real-Time
 

--- a/docs/blockchain/Solana/Solana-Raydium-DEX-API.mdx
+++ b/docs/blockchain/Solana/Solana-Raydium-DEX-API.mdx
@@ -4,11 +4,14 @@ title: "Raydium DEX API - Solana Trades, Pools, OHLC"
 description: "Query Raydium on Solana with Bitquery GraphQL: new liquidity pools over WebSocket, pair creation times, historical pairs, token prices and OHLC candles."
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 # Raydium DEX API - Solana Trades, Pools, OHLC
 
 :::tip Need real-time Raydium data or anything from the last ~30 days?
 For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trading-data-overview) — [`Trading.Trades`](/docs/trading/crypto-trades-api/trades-api) gives you clean, MEV-filtered Raydium swaps with **USD price, market cap, and supply on every row** across **9 chains in one API**. Use this page when you need **historical Raydium data older than ~30 days**, raw per-swap detail, or call / event context.
+
+For an overview of what the [Raydium API](https://bitquery.io/products/raydium-api) covers — AMM, CLMM and CPMM trades, pools and OHLC — with plans and trial access, see the product page.
 :::
 
 In this section, we will see how to get Raydium information using Bitquery APIs.
@@ -20,6 +23,8 @@ For gRPC streaming of Raydium DEX trades: [Solana gRPC Streams (CoreCast) →](/
 :::
 
 import VideoPlayer from "../../../src/components/videoplayer.js";
+
+<ProductCTA href="https://bitquery.io/products/raydium-api" title="Raydium API" />
 
 ## New Liquidity Pools Created on Solana Raydium DEX (Using Websocket)
 

--- a/docs/blockchain/Solana/solana-dextrades.mdx
+++ b/docs/blockchain/Solana/solana-dextrades.mdx
@@ -4,11 +4,14 @@ title: "Solana DEX Trades API"
 description: "Stream Solana DEX swaps, prices, and OHLC for Raydium, Jupiter, and more using Bitquery GraphQL queries and live streams."
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 # Solana DEX Trades API
 
 :::tip Need real-time Solana DEX data or anything from the last ~30 days?
 For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trading-data-overview) — [`Trading.Trades`](/docs/trading/crypto-trades-api/trades-api) gives you clean, MEV-filtered swaps with **USD price, market cap, and supply on every row** across **9 chains in one API** (filter with `Pair.Market.Network: Solana`). Use this page when you need **historical Solana data older than ~30 days** (with `dataset: archive`), raw per-swap detail, or call / event context.
+
+Everything on this page is part of the [Solana DEX API](https://bitquery.io/products/solana-dex-api) — the product page summarizes venues, OHLCV, pools and streaming latency.
 
 :::caution `dataset: combined` currently fails on Solana
 Every `Solana(dataset: combined)` query tested returns a ClickHouse 500 on the `/graphql` endpoint. Use `dataset: archive` for history and realtime for recent data. Several queries further down this page still use `combined` and will error until that is resolved — swap `combined` for `archive` to run them. See [data coverage & retention](/docs/graphql/data-coverage-retention/).
@@ -29,6 +32,8 @@ If you have questions or need custom data, reach out to [support](https://t.me/B
 Need zero-latency Solana DEX trade data?  
 [Read about our Shred Streams and contact us for a trial ➤](/docs/streams/real-time-solana-data/)  
 For gRPC streaming: [Solana gRPC Streams (CoreCast) →](/docs/grpc/solana/introduction/)
+
+<ProductCTA href="https://bitquery.io/products/solana-dex-api" title="Solana DEX API" />
 
 ## 🔗 Related Solana APIs
 

--- a/docs/blockchain/Solana/solana-orca-dex-api.mdx
+++ b/docs/blockchain/Solana/solana-orca-dex-api.mdx
@@ -4,11 +4,14 @@ title: "Orca DEX API — Solana Liquidity Pools & Trades"
 description: "Solana Orca DEX API: query and stream Solana on-chain data with Bitquery GraphQL examples for developers. Works with WebSocket live subscriptions."
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 # Orca DEX API
 
 :::tip Need real-time Orca data or anything from the last ~30 days?
 For **real-time + last ~30 days**, use the [**Trading cube**](/docs/trading/trading-data-overview) — [`Trading.Trades`](/docs/trading/crypto-trades-api/trades-api) gives you clean, MEV-filtered Orca swaps with **USD price, market cap, and supply on every row** across **9 chains in one API**. Use this page when you need **historical Orca data older than ~30 days**, raw per-swap detail, or call / event context.
+
+Orca is one of the venues covered by our [Solana DEX API](https://bitquery.io/products/solana-dex-api), which unifies Raydium, Orca, Meteora, Pump.fun and Jupiter trades in one schema.
 :::
 
 In this section, we'll show you how to access information about Orca DEX data using Bitquery APIs.
@@ -18,6 +21,8 @@ In this section, we'll show you how to access information about Orca DEX data us
 :::
 
 import VideoPlayer from "../../../src/components/videoplayer.js";
+
+<ProductCTA href="https://bitquery.io/products/solana-dex-api" title="Solana DEX API" />
 
 ## Latest Pools Created On Orca
 

--- a/docs/blockchain/Solana/solana-photon-api.md
+++ b/docs/blockchain/Solana/solana-photon-api.md
@@ -4,11 +4,14 @@ title: "Solana Photon API"
 description: "Track Photon-routed Solana trades with Bitquery GraphQL: latest trades by pair, trader-level rows with USD price, market cap and supply, plus live streams."
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 # Photon Solana API
 
 :::tip Need real-time Photon-style trader data or anything from the last ~30 days?
 For **real-time trader and wallet data over the last ~30 days** across **9 chains in one API**, use the [**Trading cube**](/docs/trading/trading-data-overview) — [`Trading.Trades`](/docs/trading/crypto-trades-api/trades-api) gives you clean, MEV-filtered swaps with **`Trader.Address`** as a first-class filter plus **USD price, market cap, and supply on every row**. Use this page when you need **historical Photon-style trader data older than ~30 days**, raw per-swap detail, or call / event context.
+
+The queries below run on the same data that powers Photon-style terminals — the [Solana DEX API](https://bitquery.io/products/solana-dex-api) page covers venues, latency and plans.
 :::
 
 Photon is a routing aggregator on Solana that finds the best execution paths across multiple DEXs. To identify trades that were routed through Photon, we use their program address `BSfD6SHZigAfDWSjzD5Q41jw8LmKwtmjskPH9XW1mrRW` in our queries.
@@ -18,6 +21,8 @@ This program address appears in the instruction data when Photon routes a trade,
 :::note
 `Trade Side Account` field will not be available for aggregate queries in Archive and Combined Datasets
 :::
+
+<ProductCTA href="https://bitquery.io/products/solana-dex-api" title="Solana DEX API" />
 
 ## Latest Trades Routed via Photon
 

--- a/docs/blockchain/Solana/token-supply-cube.mdx
+++ b/docs/blockchain/Solana/token-supply-cube.mdx
@@ -6,8 +6,13 @@ description: "Track Solana token supply with Bitquery GraphQL: subscribe to supp
 # Solana Token Supply API
 
 import VideoPlayer from "../../../src/components/videoplayer.js";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 In this section we will see how to get Solana Token Supply information using our API.
+
+Supply metrics are part of the broader [Token API](https://bitquery.io/products/digital-assets) — transfers, supply and new token creation across chains.
+
+<ProductCTA href="https://bitquery.io/products/digital-assets" title="Token API" />
 
 ## Overview
 

--- a/docs/blockchain/Tron/sunswap-api.md
+++ b/docs/blockchain/Tron/sunswap-api.md
@@ -2,13 +2,20 @@
 title: "Tron Sunswap API"
 description: "Query SunSwap on Tron with Bitquery GraphQL: latest trades, per-token trade history, and new Sunpump tokens plus sell events from the Tron mempool."
 ---
+
+import ProductCTA from "@site/src/components/ProductCTA";
+
 # Tron SunSwap API
 
 **[Bitquery](https://bitquery.io)** provides useful tron activity through **GraphQL** (on-demand queries and live **subscriptions**), and high-throughput Kafks streams for enterprise teams.
 
 This page documents **SunSwap**-related examples on **Tron**—events, contracts, and streams you can copy into the IDE. For general Tron DEX trade patterns, see the [Tron DEX Trades API](/docs/blockchain/Tron/tron-dextrades). If you are new here, start with [Your first query](/docs/start/first-query).
 
+SunSwap trades are part of our full [Tron blockchain API](https://bitquery.io/blockchains/tron-blockchain-api) — see the page for USDT transfers, balances and streaming coverage.
+
 If you want fastest data without any latency, we can provide Kafka streams, please [fill this form](https://bitquery.io/forms/api) for it. Our Team will reach out.
+
+<ProductCTA href="https://bitquery.io/blockchains/tron-blockchain-api" title="Tron blockchain API" />
 
 ## New Tokens on Sunpump and Sell event in Tron Mempool
 

--- a/docs/examples/polymarket-api/polymarket-api.md
+++ b/docs/examples/polymarket-api/polymarket-api.md
@@ -25,10 +25,13 @@ keywords:
   - oracle resolution API
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 # Polymarket API Guide - Data & Query Reference
 
 The Bitquery Polymarket API provides prediction market data on Polygon via GraphQL. Use **`dataset: realtime`** on `EVM` queries for **`PredictionTrades`**, **`PredictionSettlements`**, and related prediction-market APIs—this dataset retains roughly the **last 7 days**. Use it to query trades, settlements, market metadata, and volume; filter by condition_id, outcome token, or trade size; and access data via REST, WebSocket subscriptions, or Kafka streams. Filter by Polymarket using `ProtocolName: "polymarket"` or `Marketplace.ProtocolName` in your queries.
+
+If you are evaluating data providers, the [Polymarket API product page](https://bitquery.io/products/polymarket-api) summarizes market, trade and position coverage with plans and real-time delivery options.
 
 :::note API Key Required
 To query or stream data outside the Bitquery IDE, you need an API access token.
@@ -41,6 +44,8 @@ Polymarket prediction-market data on Polygon requires **`dataset: realtime`** (~
 :::
 
 ---
+
+<ProductCTA href="https://bitquery.io/products/polymarket-api" title="Polymarket API" />
 
 ## What Polymarket data can I get with Bitquery?
 

--- a/docs/stablecoin-APIs/usdt-api.md
+++ b/docs/stablecoin-APIs/usdt-api.md
@@ -16,11 +16,18 @@ keywords:
     "Bitquery API",
   ]
 ---
+
+import ProductCTA from "@site/src/components/ProductCTA";
+
 # USDT API
 
 USDT (Tether) powers a large share of on-chain value transfer, payments, and trading across multiple blockchains. This page curates the most useful USDT APIs—covering price, payments (transfers), trades, reserves, and balances—along with live streams you can use in production.
 
+Most USDT volume lives on Tron — the [Tron USDT API](https://bitquery.io/blockchains/tron-blockchain-api) page covers tracing and streaming every TRC-20 transfer.
+
 Use the sections below to discover key USDT datasets, with both API and streaming options. Links point to runnable examples, and code blocks are provided as placeholders for your queries.
+
+<ProductCTA href="https://bitquery.io/blockchains/tron-blockchain-api" title="Tron USDT API" />
 
 ## USDT Price API
 

--- a/docs/subscriptions/google-bigquery/bigquery.md
+++ b/docs/subscriptions/google-bigquery/bigquery.md
@@ -2,9 +2,14 @@
 title: "Filing Data into Google BigQuery"
 description: "Filing Data into Google BigQuery using Bitquery GraphQL subscriptions over WebSocket for live multi-chain blockchain monitoring."
 ---
+
+import ProductCTA from "@site/src/components/ProductCTA";
+
 # Filing Data into Google BigQuery
 
 In this part, we'll demonstrate how to set up Google BigQuery to store data from Google Pub/Sub. The incoming data will be stored in a BigQuery table called `newtrades`. We'll go step-by-step, covering table creation, schema definition, and configuring Pub/Sub to write directly to BigQuery.
+
+For managed datasets in BigQuery and Snowflake, see the [Blockchain Data Warehouse](https://bitquery.io/products/data-warehouse) product page.
 
 ### 1. Create a Table and Define the Schema
 
@@ -113,3 +118,6 @@ python bitquery_pubsub.py
 - Use SQL queries to analyze trends in the trade data.
 - Automate data pipelines using Google Cloud Dataflow or scheduled BigQuery queries.
 
+
+
+<ProductCTA href="https://bitquery.io/products/data-warehouse" title="Blockchain Data Warehouse" />

--- a/docs/trading/crypto-price-api/introduction.mdx
+++ b/docs/trading/crypto-price-api/introduction.mdx
@@ -28,11 +28,14 @@ keywords:
   - "low latency price feed"
 ---
 import FAQ from "@site/src/components/FAQ";
+import ProductCTA from "@site/src/components/ProductCTA";
 
 # Crypto Price API – Real-Time Token Data, Charts & OHLC
 
 :::tip Real-time + last ~30 days only
 The Crypto Price API cubes (`Trading.Tokens`, `Trading.Currencies`, `Trading.Pairs`) are part of the **Trading cube** family — built for **real-time and the last ~30 days**. For OHLC built from raw trades **older than ~30 days**, use chain-level [`DEXTradeByTokens`](/docs/cubes/dextradesbyTokens) instead. See the [**Trading Data Overview**](/docs/trading/trading-data-overview) for the side-by-side comparison.
+
+For a product-level overview — supported chains, OHLCV, USD pricing and plans — see the [Crypto Price API](https://bitquery.io/products/crypto-price-api) page.
 :::
 
 Bitquery provides **Crypto Price APIs and Streams** via GraphQL and [Kafka](https://github.com/bitquery/streaming_protobuf/blob/feature/trading/market/price_index.proto). This **cryptocurrency price API** delivers comprehensive pricing data across multiple blockchains.
@@ -43,6 +46,8 @@ The Crypto Price API provides more than just pair prices, it also includes [OHLC
 While you can access the aggregated price for a single trading pair, the Price Index also supports cross-chain and cross-DEX aggregation, giving you a unified view of token prices across multiple ecosystems.
 
 **OHLC & K-lines:** Use this **Crypto Price API** as the **primary** source. For **historical** OHLC (long backfills, archive data, or trade-built candles), use **`DEXTradeByTokens`** (see [OHLC guide — when to use DEX](/docs/trading/crypto-price-api/crypto-ohlc-candle-k-line-api/#crypto-price-api-vs-dextradebytoken)).
+
+<ProductCTA href="https://bitquery.io/products/crypto-price-api" title="Crypto Price API" />
 
 ## Key Features of These APIs
 

--- a/docs/usecases/base-sniper-bot.mdx
+++ b/docs/usecases/base-sniper-bot.mdx
@@ -6,9 +6,14 @@ description: "Build Base Sniper Bot: a practical Bitquery tutorial with GraphQL 
 
 This tutorial will guide you through building a Base sniper bot using Bitquery Events API and the Uniswap SDK for executing swaps.
 
+Sniping depends on seeing transactions before they confirm — the [Mempool API](https://bitquery.io/products/mempool-api) page covers pending transactions and MEV data feeds.
+
 > Note: This material is for educational and informational purposes only and is not intended as investment advice. The content reflects the author's personal research and understanding. While specific investments and strategies are mentioned, no endorsement or association with these entities is implied. Readers should conduct their own research and consult with qualified professionals before making any investment decisions. Bitquery is not liable for any losses or damages resulting from the application of this information.
 
 import VideoPlayer from "../../src/components/videoplayer.js";
+import ProductCTA from "@site/src/components/ProductCTA";
+
+<ProductCTA href="https://bitquery.io/products/mempool-api" title="Mempool API" />
 
 ## Tutorial Video
 

--- a/docs/usecases/nft-analytics.md
+++ b/docs/usecases/nft-analytics.md
@@ -3,10 +3,17 @@ sidebar_position: 3
 title: "NFT Analytics Dashboard - Tutorial"
 description: "Build NFT Analytics Dashboard - Tutorial: a practical Bitquery tutorial with GraphQL examples, streams, and runnable application code."
 ---
+
+import ProductCTA from "@site/src/components/ProductCTA";
+
 # NFT Analytics Dashboard - Tutorial
 
  ### Marketplace Analysis
  Bitquery's queries can help NFT marketplace builders analyze the performance of different NFTs on various blockchain networks. By providing real-time data on  transaction volume, and other key metrics, Bitquery can help builders optimize their marketplace's offerings and improve trading conditions for users.
+
+Everything used here comes from the [NFT API](https://bitquery.io/products/nft-api) — trades, metadata, holders and floor prices across 40+ chains.
+
+<ProductCTA href="https://bitquery.io/products/nft-api" title="NFT API" />
 
 ## Tutorial 
 This is a tutorial to build a NFT Dashboard using Python code that connects to the Bitquery API and retrieves data for a particular NFT on the Ethereum network. The code then displays the data on a user-friendly interface built using Python and Streamlit.

--- a/docs/usecases/tradingview-subscription-realtime/getting-started.md
+++ b/docs/usecases/tradingview-subscription-realtime/getting-started.md
@@ -17,9 +17,14 @@ keywords:
     real-time price feed,
   ]
 ---
+
+import ProductCTA from "@site/src/components/ProductCTA";
+
 # TradingView API - Real-Time Crypto OHLC Stream
 
 This guide is the **entry point** for the tutorial: how to embed [TradingView Advanced Charts](https://in.tradingview.com/advanced-charts/) in a React app and drive the chart with **Bitquery**—historical OHLC over HTTPS and **live** OHLC over a GraphQL WebSocket subscription.
+
+If you want this without building the datafeed yourself, the [TradingView DEX charts](https://bitquery.io/products/tradingview-dex) page covers our ready UDF datafeed for any token.
 
 **Complete reference implementation:** [github.com/bitquery/tradingview-subscription-realtime](https://github.com/bitquery/tradingview-subscription-realtime/tree/main)
 
@@ -28,6 +33,8 @@ This guide is the **entry point** for the tutorial: how to embed [TradingView Ad
 The chart loads history first, then extends the last candle as new OHLC arrives:
 
 <video controls loop muted playsInline width="100%" src="/img/ApplicationExamples/charting.mp4"></video>
+
+<ProductCTA href="https://bitquery.io/products/tradingview-dex" title="TradingView DEX charts" />
 
 ## If this is your first time here
 

--- a/src/components/ProductCTA.module.css
+++ b/src/components/ProductCTA.module.css
@@ -1,0 +1,25 @@
+.cta {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 1rem 0 1.25rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-left: 3px solid var(--ifm-color-primary);
+  border-radius: 6px;
+  background: var(--ifm-background-surface-color);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.badge {
+  flex: none;
+  padding: 0.05rem 0.45rem;
+  border-radius: 999px;
+  background: var(--ifm-color-primary-lightest);
+  color: var(--ifm-color-primary-darkest);
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}

--- a/src/components/ProductCTA.tsx
+++ b/src/components/ProductCTA.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import styles from "./ProductCTA.module.css";
+
+type ProductCTAProps = {
+  /** Absolute URL of the bitquery.io product or chain page. */
+  href: string;
+  /** Anchor text — the product page's name, e.g. "Solana DEX API". */
+  title: string;
+  /** Short trailing note. Defaults to plans/trial phrasing. */
+  note?: string;
+};
+
+export default function ProductCTA({
+  href,
+  title,
+  note = "plans, free trial and enterprise delivery options",
+}: ProductCTAProps) {
+  return (
+    <p className={styles.cta}>
+      <span className={styles.badge}>Product</span>
+      Using this in production? See the <a href={href}>{title}</a> page for {note}.
+    </p>
+  );
+}


### PR DESCRIPTION
## What

27 docs pages that hold organic rankings (`uniswap api` #1, `pancakeswap api` #2, the Polymarket cluster, Raydium/Orca/Photon/DEXScreener/OpenBook/Lifinity/DexPools, TradingView getting-started, token-holder, USDT, SunSwap, GMX, Base DEXTrades, crypto-price intro, NFT analytics, internal transactions, Matic balances, Base sniper bot, Phoenix, token supply, BigQuery) now each carry:

1. one contextual anchor in the intro, hand-written per page, and
2. one `<ProductCTA>` callout — a quiet one-line box before the first H2 — linking to the matching bitquery.io product or chain page.

## Why

The marketing site sends docs 1,083 internal links; docs sends almost none back. The pages where docs wins SERPs (per Ahrefs) handed no authority or traffic to any page that can convert. This closes the loop on exactly the pages where it matters, with explicit editorial placement — no theme swizzle, no sitewide injection.

## Verification

- `docusaurus build` green — all 1,065 pages compile
- Fence-parity audit: every inserted import/sentence/CTA sits outside code fences (one insertion initially landed inside a ```python block on nft-analytics.md — caught and fixed)
- Component uses Infima theme tokens only; rendering verified in light and dark on the served build
- No page titles, H1s, or existing content modified — two added lines per page

🤖 Generated with [Claude Code](https://claude.com/claude-code)