### PR TITLE
docs: remove Fantom and Moonbeam from supported chains matrix

### DIFF
--- a/docs/blockchain/supported-chains.mdx
+++ b/docs/blockchain/supported-chains.mdx
@@ -66,8 +66,6 @@ This guide lists **which blockchains Bitquery indexes** and how that lines up wi
 | Tron | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Celo | ✓ | — | — | ✓ | ✓ |
 | Algorand | ✓ | — | — | ✓ | ✓ |
-| Moonbeam | ✓ | — | — | ✓ | ✓ |
-| Fantom | ✓ | — | — | ✓ | ✓ |
 | Cronos | ✓ | — | — | ✓ | ✓ |
 | Solana | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Cardano | ✓ | — | — | ✓ | ✓ |


### PR DESCRIPTION
Removes the **Fantom** and **Moonbeam** rows from the chain × product matrix on [`docs/blockchain/supported-chains.mdx`](https://docs.bitquery.io/docs/blockchain/supported-chains/).

## Change

Two table rows deleted, nothing else:

```diff
-| Moonbeam | ✓ | — | — | ✓ | ✓ |
-| Fantom | ✓ | — | — | ✓ | ✓ |
```

Table integrity verified after the edit: 23 data rows remaining, uniform column count, no orphaned separators, no remaining references to either chain in the file.

## Still inconsistent elsewhere — not changed here

These were left alone deliberately, since they are separate claims that need their own call:

| File | What it says | Why it was left |
|---|---|---|
| `docs/blockchain/introduction.md:51` | Prose list still reads `… Celo, **Moonbeam, Fantom**, Cronos, …` | **Directly contradicts this PR.** Likely wants the same treatment — flagged for a follow-up. |
| `docs/labels/address-labels-api.md:352,404` | Fantom listed among label-supported EVM chains | Different product; labels coverage may genuinely still include Fantom. Needs a product decision, not a blind delete. |
| `docs/graphql/dataset/network.md:34,39` | `fantom: 250`, `moonbeam: 1284` | Chain-ID reference values, not support claims. Should stay unless the V1 network enum has actually dropped the identifiers. |

The page's "V1 historically covers 40+ blockchains" note is unaffected — the matrix is explicitly a short list, not the full catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)