### PR TITLE
docs: steer single-token prices to Pairs cube with rank-1 filter

### DIFF
--- a/docs/trading/crypto-price-api/crypto-ohlc-candle-k-line-api.md
+++ b/docs/trading/crypto-price-api/crypto-ohlc-candle-k-line-api.md
@@ -20,11 +20,12 @@ Get real-time and historical OHLC (Open, High, Low, Close) candle data, K-line c
 | How do I get OHLCV data for a token using Bitquery? | **Last 7 Days** [Crypto Price API](/docs/trading/crypto-price-api/introduction/) ; **historical:** [DEXTradeByTokens OHLC](/docs/cubes/dextradesbyTokens/#how-do-i-get-ohlc-in-a-dextradebytokens-query) |
 | How do I get OHLC in a DEXTradeByTokens query? | [DEXTradeByTokens OHLC](/docs/cubes/dextradesbyTokens/#how-do-i-get-ohlc-in-a-dextradebytokens-query) (for **historical** OHLC or DEX-level control) |
 | How do I get historical OHLCV for a Solana token? | **Main OHLC:** [Crypto Price API — Quick start](/docs/trading/crypto-price-api/introduction/#quick-start) · [Tokens cube](/docs/trading/crypto-price-api/tokens/) · **Historical / DEX:** [Historical OHLCV on Solana](/docs/blockchain/Solana/solana-dextrades/#how-do-i-get-historical-ohlcv-for-a-solana-token) · [Solana OHLC API](/docs/blockchain/Solana/solana-dextrades/#solana-ohlc-api) |
-| How do I get the current price of a token using Bitquery API? | [Quick start](/docs/trading/crypto-price-api/introduction/#quick-start) · [Tokens cube](/docs/trading/crypto-price-api/tokens/) · [Examples](/docs/trading/crypto-price-api/examples/) |
+| How do I get the current price of a token using Bitquery API? | **Recommended:** [Pairs + rank 1 (top market)](/docs/trading/crypto-price-api/pairs#most-accurate-token-price) · [Quick start](/docs/trading/crypto-price-api/introduction/#quick-start) · [Examples](/docs/trading/crypto-price-api/examples/) |
+| Which cube gives the most accurate price for one token? | [Pairs with `Ranking: { Position: { eq: 1 } }`](/docs/trading/crypto-price-api/pairs#most-accurate-token-price) — prices from the token's top market rather than a blend across all its pools |
 | How do I get price change percentage for a token? | [Price change](/docs/start/starter-queries/#volume-of-multiple-tokens-across-different-chains) |
 | How do I get 1-minute OHLC candles for a DEX pair? | **Main:** [Your first OHLC query](#your-first-ohlc-query) (`Duration: { eq: 60 }`) · [Pairs cube](/docs/trading/crypto-price-api/pairs/) · **Historical:** [DEX OHLC pattern](/docs/cubes/dextradesbyTokens/#how-do-i-get-ohlc-in-a-dextradebytokens-query) |
 | How do I get the all-time high (ATH) price of a token? | [Solana ATH example](/docs/blockchain/Solana/solana-dextrades/#get-ath-market-cap-of-tokens)|
-| Is there an API to get token price in USD on Solana? | [Crypto Price API — Quick start](/docs/trading/crypto-price-api/introduction/#quick-start) · [Tokens cube](/docs/trading/crypto-price-api/tokens/) · [Latest USD (Solana DEX trades)](/docs/blockchain/Solana/solana-dextrades/#latest-usd-price-of-a-token) |
+| Is there an API to get token price in USD on Solana? | [Pairs + rank 1 (top market)](/docs/trading/crypto-price-api/pairs#most-accurate-token-price) · [Crypto Price API — Quick start](/docs/trading/crypto-price-api/introduction/#quick-start) · [Latest USD (Solana DEX trades)](/docs/blockchain/Solana/solana-dextrades/#latest-usd-price-of-a-token) |
 | How do I use DEXTradeByTokens vs DEXTrades for OHLCV? | [OHLCV: which cube?](/docs/cubes/dextradesbyTokens/#how-do-i-use-dextradebytokens-vs-dextrades-for-ohlcv) · [DEXTrades cube](/docs/cubes/dextrades/) |
 
 ## What is OHLC Data?
@@ -202,9 +203,9 @@ Use the **Currency** cube when you want a unified price view of an asset across 
 
 [Learn more about Currency Cube ➤](/docs/trading/crypto-price-api/currency/)
 
-### **Tokens Cube** - Chain-Specific Token Data
+### **Tokens Cube** - Chain-Wide Blended Candles
 
-Use the **Tokens** cube when you need OHLC data for a specific token on a specific blockchain.
+Use the **Tokens** cube when you want one candle per token per chain, or a stream of candles for every token on a chain.
 
 **Key Features:**
 - Aggregates across all pairs for that token
@@ -212,13 +213,16 @@ Use the **Tokens** cube when you need OHLC data for a specific token on a specif
 - Can provide only USD-quoted prices
 - Can combine volume and price data from all chains
 
+> Because the candle blends every pool where the token is base, thin pools contribute to it as well. For candles on **one specific token**, prefer the Pairs cube with rank 1 (below).
+
 [Learn more about Tokens Cube ➤](/docs/trading/crypto-price-api/tokens/)
 
-### **Pairs Cube** - Trading Pair Specific Data
+### **Pairs Cube** - Top Market and Pair-Specific Candles
 
-Use the **Pairs** cube when you need OHLC data for specific trading pairs on specific DEXs.
+Use the **Pairs** cube for OHLC on a specific market — and, with the rank filter, for the most accurate candles on a specific **token**.
 
 **Key Features:**
+- **Recommended for a single token:** add `Ranking: { Position: { eq: 1 } }` to get candles from the token's top market instead of a blend across all pools ([how and why](/docs/trading/crypto-price-api/pairs#most-accurate-token-price))
 - Pair-specific OHLC data (e.g., ETH/USDC on Uniswap)
 - Can be quoted in USD or quote token
 - Market/DEX-specific data

--- a/docs/trading/crypto-price-api/currency.md
+++ b/docs/trading/crypto-price-api/currency.md
@@ -6,6 +6,10 @@ description: "Query currency-level crypto prices and conversions with Bitquery T
 
 The Currency Cube provides a unified, chain-agnostic price for an asset in USD, such as Bitcoin by aggregating prices and volumes from all its representations (e.g., WBTC, cbBTC, and other bridged or wrapped forms) across all supported chains. This multi-chain cryptocurrency price data approach ensures consistent pricing across different blockchain implementations.
 
+:::note Use this for cross-chain assets, not for a single token
+Currency prices aggregate **across chains and token representations**, so use this cube when you want one global number for an asset like BTC or ETH. For the price of a **specific token on a specific market**, use the [Pairs cube with `Ranking: { Position: { eq: 1 } }`](/docs/trading/crypto-price-api/pairs#most-accurate-token-price). Note that `Ranking` is **not** available on `Currencies` — it exists on `Trades`, `Pairs`, and `Tokens` only.
+:::
+
 ### How OHLC is Calculated
 
 The OHLC values (Open, High, Low, Close) are determined across all chains and token representations of an asset for the selected interval (e.g., 60 seconds):

--- a/docs/trading/crypto-price-api/examples.md
+++ b/docs/trading/crypto-price-api/examples.md
@@ -4,6 +4,67 @@ description: "Quick Start Examples via Bitquery Trading APIs for multi-chain pri
 ---
 # Quick Start Examples
 
+## Most Accurate Price for a Token (Top Market, Rank 1) {#most-accurate-price-for-a-token}
+
+The recommended way to price a **specific token**: query the `Pairs` cube with `Ranking: { Position: { eq: 1 } }` to get the price from the token's **top market** — the pool currently carrying the most volume for it — instead of a value blended across every pool it trades in. Thin, fragmented pools therefore cannot pull the number away from the market where the token actually trades.
+
+Full explanation, streaming variant, and caveats: [Getting the Most Accurate Token Price](/docs/trading/crypto-price-api/pairs#most-accurate-token-price).
+
+```graphql
+{
+  Trading {
+    Pairs(
+      where: {
+        Token: {
+          Address: { is: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263" }
+          Network: { is: "Solana" }
+        }
+        Ranking: { Position: { eq: 1 } }
+        Interval: { Time: { Duration: { eq: 60 } } }
+      }
+      limit: { count: 1 }
+      orderBy: { descending: Block_Time }
+    ) {
+      Token {
+        Symbol
+        Address
+      }
+      QuoteToken {
+        Symbol
+      }
+      Market {
+        Protocol
+        Address
+        Network
+      }
+      Price {
+        IsQuotedInUsd
+        Ohlc {
+          Open
+          High
+          Low
+          Close
+        }
+      }
+      Ranking {
+        Position
+        Weight
+      }
+      Volume {
+        Usd
+      }
+      Block {
+        Time
+      }
+    }
+  }
+}
+```
+
+`Price.Ohlc.Close` is the latest price on the top market, in USD (`IsQuotedInUsd: true`) even when the quote token is WSOL or another non-stable asset. `Ranking.Weight` tells you how concentrated the token's liquidity is: near 1 means a single pool drives the price; a low value means it is fragmented across many pools — the case where this query differs most from the blended `Tokens` price.
+
+Change `query` to `subscription` and drop `limit`/`orderBy` to stream it live.
+
 ## Real-Time Token Prices in USD on Solana
 
 Stream live OHLC (Open, High, Low, Close) price and volume data for all tokens on Solana, quoted directly in USD. Useful for dashboards, analytics, or bots that need stable fiat-based prices.
@@ -215,6 +276,8 @@ subscription {
 ## Aggregated Token Data (Volume & Price, Last 24h)
 
 Get a snapshot of tokens with aggregated USD volume and average price over the last 24 hours. The query uses `limitBy: { count: 1, by: Token_Id }` to return one row per token, and conditional metrics (`Volume.Usd(if: ...)`, `Price.Average.Mean(..., if: ...)`) to show volume and price for the last 1h, 4h, and 24h. Useful for dashboards, top-movers lists, or comparing short-term vs daily metrics.
+
+> The `Tokens` cube is the right choice here: volume is summed across all of a token's pools. Note that its prices are blended across those pools too — to price one specific token from its top market instead, use [Pairs with rank 1](/docs/trading/crypto-price-api/pairs#most-accurate-token-price).
 
 [Run query ➤](https://ide.bitquery.io/aggregated-data-for-tokens)
 
@@ -559,6 +622,8 @@ query {
 
 Fetch the top 10 tokens by 5-minute percentage price change (USD-based), only including tokens with at least $100k trading volume. Ideal for building a "top movers" list.
 
+> Scanning every token on a chain is exactly what the `Tokens` cube is for. Once you have picked a token out of the list, price it from its top market with [Pairs + rank 1](/docs/trading/crypto-price-api/pairs#most-accurate-token-price).
+
 Here we have selected the filter `Price: {IsQuotedInUsd: true}`, this means that any price values such as OHLC or Average indicators will be in USD. If you want them in quote currency, change the filter to `Price: {IsQuotedInUsd: false}`.
 
 This stream uses [expressions](/docs/graphql/capabilities/expression/)
@@ -641,6 +706,8 @@ This stream uses [expressions](/docs/graphql/capabilities/expression/)
 
 Stream the top 10 tokens on Solana by 5-minute price change (in USD), filtered by $100k+ volume. Updates continuously.
 
+> As above, this is a chain-wide scan. For a watchlist of specific tokens, stream their top markets instead — see [Watchlist: top-market price for several tokens](/docs/trading/crypto-price-api/pairs#most-accurate-token-price).
+
 Here we have selected the filter `Price: {IsQuotedInUsd: true}`, this means that any price values such as OHLC or Average indicators will be in USD. If you want them in quote currency, change the filter to `Price: {IsQuotedInUsd: false}`.
 
 This stream uses [expressions](/docs/graphql/capabilities/expression/)
@@ -722,6 +789,8 @@ subscription{
 Calculate the percentage drawdown (price decline) for tokens of a specific currency (e.g., Bitcoin) over a 1-hour interval.
 
 This query uses [expressions](/docs/graphql/capabilities/expression/) to calculate drawdown as: `((Close - Open) / Open) * 100`.
+
+> This compares a currency's token representations against each other, so `Tokens` fits. To measure one token's drawdown on the market where it actually trades, run the same expression against [Pairs with rank 1](/docs/trading/crypto-price-api/pairs#most-accurate-token-price).
 
 > **Note:** You can use `Token: {Address: {is: "token_address"}}` filter instead of `Currency: {Id: {is: "bid:bitcoin"}}` to filter by token address. We include `Volume: { Usd: { gt: 10 } }` to filter out tokens with very low trading volume.
 

--- a/docs/trading/crypto-price-api/examples.md
+++ b/docs/trading/crypto-price-api/examples.md
@@ -21,6 +21,7 @@ Full explanation, streaming variant, and caveats: [Getting the Most Accurate Tok
         }
         Ranking: { Position: { eq: 1 } }
         Interval: { Time: { Duration: { eq: 60 } } }
+        Price: { IsQuotedInUsd: true }
       }
       limit: { count: 1 }
       orderBy: { descending: Block_Time }
@@ -61,7 +62,9 @@ Full explanation, streaming variant, and caveats: [Getting the Most Accurate Tok
 }
 ```
 
-`Price.Ohlc.Close` is the latest price on the top market, in USD (`IsQuotedInUsd: true`) even when the quote token is WSOL or another non-stable asset. `Ranking.Weight` tells you how concentrated the token's liquidity is: near 1 means a single pool drives the price; a low value means it is fragmented across many pools — the case where this query differs most from the blended `Tokens` price.
+`Price.Ohlc.Close` is the latest price on the top market. Keep `Price: { IsQuotedInUsd: true }` in the filter — every market also publishes rows priced in **quote token units**, so without it a WBTC/WSOL market would return the price of WBTC in SOL rather than in dollars.
+
+`Ranking.Weight` tells you how concentrated the token's liquidity is: near 1 means a single pool drives the price; a low value means it is fragmented across many pools — the case where this query differs most from the blended `Tokens` price.
 
 Change `query` to `subscription` and drop `limit`/`orderBy` to stream it live.
 

--- a/docs/trading/crypto-price-api/examples.md
+++ b/docs/trading/crypto-price-api/examples.md
@@ -10,6 +10,8 @@ The recommended way to price a **specific token**: query the `Pairs` cube with `
 
 Full explanation, streaming variant, and caveats: [Getting the Most Accurate Token Price](/docs/trading/crypto-price-api/pairs#most-accurate-token-price).
 
+[Run query ➤](https://ide.bitquery.io/Token-price-from-top-market--rank-1_2)
+
 ```graphql
 {
   Trading {

--- a/docs/trading/crypto-price-api/introduction.mdx
+++ b/docs/trading/crypto-price-api/introduction.mdx
@@ -97,6 +97,10 @@ Use the same **`bid:<chain>`** convention as **`Token.Id`**.
 
 ## Quick Start {#quick-start}
 
+:::tip Pricing one specific token? Start with Pairs + rank 1
+The stream below is a **firehose** of every token on every chain, and the `Tokens` cube is the right choice for it. If instead you want the price of **one token**, query the [**Pairs** cube with `Ranking: { Position: { eq: 1 } }`](/docs/trading/crypto-price-api/pairs#most-accurate-token-price) — it returns the price from the token's **top market** rather than a blend across all of its pools, which matters for tokens with fragmented liquidity.
+:::
+
 [Run Stream >](https://ide.bitquery.io/1-second-crypto-price-stream)
 
 > Note: A `Volume: {Usd: {gt: 5}}` filter is applied to remove extreme outliers; the price stream already pre-filters outliers—this is an additional check.
@@ -247,9 +251,9 @@ Each message contains:
 
 The Price APIs have three core data cubes:
 
-- **Tokens**: Price data for a specific token on a specific chain. Use this when you care about chain-specific prices like USDT on Solana.
+- **Tokens**: One blended price per token per chain, aggregated across every pool the token trades in. Use it for chain-wide streams and per-chain aggregates.
 - **Currencies**: An aggregated view of tokens that represent the same underlying asset. For example, tokens like cbBTC, WBTC, and other Bitcoin-wrapped tokens are all grouped under the Bitcoin currency.
-- **Pairs**: Price and volume data for token pairs on specific markets/protocols. E.g., SOL/USDC on Raydium (Solana) or ETH/USDT on Uniswap (Ethereum).
+- **Pairs**: Price and volume data for token pairs on specific markets/protocols. E.g., SOL/USDC on Raydium (Solana) or ETH/USDT on Uniswap (Ethereum). **This is also the recommended cube for a specific token's price** — filter to its top market with [`Ranking: { Position: { eq: 1 } }`](/docs/trading/crypto-price-api/pairs#most-accurate-token-price).
 
 > Note: Expressions are supported in this API.
 
@@ -325,6 +329,8 @@ It takes amounts and prices from all chains that use BTC and wrapped versions (i
 ### Tokens
 
 Let's say you don't want a chain agnostic view, but want to focus on a particular chain. How to stream or query prices for it? This is where tokens come in.
+
+> **Note:** the price below is blended across **all pools** where the token is base. For a single token, the [rank-1 Pairs query](/docs/trading/crypto-price-api/pairs#most-accurate-token-price) prices it from its top market instead — recommended whenever you care about one specific token.
 
 > Note: We include `Volume: {Usd: {gt: 5}}` to further remove extreme outliers; the stream already pre-filters outliers—this is an additional check.
 
@@ -469,6 +475,8 @@ subscription {
 This is the 3rd cube in these set of APIs. The Pairs cube gives you price, volume, and market-level trading data between two tokens — a base token and a quote token.
 We will breakdown in detail how base token and Quote are chosen in the next section.
 
+> **Recommended for single-token prices:** add `Ranking: { Position: { eq: 1 } }` to a Pairs query to get a token's price from its **top market** — the pool carrying the most volume for it. See [Getting the Most Accurate Token Price](/docs/trading/crypto-price-api/pairs#most-accurate-token-price).
+
 > **Tip**: Use `TokenId` instead of `Token.Address` to fetch all variants of the same token (e.g., ETH, WETH, bridged ETH) across multiple chains.
 
 > Note: We include `Volume: {Usd: {gt: 5}}` to further remove extreme outliers; the stream already pre-filters outliers—this is an additional check.
@@ -565,24 +573,31 @@ Use `TargetVolume` to get price intervals aggregated over a volume threshold:
 
 ## When to Choose Which Cube (Token, Currency, Pair)?
 
+:::tip The short answer
+For the price of a **specific token**, use **`Pairs` with `Ranking: { Position: { eq: 1 } }`** — see [Getting the Most Accurate Token Price](/docs/trading/crypto-price-api/pairs#most-accurate-token-price). Use `Tokens` for chain-wide streams and per-chain aggregates, and `Currencies` for one cross-chain number per asset.
+:::
+
+### Use the **`Pairs`** cube when:
+
+- You want the **price of a specific token** — filter to its top market with `Ranking: { Position: { eq: 1 } }` so thin pools do not affect the number ([how and why](/docs/trading/crypto-price-api/pairs#most-accurate-token-price)).
+- You want **pair-level trading data** (e.g., SOL/USDC, ETH/DAI).
+- You’re analyzing trading activity **on a specific market or DEX** (e.g., Uniswap, PancakeSwap, Raydium).
+- You need **OHLC, volume, liquidity**, and market-specific pricing between two tokens.
+- You're exploring **price arbitrage** or spreads across chains or platforms.
+
 ### Use the **`Tokens`** cube when:
 
-- You want token price data **on a specific blockchain**.
-- You're interested in metrics like OHLC, volume, and moving averages **for one network** (e.g., USDC on Solana or ETH on Arbitrum).
-- You want to stream or query **chain-specific** price movements.
+- You want a **firehose** of price updates for every token on a chain.
+- You want **one chain-wide number per token**, blended across all of its pools, rather than the price on a single market.
+- You're interested in **aggregate volume across all of a token's pools**, or the currency-level `Supply` and `MarketCap` fields.
+
+  > For a **single token's price**, prefer `Pairs` with rank 1: the `Tokens` price is a volume-weighted blend of every pool, so thin pools can pull it away from the primary market. See [Tokens cube](/docs/trading/crypto-price-api/tokens).
 
 ### Use the **`Currencies`** cube when:
 
 - You want a **chain-agnostic view** of a token (e.g., BTC across Bitcoin, Ethereum (WBTC), Solana, etc.).
 - You need a **global price** for a currency, combining its various representations.
 - You're looking for **aggregated OHLC and average prices** for a token across chains.
-
-### Use the **`Pairs`** cube when:
-
-- You want **pair-level trading data** (e.g., SOL/USDC, ETH/DAI).
-- You’re analyzing trading activity **on a specific market or DEX** (e.g., Uniswap, PancakeSwap, Raydium).
-- You need **OHLC, volume, liquidity**, and market-specific pricing between two tokens.
-- You're exploring **price arbitrage** or spreads across chains or platforms.
 
 ## Crypto Price API for TradingView
 
@@ -602,6 +617,10 @@ import VideoPlayer from "../../../src/components/videoplayer.js";
     {
       q: "How do I get real-time crypto prices and OHLC candles?",
       a: "Use Trading.Tokens, Trading.Pairs, or Trading.Currencies for aggregated USD prices and OHLC over the last ~30 days. For older history, build candles from DEXTradeByTokens on the chain you need.",
+    },
+    {
+      q: "Which cube gives the most accurate price for a specific token?",
+      a: "Trading.Pairs filtered with Ranking: { Position: { eq: 1 } }. That returns the price on the token's top market — the pool contributing the most volume — instead of the Tokens cube's blend across every pool, which thin pools can pull off the primary market's price. See Getting the Most Accurate Token Price on the Pairs cube page.",
     },
     {
       q: "What is the difference between Crypto Price API and Crypto Trades API?",

--- a/docs/trading/crypto-price-api/limit-order-price-api.md
+++ b/docs/trading/crypto-price-api/limit-order-price-api.md
@@ -266,6 +266,12 @@ subscription {
 
 ### **4. Pair-Specific Market Data**
 
+:::tip Track the deepest market instead of hardcoding one
+Pinning a limit order to a **named** pool reintroduces the single-pool risk described above — that pool can thin out or stop being where the token trades. Adding **`Ranking: { Position: { eq: 1 } }`** to a `Pairs` query instead follows the token's **top market** automatically: you get the price from the deepest pool at any moment, and thin pools cannot influence it.
+
+This is the complement to blended aggregation, not a contradiction of it. Blended [`Tokens`](/docs/trading/crypto-price-api/tokens) prices dampen spikes by mixing every pool, including thin ones; rank-1 removes the thin pools entirely and quotes the market with the most volume. Use blended prices when you want smoothing across the whole market, and rank-1 when you want the price you could actually execute against. See [Getting the Most Accurate Token Price](/docs/trading/crypto-price-api/pairs#most-accurate-token-price).
+:::
+
 **Example: SOL/USDC on Raydium**
 ```graphql
 subscription {

--- a/docs/trading/crypto-price-api/pairs.md
+++ b/docs/trading/crypto-price-api/pairs.md
@@ -40,6 +40,7 @@ Filtering `Pairs` to `Ranking.Position = 1` avoids that: you get the quote from 
         }
         Ranking: { Position: { eq: 1 } }
         Interval: { Time: { Duration: { eq: 60 } } }
+        Price: { IsQuotedInUsd: true }
       }
       limit: { count: 1 }
       orderBy: { descending: Block_Time }
@@ -80,7 +81,13 @@ Filtering `Pairs` to `Ranking.Position = 1` avoids that: you get the quote from 
 }
 ```
 
-`Price.Ohlc.Close` is the token's latest price on its top market. Values come back in **USD** (`IsQuotedInUsd: true`) even when the quote token is WSOL or another non-stable asset, because the index normalizes the quote side — see [How Pool Prices Are Normalized](/docs/trading/crypto-price-api/price-index-algorithm#how-pool-prices-are-normalized-to-the-current-quote-token).
+`Price.Ohlc.Close` is the token's latest price on its top market.
+
+:::warning Keep `Price: { IsQuotedInUsd: true }` in the filter
+Each market publishes its rows **twice**: once priced in **USD** and once priced in **quote token units**. Without the `Price: { IsQuotedInUsd: true }` filter you will receive both, and a row such as a WBTC/WSOL market would return the price of WBTC **in SOL**, not in dollars.
+
+With the filter, prices are in USD even when the quote token is WSOL or another non-stable asset, because the index normalizes the quote side — see [How Pool Prices Are Normalized](/docs/trading/crypto-price-api/price-index-algorithm#how-pool-prices-are-normalized-to-the-current-quote-token). Set it to `false` when you deliberately want the price in quote-token terms.
+:::
 
 ### Stream the same price
 
@@ -97,6 +104,7 @@ subscription {
         }
         Ranking: { Position: { eq: 1 } }
         Interval: { Time: { Duration: { eq: 1 } } }
+        Price: { IsQuotedInUsd: true }
       }
     ) {
       Token {
@@ -148,6 +156,7 @@ Add `limitBy` to collapse the result to one current row per token:
         }
         Ranking: { Position: { eq: 1 } }
         Interval: { Time: { Duration: { eq: 60 } } }
+        Price: { IsQuotedInUsd: true }
         Block: { Time: { since_relative: { minutes_ago: 10 } } }
       }
       limit: { count: 10 }
@@ -192,6 +201,7 @@ Add `limitBy` to collapse the result to one current row per token:
 
 ### Things to know
 
+- **Rank 1 does not imply USD.** The rank filter selects the market, not the price denomination — always pair it with `Price: { IsQuotedInUsd: true }` (or read the `IsQuotedInUsd` field on each row) so you are not mixing USD and quote-token prices.
 - **The top market can change.** Ranking is recomputed as volume moves, so a token's rank-1 pool — and its quote token — may flip during a stream. Key your state on `Market.Address` from each message instead of assuming a fixed pool.
 - **Always scope the query.** A rank filter is not a substitute for a token filter: an unscoped rank-1 query across a whole chain scans very wide and can time out. Filter by `Token.Address` with `Network` (or `Market: { NetworkBid: { is: "bid:eth" } }` for lower latency), and add `Block: { Time: { since_relative: { minutes_ago: N } } }` for broad queries.
 - **Want the runner-up markets too?** Use `Ranking: { Position: { in: [1, 2, 3] } }` to compare a token's main venues — useful for spread and arbitrage checks. You can also sort by `orderBy: { descending: Ranking_Weight }`.

--- a/docs/trading/crypto-price-api/pairs.md
+++ b/docs/trading/crypto-price-api/pairs.md
@@ -6,6 +6,199 @@ description: "Get crypto trading pair prices, volume, and OHLC with Bitquery Tra
 
 The Pairs cube provides trading data for a base token traded against a quote token on a particular DEX or protocol.
 
+## Getting the Most Accurate Token Price (Rank 1) {#most-accurate-token-price}
+
+:::tip Querying the price of a specific token? Use this pattern
+Query the **Pairs** cube with **`Ranking: { Position: { eq: 1 } }`**. This returns the token's price on its **top market** — the pool currently contributing the most volume to that token's price — rather than a value blended across every pool the token trades in.
+:::
+
+### Why the top market, and not the blended token price
+
+The [Tokens cube](/docs/trading/crypto-price-api/tokens) reports one price per token per chain, computed as a **volume-weighted blend of every pool** where the token is the base asset (see [Price Index Algorithm](/docs/trading/crypto-price-api/price-index-algorithm)). That blend is the right answer when you want a single chain-wide number, and for a token whose liquidity sits in one deep pool the blended price and the top-market price agree closely.
+
+Fragmented tokens behave differently. When the same token trades across many pools — one primary pool plus a long tail of thin ones — every pool contributes to the blend in proportion to its decay-weighted volume. Thin pools quote wider, move on small trades, and can sit at prices the primary market has already left. Their share of the blend pulls the reported number away from the price you could actually trade at.
+
+Filtering `Pairs` to `Ranking.Position = 1` avoids that: you get the quote from the single market carrying the most volume for that token, which is the closest thing to an executable price.
+
+| You want | Use |
+| --- | --- |
+| The price of one specific token | **`Pairs` + `Ranking: { Position: { eq: 1 } }`** |
+| A firehose of every token on a chain, or one chain-wide number per token | [`Tokens`](/docs/trading/crypto-price-api/tokens) |
+| One number for an asset across all chains (BTC, ETH) | [`Currencies`](/docs/trading/crypto-price-api/currency) |
+| A specific pool you already know the address of | `Pairs` + `Market: { Address: ... }` |
+
+### Latest price of a token from its top market
+
+```graphql
+{
+  Trading {
+    Pairs(
+      where: {
+        Token: {
+          Address: { is: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263" }
+          Network: { is: "Solana" }
+        }
+        Ranking: { Position: { eq: 1 } }
+        Interval: { Time: { Duration: { eq: 60 } } }
+      }
+      limit: { count: 1 }
+      orderBy: { descending: Block_Time }
+    ) {
+      Token {
+        Symbol
+        Address
+      }
+      QuoteToken {
+        Symbol
+      }
+      Market {
+        Protocol
+        Address
+        Network
+      }
+      Price {
+        IsQuotedInUsd
+        Ohlc {
+          Open
+          High
+          Low
+          Close
+        }
+      }
+      Ranking {
+        Position
+        Weight
+      }
+      Volume {
+        Usd
+      }
+      Block {
+        Time
+      }
+    }
+  }
+}
+```
+
+`Price.Ohlc.Close` is the token's latest price on its top market. Values come back in **USD** (`IsQuotedInUsd: true`) even when the quote token is WSOL or another non-stable asset, because the index normalizes the quote side — see [How Pool Prices Are Normalized](/docs/trading/crypto-price-api/price-index-algorithm#how-pool-prices-are-normalized-to-the-current-quote-token).
+
+### Stream the same price
+
+Change `query` to `subscription` and drop `limit`/`orderBy` to receive top-market updates as they happen:
+
+```graphql
+subscription {
+  Trading {
+    Pairs(
+      where: {
+        Token: {
+          Address: { is: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263" }
+          Network: { is: "Solana" }
+        }
+        Ranking: { Position: { eq: 1 } }
+        Interval: { Time: { Duration: { eq: 1 } } }
+      }
+    ) {
+      Token {
+        Symbol
+        Address
+      }
+      QuoteToken {
+        Symbol
+      }
+      Market {
+        Protocol
+        Address
+      }
+      Price {
+        IsQuotedInUsd
+        Ohlc {
+          Close
+        }
+      }
+      Ranking {
+        Position
+        Weight
+      }
+    }
+  }
+}
+```
+
+To stream the top market of **every** token on a chain, replace the `Token.Address` filter with `Token: { Network: { is: "Solana" } }` and keep the rank filter.
+
+### Watchlist: top-market price for several tokens
+
+Add `limitBy` to collapse the result to one current row per token:
+
+```graphql
+{
+  Trading {
+    Pairs(
+      where: {
+        Token: {
+          Address: {
+            in: [
+              "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263"
+              "So11111111111111111111111111111111111111112"
+              "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+            ]
+          }
+          Network: { is: "Solana" }
+        }
+        Ranking: { Position: { eq: 1 } }
+        Interval: { Time: { Duration: { eq: 60 } } }
+        Block: { Time: { since_relative: { minutes_ago: 10 } } }
+      }
+      limit: { count: 10 }
+      limitBy: { by: Token_Address, count: 1 }
+      orderBy: { descending: Block_Time }
+    ) {
+      Token {
+        Symbol
+        Address
+      }
+      QuoteToken {
+        Symbol
+      }
+      Market {
+        Protocol
+      }
+      Price {
+        Ohlc {
+          Close
+        }
+      }
+      Ranking {
+        Position
+        Weight
+      }
+      Block {
+        Time
+      }
+    }
+  }
+}
+```
+
+### Reading `Ranking.Weight`
+
+`Weight` is that market's share of the token's total decay-weighted volume, a float in `[0, 1]`; weights across all contributing pools sum to 1. Treat it as a confidence signal on the blended price:
+
+- **Weight close to 1** — a single pool drives essentially the whole token price. The blended `Tokens` price and the rank-1 price will be nearly identical, so either works.
+- **Low weight** — liquidity is fragmented across many pools and the blended price mixes all of them. This is exactly the case where the rank-1 price and the blended price diverge, and where the rank-1 price is the one you want.
+
+`Position` and `Weight` are computed over the rolling **1-hour, decay-weighted** window described in the [Price Index Algorithm](/docs/trading/crypto-price-api/price-index-algorithm#ranking-on-trades-pairs-and-tokens) — not over the interval of the row you are reading. A rank-1 row can therefore report less `Volume.Usd` for its own interval than a lower-ranked row does for another.
+
+### Things to know
+
+- **The top market can change.** Ranking is recomputed as volume moves, so a token's rank-1 pool — and its quote token — may flip during a stream. Key your state on `Market.Address` from each message instead of assuming a fixed pool.
+- **Always scope the query.** A rank filter is not a substitute for a token filter: an unscoped rank-1 query across a whole chain scans very wide and can time out. Filter by `Token.Address` with `Network` (or `Market: { NetworkBid: { is: "bid:eth" } }` for lower latency), and add `Block: { Time: { since_relative: { minutes_ago: N } } }` for broad queries.
+- **Want the runner-up markets too?** Use `Ranking: { Position: { in: [1, 2, 3] } }` to compare a token's main venues — useful for spread and arbitrage checks. You can also sort by `orderBy: { descending: Ranking_Weight }`.
+- **`Ranking` does not exist on `Currencies`.** It is available on `Trades`, `Pairs`, and `Tokens` only.
+
+## Schema and Fields
+
 ```graphql
 {
   Trading {

--- a/docs/trading/crypto-price-api/pairs.md
+++ b/docs/trading/crypto-price-api/pairs.md
@@ -29,6 +29,8 @@ Filtering `Pairs` to `Ranking.Position = 1` avoids that: you get the quote from 
 
 ### Latest price of a token from its top market
 
+[Run query ➤](https://ide.bitquery.io/Token-price-from-top-market--rank-1_2)
+
 ```graphql
 {
   Trading {
@@ -93,6 +95,8 @@ With the filter, prices are in USD even when the quote token is WSOL or another 
 
 Change `query` to `subscription` and drop `limit`/`orderBy` to receive top-market updates as they happen:
 
+[Run Stream ➤](https://ide.bitquery.io/Token-price-stream-from-top-market--rank-1)
+
 ```graphql
 subscription {
   Trading {
@@ -138,6 +142,8 @@ To stream the top market of **every** token on a chain, replace the `Token.Addre
 ### Watchlist: top-market price for several tokens
 
 Add `limitBy` to collapse the result to one current row per token:
+
+[Run query ➤](https://ide.bitquery.io/Multi-token-watchlist--rank-1-per-token)
 
 ```graphql
 {

--- a/docs/trading/crypto-price-api/price-index-algorithm.md
+++ b/docs/trading/crypto-price-api/price-index-algorithm.md
@@ -82,6 +82,10 @@ The API for **Trades**, **Pairs**, and **Tokens** exposes a **Ranking** object w
 
 Use **Position** for display order or precedence; use **Weight** for how much each contributor matters in the blended price.
 
+:::tip Practical use: pricing a token from its top market
+Filtering **`Pairs`** to **`Ranking: { Position: { eq: 1 } }`** gives you a token's price on the single market contributing the most decay-weighted volume, instead of the blend across all of its pools. This is the recommended way to price a specific token — see [Getting the Most Accurate Token Price](/docs/trading/crypto-price-api/pairs#most-accurate-token-price) for queries, streaming, and caveats.
+:::
+
 ### Example: filter by ranking position
 
 Filter pairs in **`where`** using **`Ranking.Position`** when you only want rows that are among the top contributors to the token price (for example positions **1**, **2**, and **3**). Request **`Ranking { Position Weight }`** on each pair to see both the rank and that pair’s **relative weight** in the blend. **`Weight`** is normally used as a returned field rather than as a filter.

--- a/docs/trading/crypto-price-api/tokens.md
+++ b/docs/trading/crypto-price-api/tokens.md
@@ -4,6 +4,10 @@ description: "Fetch token USD prices, market stats, and history with Bitquery cr
 ---
 # Tokens Cube
 
+:::tip Looking for one token's price? Use the Pairs cube with rank 1
+The price on this cube is a **volume-weighted blend of every pool** where the token is the base asset. That is what you want for a chain-wide number or a firehose of all tokens on a chain. But for a **specific token** — especially one whose liquidity is spread across many pools — thin pools contribute to the blend and can pull the price away from where the token actually trades. For a single token's price, query the [Pairs cube with `Ranking: { Position: { eq: 1 } }`](/docs/trading/crypto-price-api/pairs#most-accurate-token-price) to get the quote from its top market.
+:::
+
 The **Tokens** cube provides chain-specific, aggregated price and volume data for individual tokens. For a **query** example that returns tokens with volume and average price over the last 24h (including conditional metrics for 1h, 4h, 24h), see [Aggregated Token Data](https://ide.bitquery.io/aggregated-data) or the [Crypto Price API examples](/docs/trading/crypto-price-api/examples#aggregated-token-data-volume--price-last-24h).
 
 ### Fields in the Schema
@@ -83,4 +87,5 @@ subscription {
 - **Clarification on "Quote":**  
   The **Tokens** cube **does not show the specific quote tokens** used in each trade. Instead, it aggregates across all pairs the token is involved in—regardless of which token acted as the quote in those trades.
 - If you need **pair-level granularity** (i.e., to know exactly which token was the quote in a specific pair), use the **Pairs Cube** instead.
+- **Where the blend can mislead:** because every pool contributes in proportion to its decay-weighted volume, tokens with **fragmented liquidity** (one primary pool plus a tail of thin ones) can report a price that drifts from the primary market. Check `Ranking.Weight` on the [Pairs cube](/docs/trading/crypto-price-api/pairs#most-accurate-token-price): a top-market weight near 1 means the blend is effectively one pool and this cube's price is equivalent; a low weight means you should price the token from its [rank-1 market](/docs/trading/crypto-price-api/pairs#most-accurate-token-price) instead.
 - **`Supply`**: Currency-level metrics for the asset (aggregated across chains); price and volume on the row remain chain-specific. See [Supply fields reference](/docs/trading/crypto-price-api/supply-fields) for each subfield (`CirculatingSupply`, `TotalSupply`, `MaxSupply`, `MarketCap`, `FullyDilutedValuationUsd`).

--- a/docs/trading/trading-data-overview.md
+++ b/docs/trading/trading-data-overview.md
@@ -83,9 +83,9 @@ It is exposed under a single `Trading` root and covers **9 chains in one API**: 
 | Cube | What it gives you | Typical use |
 |---|---|---|
 | **`Trading.Trades`** | Individual swap-level rows with **USD price**, **USD amounts**, **market cap**, **FDV**, **supply**, and pair / trader / tx context | Live trade feeds, copy-trading bots, whale alerts, per-swap analytics |
-| **`Trading.Tokens`** | Pre-aggregated OHLC, volume, supply and moving averages for a **token on a specific chain** | Token-level price charts, token screeners |
+| **`Trading.Tokens`** | Pre-aggregated OHLC, volume, supply and moving averages for a **token on a specific chain**, blended across all of its pools | Chain-wide price streams, token screeners |
 | **`Trading.Currencies`** | Pre-aggregated OHLC for a **currency aggregated across chains** (e.g. BTC across WBTC, cbBTC, native BTC, etc.) | Chain-agnostic global price for an asset |
-| **`Trading.Pairs`** | Pre-aggregated OHLC and volume **per trading pair on a specific market/DEX** | Pair-specific charts (e.g. SOL/USDC on Raydium) |
+| **`Trading.Pairs`** | Pre-aggregated OHLC and volume **per trading pair on a specific market/DEX** | Pair-specific charts (e.g. SOL/USDC on Raydium), and — with [rank 1](/docs/trading/crypto-price-api/pairs#most-accurate-token-price) — the most accurate price for a single token |
 
 ### Characteristics
 
@@ -151,6 +151,7 @@ The first two rows answer the question for 80% of users — pick by **how far ba
 | Get **older than ~30 days** of trades or candles (historical / archive) | **`EVM.DEXTradeByTokens`** / **`Solana.DEXTradeByTokens`** (with `dataset: combined` or `archive`) |
 | Render a real-time trade tape in a trading UI | `Trading.Trades` |
 | Power a price ticker / candle chart with ready USD values | `Trading.Tokens` or `Trading.Pairs` |
+| Get the **most accurate price for one specific token** | [`Trading.Pairs` + `Ranking: { Position: { eq: 1 } }`](/docs/trading/crypto-price-api/pairs#most-accurate-token-price) — prices from the token's top market instead of a blend across all its pools |
 | Get a chain-agnostic price for an asset (e.g. BTC across all chains) | `Trading.Currencies` |
 | Stream all swaps on 9 chains in **one** subscription | `Trading.Trades` |
 | Build OHLC at a **custom** interval (e.g. 7-second, 4-hour) | `DEXTradeByTokens` (in-query aggregation) |

--- a/docs/usecases/trading-indicators.md
+++ b/docs/usecases/trading-indicators.md
@@ -47,6 +47,8 @@ We write a query to get OHLC data for the Uniswap pair ETH-DAI, filtering for tr
 
 We’ll request **Solana token** prices in **1-minute intervals**, including SMA/EMA/WSMA.
 
+> Streaming every token on a chain is a good fit for the `Tokens` cube. To compute indicators for **one specific token**, swap in [`Pairs` with `Ranking: { Position: { eq: 1 } }`](/docs/trading/crypto-price-api/pairs#most-accurate-token-price): the same `Price.Average` fields (`SimpleMoving`, `ExponentialMoving`, `WeightedSimpleMoving`) are available there, computed from the token's top market rather than blended across all of its pools.
+
 ```python
 query = gql("""
 subscription {

--- a/docs/usecases/tradingview-subscription-realtime/historical_OHLC.md
+++ b/docs/usecases/tradingview-subscription-realtime/historical_OHLC.md
@@ -23,6 +23,10 @@ import { connectBarContinuity } from "./barContinuity";
 
 We are using the [Tokens Cube from the Crypto Price API](/docs/trading/crypto-price-api/introduction/) which gives you price of a token on different chains in **USD**. You can use Pairs Cube as well to get price against specific currency.
 
+:::tip Charting one specific token? Prefer Pairs + rank 1
+The `Tokens` candle blends every pool where the token is base, so thin pools contribute to the bar. For a chart of **one** token, query [`Pairs` with `Ranking: { Position: { eq: 1 } }`](/docs/trading/crypto-price-api/pairs#most-accurate-token-price) instead — same `Price.Ohlc` fields, but taken from the token's top market. Keep the `Market.Address` from each row if you want to show which venue the candle came from.
+:::
+
 [You can test the query here](https://ide.bitquery.io/Historical-price-data)
 
 **We have used Solana as an example below, you can remove it and get data for all chains provided by the Price API**

--- a/docs/usecases/tradingview-subscription-realtime/realtime_OHLC.md
+++ b/docs/usecases/tradingview-subscription-realtime/realtime_OHLC.md
@@ -31,6 +31,10 @@ const BITQUERY_ENDPOINT =
 
 ### Subscription Query
 
+:::tip Charting one specific token? Prefer Pairs + rank 1
+The subscription below uses the `Tokens` cube, whose price blends every pool where the token is base. For a chart of **one** token, subscribe to [`Pairs` with `Ranking: { Position: { eq: 1 } }`](/docs/trading/crypto-price-api/pairs#most-accurate-token-price) instead — the same `Price.Ohlc` fields, taken from the token's top market. Note that the top market can change during a stream, so read `Market.Address` from each message rather than assuming a fixed pool.
+:::
+
 [Run Stream on IDE](https://ide.bitquery.io/1-second-crypto-price-stream)
 **We have used Solana as an example below, you can remove it and get data for all chains provided by the Price API**
 


### PR DESCRIPTION
## Problem

The docs teach `Trading.Tokens` as the default way to get a token's price. That price is a **volume-weighted blend of every pool** where the token is base. For tokens with fragmented liquidity — one primary pool plus a tail of thin ones — the thin pools contribute to the blend and pull the reported price away from the market where the token actually trades. Users hit this and conclude our prices are wrong.

## Change

Recommend `Trading.Pairs` with `Ranking: { Position: { eq: 1 } }` for the price of a **specific token** — the quote from the pool currently carrying the most volume for it.

Stance is **steer, not deprecate**. `Tokens` stays documented as the right cube for chain-wide firehose streams, cross-pool volume totals, and currency-level `Supply`/`MarketCap`. The framing is *blend vs. top market*, consistent with the Price Index Algorithm page rather than contradicting it.

New canonical section: **Getting the Most Accurate Token Price (Rank 1)** on the Pairs cube page (`#most-accurate-token-price`) — query, streaming variant, multi-token watchlist, how to read `Ranking.Weight`, and caveats. Eleven other pages link to it instead of re-explaining.

**12 files:** Pairs (canonical section) · Tokens, Currencies, introduction, price-index-algorithm, examples, OHLC guide, limit-order, trading-data-overview · both TradingView guides + trading-indicators.

## Gotcha this uncovered

Live checking caught a trap worth reviewing carefully: **every market publishes each row twice**, once priced in USD and once in quote-token units. The rank filter selects the *market*, not the denomination — so a rank-1 query without `Price: { IsQuotedInUsd: true }` can return e.g. WBTC priced in SOL. All snippets carry the filter and the page warns about it explicitly (3rd commit).

Also documented: the rank-1 market **flips** as volume moves (observed BONK switching between an amm_v3/USDC pool and a whirlpool/WSOL pool within minutes), so stream consumers must key on `Market.Address` per message.

## Verification

- Every query snippet executed against `streaming.bitquery.io` and returned data; the subscription validated verbatim over WebSocket (graphql-transport-ws).
- `Price.Average` (SMA/EMA/WSMA) confirmed populated on rank-1 rows, so the indicators guide can honestly point there.
- Full Docusaurus build passes (exit 0; `onBrokenLinks: "throw"`); `check-links` reports no errors.

## Deliberately not touched

- `crypto-marketcap-api.md` — supply and market cap are currency-level fields, unaffected by the pool blend.
- Stablecoin pages — stablecoin prices come from a separate external-spot pipeline, not decay-weighted DEX aggregation.
- `crypto-trades-api/*` and `mcp/trading/*` — these use `Trading.Trades`, no Tokens-cube price queries.

## Follow-ups

- **Tier 3 (separate PR):** ~25 chain pages (`solana-dextrades`, `bsc-dextrades`, `robinhood-trades`, per-chain marketcap) still show Tokens-price examples. They now have a stable link target.
- **IDE saved queries needed** for the three new snippets (rank-1 latest price, subscription, watchlist) — they ship without "Run query" links until those exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)