### PR TITLE
docs: restructure the IDE starter panel by chain and data type (323 → 1,025 entries)

### DIFF
--- a/docs/ide/paid.md
+++ b/docs/ide/paid.md
@@ -30,7 +30,9 @@ On the **Choose plan** step you can:
 | **Scale** ⭐ (recommended) | 5,000,000       | 240            | 12                  | 1,000                | 2,000,000 min  | 50 GB     | 5         |
 | **Enterprise**             | Custom          | Custom         | Custom              | Unlimited            | Custom         | Unlimited | Custom    |
 
-All self-serve plans use the `realtime` dataset. **Enterprise** includes all datasets (Archive, Realtime, Combined), volume pricing, and dedicated support & SLA — [contact sales](https://bitquery.io/forms/api) for a quote.
+Self-serve plans query the `realtime` dataset by default. To query history — the `archive` and `combined` datasets — add the **historical data add-on** to your plan; see the [pricing page](https://bitquery.io/pricing) for the chains it covers. Without it, a query using `dataset: archive` or `dataset: combined` will be rejected. **Enterprise** includes all datasets (Archive, Realtime, Combined), volume pricing, and dedicated support & SLA — [contact sales](https://bitquery.io/forms/api) for a quote.
+
+For which cube has how much history on each chain, see [Data Coverage & Retention](/docs/graphql/data-coverage-retention/).
 
 Current pricing is always on the [pricing page](https://bitquery.io/pricing).
 

--- a/docs/start/learning-path.md
+++ b/docs/start/learning-path.md
@@ -37,7 +37,7 @@ This guide provides a structured path to learn Bitquery APIs progressively, from
 
 ### For Traders
 
-- Start with **[Crypto Price APIs](/docs/start/starter-queries#crypto-price-change-api)**
+- Start with **[Crypto Price APIs](/docs/start/starter-queries#latest-price-of-any-token)**
 - Learn **[Real-time Price Streams](/docs/start/starter-subscriptions)**
 - Explore **[DEX Trading APIs](/docs/blockchain/Solana/solana-dextrades)**
 

--- a/docs/start/starter-queries.md
+++ b/docs/start/starter-queries.md
@@ -1977,7 +1977,7 @@ Use the below query to get Token's metadata like `Name`, `symbol`, `SmartContrac
 
 #### Latest slippage of a pool on Uniswap v3
 
-Retrieves the latest slippage data for a specific DEX pool on Arbitrum. Use this to check current liquidity depth and price impact for a particular token pair.
+Latest slippage of a pool on Uniswap v3. Change the token address in the `where` clause to use it.
 
 ▶️ [Latest slippage of a pool on Uniswap v3](https://ide.bitquery.io/Latest-slippage-of-a-pool-on-Uniswap-v3)
 
@@ -3527,7 +3527,7 @@ Tokens ranked by market cap. Uses the `Trades` cube.
 
 #### Solana USDT trades query
 
-Below example is to track USDT trading activity on Solana.
+Solana USDT trades query. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Solana USDT trades query](https://ide.bitquery.io/solana-USDT-trades-query)
 
@@ -3553,25 +3553,25 @@ Listen to stablecoin payments across all major blockchains. The Mempool option l
 
 #### Stablecoin Transfers from/to an address
 
-Below query will give you `EURC` transfers from/to `cHxJ2uC6vgcCfoFSfupkfCWbKHAkekrGfG39DXRamXT` on Solana.
+Stablecoin Transfers from/to an address. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Stablecoin Transfers from/to an address](https://ide.bitquery.io/stablecoin-Transfers-fromto-an-address)
 
 #### Stablecoin recieved and sent by an address
 
-Below query will give you `USDT` transfers from/to `TUTQj7VJ1QjR3t2GJByvrP25yZNFcj38VJ` on Tron.
+Stablecoin recieved and sent by an address. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
 
 ▶️ [Stablecoin recieved and sent by an address](https://ide.bitquery.io/Stablecoin-recieved-and-sent-by-an-address)
 
 #### USDT Stablecoin reserves on Ethereum
 
-Below API query will give you realtime reserves data of `USDT` on Ethereum.
+USDT Stablecoin reserves on Ethereum. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
 
 ▶️ [USDT Stablecoin reserves on Ethereum](https://ide.bitquery.io/USDT-Stablecoin-reserves-on-Ethereum)
 
 #### USDT and USDC token Transfers api on solana
 
-This GraphQL stream provides live USDT and USDC stablecoin transfers on Solana.
+USDT and USDC token Transfers api on solana. Uses the `Transfers` cube.
 
 ▶️ [USDT and USDC token Transfers api on solana](https://ide.bitquery.io/USDT-and-USDC-token-Transfers-api-on-solana)
 
@@ -3605,13 +3605,13 @@ This query compares USDT prices across different blockchain networks in real-tim
 
 #### USDC Stablecoin reserves on Solana
 
-Below API query will give you realtime reserves data of `USDC` on Solana.
+USDC Stablecoin reserves on Solana. Uses the `TokenSupplyUpdates` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [USDC Stablecoin reserves on Solana](https://ide.bitquery.io/USDC-Stablecoin-reserves-on-Solana)
 
 #### USDT Stablecoin reserves on Solana query
 
-Monitor USDT reserve or get lateast reserve value on Solana using below Stream/API.
+USDT Stablecoin reserves on Solana query. Uses the `TokenSupplyUpdates` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [USDT Stablecoin reserves on Solana query](https://ide.bitquery.io/USDT-Stablecoin-reserves-on-Solana--query)
 
@@ -3699,7 +3699,7 @@ Get trades of NFTs for a given wallet.
 
 #### Latest NFT Trades
 
-This query gets the latest 10 NFT trades on Ethereum mainnet. You can increase the limit to whatever you like, up to 25,000. Currently, it only retrieves data from the real-time database. To include historical data, use `dataset: combined`.
+Latest NFT Trades.
 
 ▶️ [Latest NFT Trades](https://ide.bitquery.io/Latest-NFT-trades-on-ETH)
 
@@ -3717,7 +3717,7 @@ Latests OpenSea Trades.
 
 #### Latest NFT trades on Ethereum network
 
-Retrieves the latest NFT Trades on Ethereum for Seaport v1.4 protocol. Many marketplaces utilize the Seaport protocol, we can add a Smart contract in Trade → Dex → SmartContract to get a specific marketplace for this protocol.
+Latest NFT trades on Ethereum network.
 
 ▶️ [Latest NFT trades on Ethereum network](https://ide.bitquery.io/latest-NFT-trades-on-Ethereum-network)
 
@@ -3927,7 +3927,7 @@ Fetch the most recent prediction market trades with full details, ordered by blo
 
 #### Prediction_trades
 
-Use Bitquery's `PredictionTrades` GraphQL query filtered by `ProtocolName: "polymarket"` on Polygon (`network: matic`). For live streaming, use a subscription or Kafka.
+Prediction_trades.
 
 ▶️ [Prediction_trades](https://ide.bitquery.io/prediction_trades)
 
@@ -4083,7 +4083,7 @@ Look up the buyer's earliest on-chain activity. If the wallet's first transfer i
 
 #### FundingSource for poylmarket
 
-Find where the wallet's money came from. The first inbound USDC transfer is usually the original funder, often a centralized exchange withdrawal or a parent wallet. This query uses bridged USDC.e on Polygon (`0x2791bca1f2de4661ed88a30c99a7a9449aa84174`).
+FundingSource for poylmarket. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
 
 ▶️ [FundingSource for poylmarket](https://ide.bitquery.io/FundingSource-for-poylmarket)
 
@@ -4199,7 +4199,7 @@ Using Bitquery's APIs you can follow specific traders on AsterDEX to check all t
 
 #### Payment Analytics for x402 Server on Solana
 
-Comprehensive payment analytics for a specific x402 server on Solana including total volume, unique users, and transaction counts.
+Payment Analytics for x402 Server on Solana. Replace the address in the `where` clause to use it.
 
 ▶️ [Payment Analytics for x402 Server on Solana](https://ide.bitquery.io/Payment-analytics-related-specific-x402-server-on-Solana)
 
@@ -4207,13 +4207,13 @@ Comprehensive payment analytics for a specific x402 server on Solana including t
 
 #### Get Latest Payments to x402 Server
 
-Retrieves the most recent payments made to a specific x402 server on Base network.
+Get Latest Payments to x402 Server. Uses the `Transfers` cube.
 
 ▶️ [Get Latest Payments to x402 Server](https://ide.bitquery.io/Latest-payment-to-specific-x402-server)
 
 #### Get Latest Payments to x402 Server on Solana
 
-Retrieves the most recent payments made to a specific x402 server on Solana network.
+Get Latest Payments to x402 Server on Solana. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [Get Latest Payments to x402 Server on Solana](https://ide.bitquery.io/Latest-Payment-to-specific-x402-server-taking-solana-payments)
 

--- a/docs/start/starter-queries.md
+++ b/docs/start/starter-queries.md
@@ -26,6 +26,12 @@ Every query below is saved in the [Bitquery IDE](https://ide.bitquery.io) and wa
 - [TRON](#tron)
 - [Robinhood Chain](#robinhood-chain)
 - [Bitcoin](#bitcoin)
+- [Litecoin](#litecoin)
+- [Bitcoin Cash](#bitcoin-cash)
+- [Dogecoin](#dogecoin)
+- [Dash](#dash)
+- [Zcash](#zcash)
+- [Bitcoin SV](#bitcoin-sv)
 - [Cardano](#cardano)
 - [Ripple](#ripple)
 - [Algorand](#algorand)
@@ -62,19 +68,19 @@ Every buy and sell made by one address. Replace the wallet in `Transaction: {Fro
 
 #### Address is Buyer or Seller V2
 
-Address is Buyer or Seller V2. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns gives you trades where the specified address is either as a buyer or a seller. This is achieved by utilizing the `any` filter, which acts as an OR condition to encompass both buyer and seller roles in the results. You can find the query [here
 
 ▶️ [Address is Buyer or Seller V2](https://ide.bitquery.io/Address-is-Buyer-or-Seller-V2)
 
 #### All events on fluid DEX VaultFactory
 
-All events on fluid DEX VaultFactory. Uses the `Events` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Get a comprehensive list of all events emitted by the Fluid DEX Vault Factory contract. This query aggregates event counts by signature to identify which events are most frequently emitted, helping you understand the contract's activity patterns.
 
 ▶️ [All events on fluid DEX VaultFactory](https://ide.bitquery.io/all-events-on-fluid-DEX-VaultFactory)
 
 #### Buys, Sells, BuyVolume, SellVolume, Makers, TotalTradedVolume, PriceinUSD for a eth pair
 
-Buys, Sells, BuyVolume, SellVolume, Makers, TotalTradedVolume, PriceinUSD for a eth pair. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+The query will fetch you the buys, sells, buy volume, sell volume and also the number of makers for a particular token just like how DEXScreener shows in its UI.
 
 ▶️ [Buys, Sells, BuyVolume, SellVolume, Makers, TotalTradedVolume, PriceinUSD for a eth pair](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-a-eth-pair)
 
@@ -86,13 +92,13 @@ Coin ticker api. Uses the `DEXTradeByTokens` cube. Change the token address in t
 
 #### Dex info
 
-Dex info. Uses the `DEXTradeByTokens` cube.
+Returns will fetch you a specific DEX stats for the selected network. You can test the query [here
 
 ▶️ [Dex info](https://ide.bitquery.io/dex-info)
 
 #### Dex markets
 
-Dex markets.
+Returns will fetch you all the DEXs info for the selected network. You can test the query [here
 
 ▶️ [Dex markets](https://ide.bitquery.io/dex-markets)
 
@@ -118,31 +124,31 @@ Token transfers for a wallet between two dates. Change `since` and `till`. Needs
 
 #### Array_intersect example for 2 addresses
 
-Array_intersect example for 2 addresses. Uses the `Transfers` cube. Needs the historical data add-on — see the comment at the top of the query.
+Find addresses that have interacted with multiple addresses from a given list. This query uses the `array_intersect` function to identify addresses that have sent or received funds to/from every address in your list.
 
 ▶️ [Array_intersect example for 2 addresses](https://ide.bitquery.io/array_intersect-example-for-2-addresses_2)
 
 #### Binance:hot wallet transfers with transaction fees
 
-Binance:hot wallet transfers with transaction fees. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Track wallet token transfers and get the fees paid for each by the address. `SenderFee` and `SenderFeeInUSD` fields in query are the transaction fees in ETH and transaction fees in USD respectively. You can test the query [here
 
 ▶️ [Binance:hot wallet transfers with transaction fees](https://ide.bitquery.io/binancehot-wallet-transfers-with-transaction-fees)
 
 #### Find earliest transfer to an account
 
-Find earliest transfer to an account. Uses the `Transfers` cube. Needs the historical data add-on — see the comment at the top of the query.
+Find the first transfer ever received by a specific wallet address. This is useful for wallet age analysis, first transaction tracking, and onboarding analytics.
 
 ▶️ [Find earliest transfer to an account](https://ide.bitquery.io/Copy-of-find-earliest-transfer-to-an-account)
 
 #### Get Contract Type in v2
 
-Get Contract Type in v2. Uses the `Transfers` cube.
+To determine the type of a contract and its details, we can use the Transfer API. By fetching the earliest transfer to the contract, we can get relevant details that indicate the contract type.
 
 ▶️ [Get Contract Type in v2](https://ide.bitquery.io/Get-Contract-Type-in-v2)
 
 #### Get Minted Address of the ICO Token
 
-Get Minted Address of the ICO Token. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+In most of the ICOs, the token is minted to a smart contract that contains various methods for distributing the token whenever the conditions set by project owners are satisfied.
 
 ▶️ [Get Minted Address of the ICO Token](https://ide.bitquery.io/Get-Minted-Address-of-the-ICO-Token)
 
@@ -160,7 +166,7 @@ Both sides of an address's transfer history in one result, using an OR filter. N
 
 #### Total txn fees paid by binance hot wallet in a day
 
-Total txn fees paid by binance hot wallet in a day. Uses the `Transfers` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Get the total fees (in Eth and USD) paid by a specific EVM account across all transfers. `SenderFee` and `SenderFeeInUSD` fields in query are the transaction fees in ETH and transaction fees in USD respectively. You can test the query [here
 
 ▶️ [Total txn fees paid by binance hot wallet in a day](https://ide.bitquery.io/total-txn-fees-paid-by-binance-hot-wallet-in-a-day)
 
@@ -198,7 +204,7 @@ This API provides a list of top holders along with relevant statistics for a giv
 
 #### Average Tip in terms of avg gas Fee
 
-Average Tip in terms of avg gas Fee. Uses the `TransactionBalances` cube.
+Compares average user tip to average total gas fee per block across the last 10 blocks. Test the query [here
 
 ▶️ [Average Tip in terms of avg gas Fee](https://ide.bitquery.io/Average-Tip-in-terms-of-avg-gas-Fee_4)
 
@@ -266,13 +272,13 @@ Use this API to get historical price and volume for a specific token pair addres
 
 #### Ohlc of a token pair 1 hour interval
 
-Ohlc of a token pair 1 hour interval. Uses the `Pairs` cube.
+Returns fetches the Open, High, Low, and Close (OHLC) price data (USD-quoted) for a given token pair across DEXs, using a specified quote token and time interval (in seconds).
 
 ▶️ [Ohlc of a token pair 1 hour interval](https://ide.bitquery.io/ohlc-of-a-token-pair-1-hour-interval)
 
 #### Pepe historical ohlcv 30days
 
-Pepe historical ohlcv 30days. Uses the `Tokens` cube.
+Fetch hourly OHLCV candles for the past 30 days. Change `Duration` for different intervals, such as 60 (1 minute) or 300 (5 minutes).
 
 ▶️ [Pepe historical ohlcv 30days](https://ide.bitquery.io/pepe-historical-ohlcv-30days)
 
@@ -284,7 +290,7 @@ Price change 5min, 1hr, 6hr precentage of a specific token. Uses the `DEXTradeBy
 
 #### Price of a token in realtime
 
-Price of a token in realtime. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Returns will give you the latest Price of a specified token using DEXTrades API. Here we have calculated the price of a token in USD and also against the sell currency. Here is the [saved query link
 
 ▶️ [Price of a token in realtime](https://ide.bitquery.io/Price-of-a-token-in-realtime)
 
@@ -304,19 +310,19 @@ Live supply for the two largest stablecoins; swap the addresses for any other to
 
 #### Get Token Total Supply and Market Cap
 
-Get Token Total Supply and Market Cap. Uses the `TransactionBalances` cube.
+Retrieve the total supply and market capitalization of a specific ERC-20 token. This query provides on-chain market cap data. Try the API [here
 
 ▶️ [Get Token Total Supply and Market Cap](https://ide.bitquery.io/Get-Token-Total-Supply-and-Market-Cap)
 
 #### Latest token supply on USDT and USDC on ethereum chain
 
-Latest token supply on USDT and USDC on ethereum chain. Uses the `TransactionBalances` cube.
+Get the current total supply for specific tokens like USDC and USDT on Ethereum or any EVM network. This is ideal for stablecoin tracking and portfolio applications.
 
 ▶️ [Latest token supply on USDT and USDC on ethereum chain](https://ide.bitquery.io/latest-token-supply-on-USDT-and-USDC-on-ethereum-chain)
 
 #### Pepe volume marketcap
 
-Pepe volume marketcap. Uses the `Tokens` cube.
+Returns provides the latest trade volume for the past one hour along with the latest market cap.
 
 ▶️ [Pepe volume marketcap](https://ide.bitquery.io/pepe-volume-marketcap)
 
@@ -328,7 +334,7 @@ Ethereum tokens ranked by market capitalisation.
 
 #### Total Supply and onchain Marketcap of a specific token
 
-Total Supply and onchain Marketcap of a specific token. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+This API gives you latest Supply and Marketcap of a token on EVM (here as example we have taken BITGET Token `0x54D2252757e1672EEaD234D27B1270728fF90581` ). Try it out [here
 
 ▶️ [Total Supply and onchain Marketcap of a specific token](https://ide.bitquery.io/Total-Supply-and-onchain-Marketcap-of-a-specific-token)
 
@@ -360,31 +366,31 @@ Every call to one function with its arguments decoded. Change the method name to
 
 #### BlackRock USD Institutional Digital Liquidity Fund Latest Issuance
 
-BlackRock USD Institutional Digital Liquidity Fund Latest Issuance. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+You can use the same as a `subscription` to monitor issuances in real-time. You can run the query [here
 
 ▶️ [BlackRock USD Institutional Digital Liquidity Fund Latest Issuance](https://ide.bitquery.io/BlackRock-USD-Institutional-Digital-Liquidity-Fund-Latest-Issuance)
 
 #### Liquidiy of all token pools
 
-Liquidiy of all token pools. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+Returns returns current liquidity across all pools where a token appears as either `CurrencyA` or `CurrencyB`. It is useful when you want a token-wide liquidity view across multiple pools and DEXes.
 
 ▶️ [Liquidiy of all token pools](https://ide.bitquery.io/liquidiy-of-all-token-pools_1)
 
 #### Top liquidity pools of atoken on ethereum
 
-Top liquidity pools of atoken on ethereum. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+Returns separates results by whether shiba inu is listed as the first token (`CurrencyA`) or the second token (`CurrencyB`) in the DEX pool, returning the 10 pools with the highest liquidity for each category.
 
 ▶️ [Top liquidity pools of atoken on ethereum](https://ide.bitquery.io/top-liquidity-pools-of-atoken-on-ethereum)
 
 #### Top liquidity pools on Ethereum
 
-Top liquidity pools on Ethereum. Uses the `DEXPoolEvents` cube.
+You can run and modify this query in the [IDE example
 
 ▶️ [Top liquidity pools on Ethereum](https://ide.bitquery.io/top-liquidity-pools-on-Ethereum)
 
 #### Latest Liquidity Changes of a Specific Pool
 
-Latest Liquidity Changes of a Specific Pool. Uses the `DEXPoolEvents` cube.
+Returns retrieves the latest liquidity events for a specific DEX pool on Ethereum. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
 
 ▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_5)
 
@@ -410,13 +416,13 @@ Converts transaction value to USD at the time it was mined.
 
 #### Debug traceTransaction
 
-Debug traceTransaction. Uses the `Calls` cube.
+To trace a transaction using the debug_traceTransaction we need the `transaction hash`. We are using [this
 
 ▶️ [Debug traceTransaction](https://ide.bitquery.io/debug_traceTransaction)
 
 #### Eth getBlockReceipt
 
-Eth getBlockReceipt. Uses the `Transactions` cube.
+In this section we will build an API that serves as an alternative to the eth_getBlockReceipts JSON RPC method that takes `Block Number` as an input and returns all transaction receipts for the given block.
 
 ▶️ [Eth getBlockReceipt](https://ide.bitquery.io/eth_getBlockReceipt)
 
@@ -428,7 +434,7 @@ Eth getTransactionByHash. Uses the `Transactions` cube.
 
 #### Eth getTransactionReceipt
 
-Eth getTransactionReceipt. Uses the `Transactions` cube.
+In this section, we will build an alternative to the eth_getTransactionReceipt JSON RPC method using the Bitquery APIs. The method is used to provide the receipt of a transaction given `transaction hash`.
 
 ▶️ [Eth getTransactionReceipt](https://ide.bitquery.io/eth_getTransactionReceipt_1)
 
@@ -454,13 +460,13 @@ Decoded event logs as they land. Filter by contract or by event name.
 
 #### All aave v3 events latest
 
-All aave v3 events latest. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+The query below shows latest 10 events emitted by the AAVE V3 contract. The `Log` field in the results will contain information about the event, including its signature, smart contract address, and transaction hash.
 
 ▶️ [All aave v3 events latest](https://ide.bitquery.io/All-aave-v3-events-latest)
 
 #### ByteCode of A Token
 
-ByteCode of A Token. Uses the `Calls` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns will return the most recent transaction that created the token contract. The `Output` field of the Call object in the transaction contains the encoded bytecode of the contract.
 
 ▶️ [ByteCode of A Token](https://ide.bitquery.io/ByteCode-of-A-Token)
 
@@ -472,19 +478,19 @@ Returns which address created a given contract, and when. Needs the historical d
 
 #### Debug_traceCall
 
-Debug_traceCall. Uses the `Calls` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+In this section, we will discuss how we can use Bitquery APIs as an alternative to the debug_traceCall JSON RPC method, which runs an eth_call within the context of the given block execution using the final state of parent block as the base.
 
 ▶️ [Debug_traceCall](https://ide.bitquery.io/debug_traceCall)
 
 #### ETH/BSC SC creates count over date
 
-ETH/BSC SC creates count over date. Uses the `Calls` cube. Needs the historical data add-on — see the comment at the top of the query.
+Returns below, will return the number of new smart contracts created on the Ethereum and Binance Smart Chain networks since a particular date. It will also return the date of each day on which new smart contracts were created. You can find the query [here
 
 ▶️ [ETH/BSC SC creates count over date](https://ide.bitquery.io/ETHBSC-SC-creates-count-over-date)
 
 #### Eth getLogs with filters
 
-Eth getLogs with filters. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Now, just like the orignal eth_getLogs method, Bitquery APIs provides the option to filter out the `Logs` based on the following parameeters.
 
 ▶️ [Eth getLogs with filters](https://ide.bitquery.io/eth_getLogs-with-filters)
 
@@ -492,13 +498,13 @@ Eth getLogs with filters. Uses the `Events` cube. Replace the address in the `wh
 
 #### Get next available nonce
 
-Get next available nonce. Uses the `Transactions` cube.
+Returns helps you determine the next available nonce for an Ethereum account by getting the latest transaction in the mempool (broadcasted transactions). The returned nonce is the highest nonce used by the account in the mempool.
 
 ▶️ [Get next available nonce](https://ide.bitquery.io/get-next-available-nonce)
 
 #### Simulating Pending Transactions
 
-Simulating Pending Transactions.
+Returns retrieves information about in-flight transactions, helping you simulate the most recent state. It is a way to see if they will succeed without sending them on-chain.
 
 ▶️ [Simulating Pending Transactions](https://ide.bitquery.io/Simulating-Pending-Transactions_1)
 
@@ -506,37 +512,37 @@ Simulating Pending Transactions.
 
 #### Aggregate Self-Destruct Statistics
 
-Aggregate Self-Destruct Statistics. Uses the `TransactionBalances` cube.
+Calculate total ETH destroyed or received from self-destructs using aggregation functions: Try the API [here
 
 ▶️ [Aggregate Self-Destruct Statistics](https://ide.bitquery.io/Aggregate-Self-Destruct-Statistics)
 
 #### QuasarBuilder MEV Payout Transaction Balance
 
-QuasarBuilder MEV Payout Transaction Balance. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+Returns focuses on a block builder address and returns the most recent payouts, including the token metadata, pre/post balances, and USD valuations, so you can quickly see how large each MEV reward was.
 
 ▶️ [QuasarBuilder MEV Payout Transaction Balance](https://ide.bitquery.io/QuasarBuilder-MEV-Payout-Transaction-Balance)
 
 #### Self-Destruct Balance Decrease API
 
-Self-Destruct Balance Decrease API. Uses the `TransactionBalances` cube.
+Monitor contract balance decrease when contracts are self-destructing. [Run Query
 
 ▶️ [Self-Destruct Balance Decrease API](https://ide.bitquery.io/Self-Destruct-Balance-Decrease-API)
 
 #### Self-Destruct Balance Increase API
 
-Self-Destruct Balance Increase API. Uses the `TransactionBalances` cube.
+Monitor contract balance increase when contracts are self-destructing. [Run query
 
 ▶️ [Self-Destruct Balance Increase API](https://ide.bitquery.io/Self-Destruct-Balance-Increase-API)
 
 #### Top validators by total tips in last 24 hrs
 
-Top validators by total tips in last 24 hrs. Uses the `TransactionBalances` cube.
+Ranks validators by cumulative priority fees (reason code 5) received in the last 24 hours. Test the query [here
 
 ▶️ [Top validators by total tips in last 24 hrs](https://ide.bitquery.io/top-validators-by-total-tips-in-last-24-hrs)
 
 #### Total tips received by a validator in last 24 hrs
 
-Total tips received by a validator in last 24 hrs. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+Returns the total priority fees (native and USD) earned by a specific validator over the last 24 hours. Test the query [here
 
 ▶️ [Total tips received by a validator in last 24 hrs](https://ide.bitquery.io/total-tips-received-by-a-validator-in-last-24-hrs)
 
@@ -550,19 +556,19 @@ Per-trade slippage for one v3 pool, to size orders before sending them.
 
 #### All Pool_Ids for currency
 
-All Pool_Ids for currency. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+These swaps use the chain-specific DEXTrades cube via `EVM { DEXTrades }`: `Trade.PoolId`, pool-relative Buy/Sell (DEXTrades cube). USD can be thin on small pools—use live swaps above when you want the Trading row shape.
 
 ▶️ [All Pool_Ids for currency](https://ide.bitquery.io/All-Pool_Ids-for-currency)
 
 #### Fee collection on Uniswap v3 Positions
 
-Fee collection on Uniswap v3 Positions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+It returns decoded arguments—including the Uniswap position `tokenId`, the `recipient` address, and the collected `amount0` and `amount1` values (raw integer amounts).
 
 ▶️ [Fee collection on Uniswap v3 Positions](https://ide.bitquery.io/Fee-collection-on-Uniswap-v3-Positions)
 
 #### Latest ModifyLiquidity Events on Uniswap v4
 
-Latest ModifyLiquidity Events on Uniswap v4. Uses the `Events` cube. Change the token address in the `where` clause to use it.
+Track the most recent liquidity modifications on Uniswap V4 by querying `ModifyLiquidity` events from the PoolManager contract.
 
 ▶️ [Latest ModifyLiquidity Events on Uniswap v4](https://ide.bitquery.io/Latest-ModifyLiquidity-Events-on-Uniswap-v4)
 
@@ -574,7 +580,7 @@ Trades for one Uniswap pair. Replace the pair address.
 
 #### Latest liquidity for a currency pair across all v4 pools
 
-Latest liquidity for a currency pair across all v4 pools. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+This API endpoint provides latest liquidity event for every Uniswap V4 pool for a given currency pair. This info includes the Price of currencies in terms of other, Price of currencies in USD, Currency Details and `PoolIDs`.
 
 ▶️ [Latest liquidity for a currency pair across all v4 pools](https://ide.bitquery.io/latest-liquidity-for-a-currency-pair-across-all-v4-pools_1)
 
@@ -582,7 +588,7 @@ Latest liquidity for a currency pair across all v4 pools. Uses the `DEXPoolEvent
 
 #### Latest Trades on PancakeSwap V3 ETH
 
-Latest Trades on PancakeSwap V3 ETH. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
+The PancakSwap DEX Data is also available for view as a dashboard at DEXRABBIT
 
 ▶️ [Latest Trades on PancakeSwap V3 ETH](https://ide.bitquery.io/Latest-Trades-on-PancakeSwap-V3-ETH)
 
@@ -658,7 +664,7 @@ Get all trades related transactions (buy, sell) for a specific wallet address.
 
 #### Buys Sells BuyVolume SellVolume Makers TotalTradedVolume PriceinUSD for solana token pair
 
-Buys Sells BuyVolume SellVolume Makers TotalTradedVolume PriceinUSD for solana token pair. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns gives you the essential stats for a token such as buy volume, sell volume, total buys, total sells, makers, total trade volume, buyers, sellers (in last 5 min, 1 hour) of a specific token. You can run the query [here
 
 ▶️ [Buys Sells BuyVolume SellVolume Makers TotalTradedVolume PriceinUSD for solana token pair](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-solana-token-pair00_2)
 
@@ -690,37 +696,37 @@ Solana Historical Transfers.
 
 #### Currency with elon inclusion
 
-Currency with elon inclusion. Uses the `Transfers` cube.
+You can search tokens on Solana using names or symbols case insensitively also using our APIs and get prices and other details.
 
 ▶️ [Currency with elon inclusion](https://ide.bitquery.io/Currency-with-elon-inclusion)
 
 #### Solana token transfers of Bags fm tokens
 
-Solana token transfers of Bags fm tokens. Uses the `Transfers` cube.
+Track all transfers of Bags FM tokens across wallets. This Bags FM token transfers endpoint provides complete transfer history. 🔗 [Try Query
 
 ▶️ [Solana token transfers of Bags fm tokens](https://ide.bitquery.io/Solana-token-transfers-of-Bags-fm-tokens)
 
 #### Total txn fees paid by the Account
 
-Total txn fees paid by the Account. Uses the `Transfers` cube.
+Get the total fees (in SOL and USD) paid by a specific Solana account across all transfers. You can test the query [here
 
 ▶️ [Total txn fees paid by the Account](https://ide.bitquery.io/total-txn-fees-paid-by-the-Account)
 
 #### Transaction fees paid by Account aggregated by currency
 
-Transaction fees paid by Account aggregated by currency. Uses the `Transfers` cube.
+Get total fees paid by a Solana account for transferring each type of token. You can test the query [here
 
 ▶️ [Transaction fees paid by Account aggregated by currency](https://ide.bitquery.io/Transaction-fees-paid-by-Account-aggregated-by-currency)
 
 #### Transfers of a wallet
 
-Transfers of a wallet. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Returns fetches you the recent 10 transfers of a specific wallet address `9nnLbotNTcUhvbrsA6Mdkx45Sm82G35zo28AqUvjExn8`. Try the query [here
 
 ▶️ [Transfers of a wallet](https://ide.bitquery.io/Transfers-of-a-wallet_1)
 
 #### Wallet transfers with transaction fees paid
 
-Wallet transfers with transaction fees paid. Uses the `Transfers` cube.
+Track wallet token transfers and get the fees paid for each by the address. You can test the query [here
 
 ▶️ [Wallet transfers with transaction fees paid](https://ide.bitquery.io/wallet-transfers-with-transaction-fees-paid)
 
@@ -734,19 +740,19 @@ This query returns Solana balance update info for any balance update event, incl
 
 #### Balance updates
 
-Balance updates. Uses the `InstructionBalanceUpdates` cube.
+The query below gives you balance update associated with a instruction invocation.
 
 ▶️ [Balance updates](https://ide.bitquery.io/balance-updates)
 
 #### Solana balance updates executing burn instruction
 
-Solana balance updates executing burn instruction. Uses the `InstructionBalanceUpdates` cube. Replace the address in the `where` clause to use it.
+The query below uses the InstructionBalanceUpdates API to fetch balance updates that occur when token burn instructions execute.
 
 ▶️ [Solana balance updates executing burn instruction](https://ide.bitquery.io/solana-balance-updates-executing-burn-instruction)
 
 #### Trades of wallets with balance Updates in that trades
 
-Trades of wallets with balance Updates in that trades. Uses the `DEXTrades` cube.
+Returns will give you the trades of the wallets present in `addressList` along with the balance updates happened in those trades.. Try the query [here
 
 ▶️ [Trades of wallets with balance Updates in that trades](https://ide.bitquery.io/Trades-of-wallets-with-balance-Updates-in-that-trades)
 
@@ -796,19 +802,19 @@ ATH of multiple tokens quantile Solana. Uses the `DEXTradeByTokens` cube. Needs 
 
 #### ATH with price delta Solana
 
-ATH with price delta Solana. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Fetches a Solana token’s ATH price, ATH date, and price change percentages over the past 24h, 7d, and 30d using Bitquery Solana APIs. Try the [query to get ATH price, ATH date, price change
 
 ▶️ [ATH with price delta Solana](https://ide.bitquery.io/ATH-with-price-delta-Solana)
 
 #### AldrinAmm OHLC for specific pair
 
-AldrinAmm OHLC for specific pair. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+If you want to get OHLC data for any specific currency pair on AldrinAmm, you can use this api. Only use [this API
 
 ▶️ [AldrinAmm OHLC for specific pair](https://ide.bitquery.io/AldrinAmm-OHLC-for-specific-pair)
 
 #### Get Latest Price of Apple xStock in USD Real-time
 
-Get Latest Price of Apple xStock in USD Real-time. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+You can use the following query to get the latest price of a Apple xStock on Solana.
 
 ▶️ [Get Latest Price of Apple xStock in USD Real-time](https://ide.bitquery.io/Get-Latest-Price-of-Apple-xStock-in--USD-Real-time)
 
@@ -822,43 +828,43 @@ Bags.fm token creation using Solana token supply updates. Uses the `TokenSupplyU
 
 #### Market cap of token
 
-Market cap of token. Uses the `TokenSupplyUpdates` cube. Change the token address in the `where` clause to use it.
+You can fetch Marketcap of a token using below query.
 
 ▶️ [Market cap of token](https://ide.bitquery.io/market-cap-of-token_1)
 
 #### Marketcap of tokens
 
-Marketcap of tokens. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query.
+Returns returns the ATH (All-Time High) market cap, starting market cap, and related price metrics for multiple tokens. It calculates market cap using a 1 billion token supply and uses quantile to find the ATH price.
 
 ▶️ [Marketcap of tokens](https://ide.bitquery.io/Marketcap-of-tokens)
 
 #### Sandisk - Backpack Securities MCAP
 
-Sandisk - Backpack Securities MCAP. Uses the `Pairs` cube. Replace the address in the `where` clause to use it.
+See the Pairs cube for full field reference.
 
 ▶️ [Sandisk - Backpack Securities MCAP](https://ide.bitquery.io/Sandisk---Backpack-Securities-MCAP)
 
 #### Token burn example solana
 
-Token burn example solana. Uses the `TokenSupplyUpdates` cube.
+You can also track real-time token burn using the TokenSupplyUpdates API. Check out the [following example
 
 ▶️ [Token burn example solana](https://ide.bitquery.io/token-burn-example-solana)
 
 #### Token supply
 
-Token supply. Uses the `TokenSupplyUpdates` cube. Change the token address in the `where` clause to use it.
+Returns will return the latest token supply of a specific token. We are getting here supply for this `6D7NaB2xsLd7cauWu1wKk6KBsJohJmP2qZH9GEfVi5Ui` token `PostBalance` will give you the current supply for this token. Check the query [here
 
 ▶️ [Token supply](https://ide.bitquery.io/token-supply_2)
 
 #### Tokens with market cap range
 
-Tokens with market cap range. Uses the `TokenSupplyUpdates` cube.
+Lets say we need to get the tokens whose marketcap has crossed the `1M USD` mark but is less than `2M USD` for various reasons like automated trading. We can get the token details that have crossed a particular marketcap using [this
 
 ▶️ [Tokens with market cap range](https://ide.bitquery.io/tokens-with-market-cap-range)
 
 #### Top 10 marketcap jump tokens in last 1hr
 
-Top 10 marketcap jump tokens in last 1hr. Uses the `TokenSupplyUpdates` cube.
+Use below query to get top 10 marketcap jump tokens in last 1hr. Test the query [here
 
 ▶️ [Top 10 marketcap jump tokens in last 1hr](https://ide.bitquery.io/top-10-marketcap-jump-tokens-in-last-1hr)
 
@@ -870,7 +876,7 @@ Top Solana tokens based on market cap. Uses the `TokenSupplyUpdates` cube.
 
 #### Top Tokens by Market Cap on solana
 
-Top Tokens by Market Cap on solana. Uses the `Tokens` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Top Tokens by Market Cap on solana](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-solana)
 
@@ -902,25 +908,25 @@ This query retrieves the latest changes to liquidity pools on Solana, including 
 
 #### All liquidity add instructions track on Solana
 
-All liquidity add instructions track on Solana. Uses the `DEXPools` cube.
+Returns tracks liquidity addition events on Solana DEX pools by monitoring specific instructions.
 
 ▶️ [All liquidity add instructions track on Solana](https://ide.bitquery.io/All-liquidity-add-instructions-track-on-Solana)
 
 #### CPMM pools created
 
-CPMM pools created. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+The mint addresses for the tokens being used in the pool are listed for example `tokenMint1` and `tokenMint0` , indicating which tokens the CPMM will support.
 
 ▶️ [CPMM pools created](https://ide.bitquery.io/CPMM-pools-created_1)
 
 #### Get LP Latest liqudity on Solana
 
-Get LP Latest liqudity on Solana. Uses the `DEXPools` cube. Replace the address in the `where` clause to use it.
+Returns gets you the liquidity/balance of the Quote Currency `WSOL` and Base Currency `SOLANADOG` for this particular pool address `BDQnwNhTWc3wK4hhsnsEaBBMj3sD4idGzvuidVqUw1vL`.
 
 ▶️ [Get LP Latest liqudity on Solana](https://ide.bitquery.io/Get-LP-Latest-liqudity-on-Solana)
 
 #### Get all the liquidity pools info for a particular token
 
-Get all the liquidity pools info for a particular token. Uses the `DEXPools` cube. Change the token address in the `where` clause to use it.
+Returns will give you the information on all the liquidity pools of a particular token `EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm`. You can find the query [here
 
 ▶️ [Get all the liquidity pools info for a particular token](https://ide.bitquery.io/get-all-the-liquidity-pools-info-for-a-particular-token_1)
 
@@ -932,7 +938,7 @@ Liquidity change in recent month. Uses the `DEXTradeByTokens` cube. Needs the hi
 
 #### Liquidity lock using instructions balance update
 
-Liquidity lock using instructions balance update. Uses the `InstructionBalanceUpdates` cube. Replace the address in the `where` clause to use it.
+Using the below query, you can retrieve latest liquidity locks made using streamflow. Test the query [here
 
 ▶️ [Liquidity lock using instructions balance update](https://ide.bitquery.io/Liquidity-lock-using-instructions-balance-update)
 
@@ -940,13 +946,13 @@ Liquidity lock using instructions balance update. Uses the `InstructionBalanceUp
 
 #### Not Anchor Error Solana Logs
 
-Not Anchor Error Solana Logs. Uses the `Instructions` cube.
+To exclude instructions containing specific log phrases such as 'AnchorError' you can use the `notLike` filter.
 
 ▶️ [Not Anchor Error Solana Logs](https://ide.bitquery.io/Not-Anchor-Error-Solana-Logs)
 
 #### Solana Zeta Market logs
 
-Solana Zeta Market logs. Uses the `Instructions` cube.
+If you need to filter out the instructions from Solana logs that involve a particular exchange but you don’t have any information, like address and protocol, then you can use the “includes” keyword on Logs.
 
 ▶️ [Solana Zeta Market logs](https://ide.bitquery.io/Solana-Zeta-Market-logs)
 
@@ -972,19 +978,19 @@ Returns Bonding Curve Percentage of a Token on the Pump Fun.
 
 #### ATH Market Cap of Pump Fun Tokens in a Specific Timeframe
 
-ATH Market Cap of Pump Fun Tokens in a Specific Timeframe. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+Use Bitquery's `DEXTradeByTokens` with `dataset: combined`, `Trade.PriceInUSD(maximum: Trade_PriceInUSD)`, and `quantile(of: Trade_PriceInUSD, level: 0.98)` to get ATH price. Market cap = ATH price × 1 billion (Pump.fun tokens have 1B supply).
 
 ▶️ [ATH Market Cap of Pump Fun Tokens in a Specific Timeframe](https://ide.bitquery.io/ATH-Market-Cap-of-Pump-Fun-Tokens-in-a-Specific-Timeframe)
 
 #### All tokens traded on Pump.fun in the last 1 hour
 
-All tokens traded on Pump.fun in the last 1 hour. Uses the `Pairs` cube.
+To get all tokens traded on Pump.fun in the last 1 hour, use a query that filters trades by the Pump.fun protocol and a block time within the past hour.
 
 ▶️ [All tokens traded on Pump.fun in the last 1 hour](https://ide.bitquery.io/all-tokens-traded-on-Pumpfun-in-the-last-1-hour_1)
 
 #### How do I get tokens that reached a specific market cap on Pump.fun?
 
-How do I get tokens that reached a specific market cap on Pump.fun?. Uses the `Pairs` cube.
+To find tokens on Pump.fun that have reached a specific market capitalization threshold, you can use the following Bitquery GraphQL example.
 
 ▶️ [How do I get tokens that reached a specific market cap on Pump.fun?](https://ide.bitquery.io/How-do-I-get-tokens-that-reached-a-specific-market-cap-on-Pumpfun)
 
@@ -992,37 +998,37 @@ How do I get tokens that reached a specific market cap on Pump.fun?. Uses the `P
 
 #### Get the Top Traders of a specific Token on Meteora DAMM v2 DEX
 
-Get the Top Traders of a specific Token on Meteora DAMM v2 DEX. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns gets the Top Traders of the specified Token on Meteora DAMM v2. This provides insights into the most active traders and their trading patterns.
 
 ▶️ [Get the Top Traders of a specific Token on Meteora DAMM v2 DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DAMM-v2-DEX_1)
 
 #### Get the Top Traders of a specific Token on Meteora DLMM DEX
 
-Get the Top Traders of a specific Token on Meteora DLMM DEX. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns gets the Top Traders of the specified Token on Meteora DLMM. This provides insights into the most active traders and their trading patterns.
 
 ▶️ [Get the Top Traders of a specific Token on Meteora DLMM DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DLMM-DEX)
 
 #### Get the Top Traders of a specific Token on Meteora DYN DEX
 
-Get the Top Traders of a specific Token on Meteora DYN DEX. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns gets the Top Traders of the specified Token `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` on Meteora DYN.
 
 ▶️ [Get the Top Traders of a specific Token on Meteora DYN DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DYN-DEX)
 
 #### Meteora DAMM v2 OHLC API
 
-Meteora DAMM v2 OHLC API. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+If you want to get OHLC (Open, High, Low, Close) data for any specific currency pair on Meteora DAMM v2, you can use this API. This provides technical analysis data for charting and trading strategies.
 
 ▶️ [Meteora DAMM v2 OHLC API](https://ide.bitquery.io/Meteora-DAMM-v2-OHLC-API)
 
 #### Meteora DLMM OHLC API
 
-Meteora DLMM OHLC API. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+If you want to get OHLC (Open, High, Low, Close) data for any specific currency pair on Meteora DLMM, you can use this API. This provides technical analysis data for charting and trading strategies.
 
 ▶️ [Meteora DLMM OHLC API](https://ide.bitquery.io/Meteora-DLMM-OHLC-API)
 
 #### Meteora DYN OHLC API
 
-Meteora DYN OHLC API. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+If you want to get OHLC data for any specific currency pair on Meteora DYN, you can use this api. Only use [this API
 
 ▶️ [Meteora DYN OHLC API](https://ide.bitquery.io/Meteora-DYN-OHLC-API)
 
@@ -1068,13 +1074,13 @@ DecreaseLiquidityV2 latest raydium clmm. Uses the `Instructions` cube. Replace t
 
 #### Latest Price of a LetsBonk.fun Token on Launchpad
 
-Latest Price of a LetsBonk.fun Token on Launchpad. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns provides the most recent price data for a specific LetsBonk.fun token `token Mint Address` launched on Raydium Launchpad. You can filter by the token’s `MintAddress`, and the query will return the last recorded trade price.
 
 ▶️ [Latest Price of a LetsBonk.fun Token on Launchpad](https://ide.bitquery.io/Latest-Price-of-a-LetsBonkfun-Token-on-Launchpad)
 
 #### Latest Trades of a letsbonk.fun token on Launchpad
 
-Latest Trades of a letsbonk.fun token on Launchpad. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns fetches the most recent trades of a LetsBonk.fun Token `token Mint Address` on the Raydium Launchpad. Run the query: [Latest trades of a LetsBonk.fun token ➤
 
 ▶️ [Latest Trades of a letsbonk.fun token on Launchpad](https://ide.bitquery.io/Latest-Trades-of-a-letsbonkfun-token-on-Launchpad)
 
@@ -1132,37 +1138,37 @@ Get all trades by a particular trader.
 
 #### All dexs info on bsc
 
-All dexs info on bsc.
+Returns will fetch you all the DEXs info for the BSC network. You can test the query [here
 
 ▶️ [All dexs info on bsc](https://ide.bitquery.io/all-dexs-info-on-bsc)
 
 #### First 500 buyers of a specific BSC chain token
 
-First 500 buyers of a specific BSC chain token. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Below API gets you the first 500 buyers of a specific BSC token, here as example we have taken this token `0x031b41e504677879370e9DBcF937283A8691Fa7f`. Try the API [here
 
 ▶️ [First 500 buyers of a specific BSC chain token](https://ide.bitquery.io/first-500-buyers-of-a-specific-BSC-chain-token_2)
 
 #### Get all dex markets for a token
 
-Get all dex markets for a token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns will fetch you all the DEXs where a token is listed for the BSC network. You can test the query [here
 
 ▶️ [Get all dex markets for a token](https://ide.bitquery.io/get-all-dex-markets-for-a-token)
 
 #### Get all the DEXs on BSC network
 
-Get all the DEXs on BSC network.
+Returns retrieves all the DEXes operating on BSC network and gives info such as `ProtocolName` , `ProtocolVersion` and `ProtocolFamily`. Find the query [here
 
 ▶️ [Get all the DEXs on BSC network](https://ide.bitquery.io/Get-all-the-DEXs-on-BSC-network)
 
 #### Latest Flap.sh trades for a specific token
 
-Latest Flap.sh trades for a specific token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Get trading activity for a specific Flap.sh token using DEXTradeByTokens API.
 
 ▶️ [Latest Flap.sh trades for a specific token](https://ide.bitquery.io/Latest-Flapsh-trades-for-a-specific-token)
 
 #### Latest Flap.sh trades using DEXTrades API
 
-Latest Flap.sh trades using DEXTrades API. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Monitor all recent trades across Flap.sh tokens using the DEXTrades API.
 
 ▶️ [Latest Flap.sh trades using DEXTrades API](https://ide.bitquery.io/Latest-Flapsh-trades-using-DEXTrades-API)
 
@@ -1170,7 +1176,7 @@ Latest Flap.sh trades using DEXTrades API. Uses the `DEXTrades` cube. Change the
 
 #### Gra fun redeem transactions
 
-Gra fun redeem transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Retrieve all redeemed transactions using [this query
 
 ▶️ [Gra fun redeem transactions](https://ide.bitquery.io/Gra-fun-redeem-transactions)
 
@@ -1190,37 +1196,37 @@ Get token transactions ordered by block number in descending order.
 
 #### Check if an address interacted with predict.fun ever
 
-Check if an address interacted with predict.fun ever. Uses the `Transfers` cube.
+Predict.fun flows on BSC often show up as USDT (`0x55d398326f99059fF775485246999027B3197955`) transfers from the user's wallet to one of the protocol contract addresses listed below.
 
 ▶️ [Check if an address interacted with predict.fun ever](https://ide.bitquery.io/check-if-an-address-interacted-with-predictfun-ever)
 
 #### Check who created this meme rush token
 
-Check who created this meme rush token. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Fetches the developer address that created a specific Meme Rush token on BSC by tracing the minting transfer (from the zero address) of that token’s smart contract.
 
 ▶️ [Check who created this meme rush token](https://ide.bitquery.io/check-who-created-this-meme-rush-token)
 
 #### Check who created this token
 
-Check who created this token. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Fetches the developer address that created a specific Four.Meme token on BSC by tracing the minting transfer (from the zero address) of that token’s smart contract.
 
 ▶️ [Check who created this token](https://ide.bitquery.io/check-who-created-this-token)
 
 #### First transfers of a token
 
-First transfers of a token. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns retrieves the first transfer of a token to each address, providing the timestamp when each address first received the token.
 
 ▶️ [First transfers of a token](https://ide.bitquery.io/first-transfers-of-a-token_5)
 
 #### Meme rush tokens created by specific dev
 
-Meme rush tokens created by specific dev. Uses the `Transfers` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+This API fetches Binance Meme Rush tokens created by a specific dev on BSC by tracking token minting transfers signed by a particular dev. `Dev Address` here in example is `0xF4f3eb591c47d14614D3A54aCBA28019e2041066`.
 
 ▶️ [Meme rush tokens created by specific dev](https://ide.bitquery.io/meme-rush-tokens-created-by-specific-dev)
 
 #### New Flap.sh Tokens Created Using Transfers API
 
-New Flap.sh Tokens Created Using Transfers API. Uses the `Transfers` cube.
+Track newly created Flap.sh tokens by monitoring transfers from the zero address with token addresses ending in the vanity suffix.
 
 ▶️ [New Flap.sh Tokens Created Using Transfers API](https://ide.bitquery.io/New-Flapsh-Tokens-Created-Using-Transfers-API)
 
@@ -1232,7 +1238,7 @@ Sender OR Receiver Transfer Example BSC. Uses the `Transfers` cube. Replace the 
 
 #### Token created by specific dev
 
-Token created by specific dev. Uses the `Transfers` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+This API fetches Four.Meme tokens created by a specific dev on BSC by tracking token minting transfers signed by a particular dev. `Dev Address` here in example is `0x9c75588640605d46b42f2d64c5c2e993de251210`.
 
 ▶️ [Token created by specific dev](https://ide.bitquery.io/token-created-by-specific-dev)
 
@@ -1246,25 +1252,25 @@ Get latest BNB balance of an wallet.
 
 #### Average Tip in terms of avg gas Fee bsc
 
-Average Tip in terms of avg gas Fee bsc. Uses the `TransactionBalances` cube.
+Compares average user tip to average total gas fee per block across the last 10 blocks. Test the query [here
 
 ▶️ [Average Tip in terms of avg gas Fee bsc](https://ide.bitquery.io/Average-Tip-in-terms-of-avg-gas-Fee-bsc)
 
 #### Latest balance of an address for a specific token bsc
 
-Latest balance of an address for a specific token bsc. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+This API gives you latest balance of a specific address (here in example `0x238a358808379702088667322f80ac48bad5e6c4`) for a specific token (here we have taken example of USDC `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`). Try it out [here
 
 ▶️ [Latest balance of an address for a specific token bsc](https://ide.bitquery.io/Latest-balance-of-an-address-for-a-specific-token-bsc)
 
 #### Top 10 holders percentage
 
-Top 10 holders percentage. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+Calculates the percentage of total supply held by the top 10 holders of a specific Four Meme token on BSC.
 
 ▶️ [Top 10 holders percentage](https://ide.bitquery.io/top-10-holders-percentage)
 
 #### Track recent ephemeral contract patterns bsc
 
-Track recent ephemeral contract patterns bsc. Uses the `TransactionBalances` cube.
+Many MEV bots and arbitrage executors create contracts that are destroyed within the same transaction. These short-lived contracts are used for:
 
 ▶️ [Track recent ephemeral contract patterns bsc](https://ide.bitquery.io/Track-recent-ephemeral-contract-patterns-bsc)
 
@@ -1326,37 +1332,37 @@ This query gets you top 10 BSC Tokens by Price Change in last 1h.
 
 #### BSC OHLC API For Token Pair
 
-BSC OHLC API For Token Pair. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns will fetch you the OHLC of a token pair for the BSC network. You can test the query [here
 
 ▶️ [BSC OHLC API For Token Pair](https://ide.bitquery.io/BSC-OHLC-API-For-Token-Pair)
 
 #### Meme rush token ATH price
 
-Meme rush token ATH price. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Fetches the All-Time High (ATH) price of a specific Meme Rush token on BSC, using the `DEXTradeByTokens` dataset to calculate the 98th percentile of trade prices (approximate ATH).
 
 ▶️ [Meme rush token ATH price](https://ide.bitquery.io/meme-rush-token-ATH-price)
 
 #### Latest price of a token on bsc
 
-Latest price of a token on bsc. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns will fetch you latest trades for a token pair for the BSC network. You can test the query [here
 
 ▶️ [Latest price of a token on bsc](https://ide.bitquery.io/Latest-price-of-a-token-on-bsc)
 
 #### OHLCV data for specific Flap.sh token against BNB
 
-OHLCV data for specific Flap.sh token against BNB. Uses the `Pairs` cube.
+Get OHLCV data for Flap.sh tokens paired with BNB.
 
 ▶️ [OHLCV data for specific Flap.sh token against BNB](https://ide.bitquery.io/OHLCV-data-for-specific-Flapsh-token-against-BNB)
 
 #### OHLCV data for specific Flap.sh token in USD
 
-OHLCV data for specific Flap.sh token in USD. Uses the `Tokens` cube.
+Get OHLCV (Open, High, Low, Close, Volume) data for Flap.sh tokens quoted in USD.
 
 ▶️ [OHLCV data for specific Flap.sh token in USD](https://ide.bitquery.io/OHLCV-data-for-specific-Flapsh-token-in-USD)
 
 #### Percentage price change for a meme rush token
 
-Percentage price change for a meme rush token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Use the below query to get the price change in percentage for various time fields including `24 hours`, `1 hour` and `5 minutes`. Try it [here
 
 ▶️ [Percentage price change for a meme rush token](https://ide.bitquery.io/Percentage-price-change-for-a-meme-rush-token)
 
@@ -1370,13 +1376,13 @@ Get Total Supply and Marketcap of an ERC20 token.
 
 #### Top Tokens by Market Cap on bsc
 
-Top Tokens by Market Cap on bsc. Uses the `Tokens` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Top Tokens by Market Cap on bsc](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-bsc)
 
 #### Total Supply and onchain Marketcap of a specific token bsc
 
-Total Supply and onchain Marketcap of a specific token bsc. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+This API gives you latest Supply and Marketcap of a token on BSC (here as example we have taken a BEP-20 token `0x55d398326f99059ff775485246999027b3197955`). Try it out [here
 
 ▶️ [Total Supply and onchain Marketcap of a specific token bsc](https://ide.bitquery.io/Total-Supply-and-onchain-Marketcap-of-a-specific-token-bsc)
 
@@ -1390,7 +1396,7 @@ This query retrieves the latest slippage data for a specific DEX pool on BSC. Us
 
 #### Latest Liquidity Changes of a Specific Pool
 
-Latest Liquidity Changes of a Specific Pool. Uses the `DEXPoolEvents` cube.
+Returns retrieves the latest liquidity events for a specific DEX pool on BSC. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
 
 ▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_2)
 
@@ -1404,13 +1410,13 @@ Get transactions ordered by block number in descending order.
 
 #### Gra fun buy transactions
 
-Gra fun buy transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Retrieve all buy transactions from GRA.fun using [this query
 
 ▶️ [Gra fun buy transactions](https://ide.bitquery.io/Gra-fun-buy-transactions)
 
 #### Gra fun sell transactions
 
-Gra fun sell transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Retrieve all sell transactions on GRA fun using [this query
 
 ▶️ [Gra fun sell transactions](https://ide.bitquery.io/Gra-fun-sell-transactions)
 
@@ -1418,13 +1424,13 @@ Gra fun sell transactions. Uses the `Events` cube. Replace the address in the `w
 
 #### Latest Calls on BSC network
 
-Latest Calls on BSC network. Uses the `Calls` cube.
+Returns retrieves the latest successful smart contract calls on the BNB Smart Chain (BSC). It fetches details about contract interactions, transaction metadata, and associated block information.
 
 ▶️ [Latest Calls on BSC network](https://ide.bitquery.io/Latest-Calls-on-BSC-network)
 
 #### Latest flap.sh token created using events data
 
-Latest flap.sh token created using events data. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Monitor token creation events directly from the Flap.sh portal contract for more detailed information.
 
 ▶️ [Latest flap.sh token created using events data](https://ide.bitquery.io/Latest-flapsh-token-created-using-events-data_1)
 
@@ -1432,25 +1438,25 @@ Latest flap.sh token created using events data. Uses the `Events` cube. Replace 
 
 #### Aggregate Self-Destruct Statistics bsc
 
-Aggregate Self-Destruct Statistics bsc. Uses the `TransactionBalances` cube.
+Calculate total ETH destroyed or received from self-destructs using aggregation functions: Try the API [here
 
 ▶️ [Aggregate Self-Destruct Statistics bsc](https://ide.bitquery.io/Aggregate-Self-Destruct-Statistics-bsc)
 
 #### Self-Destruct Balance Decrease API bsc
 
-Self-Destruct Balance Decrease API bsc. Uses the `TransactionBalances` cube.
+Monitor contract balance decrease when contracts are self-destructing. [Run Query
 
 ▶️ [Self-Destruct Balance Decrease API bsc](https://ide.bitquery.io/Self-Destruct-Balance-Decrease-API-bsc)
 
 #### Self-Destruct Balance Increase API bsc
 
-Self-Destruct Balance Increase API bsc. Uses the `TransactionBalances` cube.
+Monitor contract balance increase when contracts are self-destructing. [Run query
 
 ▶️ [Self-Destruct Balance Increase API bsc](https://ide.bitquery.io/Self-Destruct-Balance-Increase-API-bsc)
 
 #### Top validators by total tips in last 24 hrs bsc
 
-Top validators by total tips in last 24 hrs bsc. Uses the `TransactionBalances` cube.
+Ranks validators by cumulative priority fees (reason code 5) received in the last 24 hours. Test the query [here
 
 ▶️ [Top validators by total tips in last 24 hrs bsc](https://ide.bitquery.io/top-validators-by-total-tips-in-last-24-hrs-bsc)
 
@@ -1462,7 +1468,7 @@ Historical Miner Balance Data bsc. Uses the `TransactionBalances` cube.
 
 #### Total tips received by a validator in last 24 hrs bsc
 
-Total tips received by a validator in last 24 hrs bsc. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+Returns the total priority fees (native and USD) earned by a specific validator over the last 24 hours. Test the query [here
 
 ▶️ [Total tips received by a validator in last 24 hrs bsc](https://ide.bitquery.io/total-tips-received-by-a-validator-in-last-24-hrs-bsc)
 
@@ -1500,7 +1506,7 @@ Bsc pancakeswap ohlc using trading api. Uses the `Pairs` cube.
 
 #### Get Latest Price of a token on PancakeSwap Infinity
 
-Get Latest Price of a token on PancakeSwap Infinity. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns will get you Latest Price of a token on PancakeSwap Infinity. Try out the API [here
 
 ▶️ [Get Latest Price of a token on PancakeSwap Infinity](https://ide.bitquery.io/Get-Latest-Price-of-a-token-on-PancakeSwap-Infinity_1)
 
@@ -1526,19 +1532,19 @@ Get the liquidity addition events for a specific token on the Four Meme Exchange
 
 #### Four meme - token ATH price
 
-Four meme - token ATH price. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Fetches the All-Time High (ATH) price of a specific Four.Meme token on BSC, using the `DEXTradeByTokens` dataset to calculate the 98th percentile of trade prices (approximate ATH). Try the API [here
 
 ▶️ [Four meme - token ATH price](https://ide.bitquery.io/four-meme---token-ATH-price)
 
 #### Get first buys of an address list of a specific token
 
-Get first buys of an address list of a specific token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns checks if the addresses from Query 1 ever bought the token and when. Pass the address array from Query 1 as a variable to this query.
 
 ▶️ [Get first buys of an address list of a specific token](https://ide.bitquery.io/get-first-buys-of-an-address-list-of-a-specific-token_2)
 
 #### If meme rush token migrated from four meme or not
 
-If meme rush token migrated from four meme or not. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+Returns will only show response if a the mentioned meme rush tokens have migrated to Pancakeswap. Note: Please use a `Block{Date}` filter to minimize the data processing and hence the query processing time and get fast responses. Try the query [here
 
 ▶️ [If meme rush token migrated from four meme or not](https://ide.bitquery.io/if-meme-rush-token-migrated-from-four-meme-or-not)
 
@@ -1552,7 +1558,7 @@ Get all trading pairs present on a BSC network DEX.
 
 #### Get metadata
 
-Get metadata. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Use the below query to get Token's metadata like `Name`, `symbol`, `SmartContract Address`, `Decimals`. Try out the API [here
 
 ▶️ [Get metadata](https://ide.bitquery.io/get-metadata_1)
 
@@ -1564,13 +1570,13 @@ Latest Trades for a currency pair on bsc. Uses the `DEXTrades` cube.
 
 #### OHLC on BSC Uniswap v3
 
-OHLC on BSC Uniswap v3. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns retrieves the Open, High, Low, and Close (OHLC) prices in USD for a specific token traded on Uniswap v3 over a defined time period and interval. You can try out the API [here
 
 ▶️ [OHLC on BSC Uniswap v3](https://ide.bitquery.io/OHLC-on-BSC-Uniswap-v3)
 
 #### Top bought tokens on bsc uniswap v3
 
-Top bought tokens on bsc uniswap v3. Uses the `DEXTradeByTokens` cube.
+Returns will fetch you the top bought tokens on uniswap v3. Try out the query [here
 
 ▶️ [Top bought tokens on bsc uniswap v3](https://ide.bitquery.io/top-bought-tokens-on-bsc-uniswap-v3)
 
@@ -1604,7 +1610,7 @@ Get all trades by a particular trader.
 
 #### First 500 buyers of a specific base token
 
-First 500 buyers of a specific base token. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Below API gets you the first 500 buyers of a specific Base chain token, here as example we have taken this token `0x58538e6A46E07434d7E7375Bc268D3cb839C0133`. Try the API [here
 
 ▶️ [First 500 buyers of a specific base token](https://ide.bitquery.io/first-500-buyers-of-a-specific-base-token)
 
@@ -1616,25 +1622,25 @@ Latest Trades of a Token on Zora Base. Uses the `DEXTrades` cube. Change the tok
 
 #### Latest Zora Trades on Base
 
-Latest Zora Trades on Base. Uses the `DEXTrades` cube.
+Returns fetches the latest DEX trades on the Zora protocol (`zora_v4`) on Base blockchain. Try out the API [here
 
 ▶️ [Latest Zora Trades on Base](https://ide.bitquery.io/Latest-Zora-Trades-on-Base)
 
 #### Most Traded Tokens on Aerodome Last Month
 
-Most Traded Tokens on Aerodome Last Month. Uses the `DEXTradeByTokens` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Discover the most actively traded tokens on Aerodrome Finance over any time period. This query analyzes all DEX trades within a specified timeframe and ranks tokens by trade count, helping you identify trending tokens and market activity patterns.
 
 ▶️ [Most Traded Tokens on Aerodome Last Month](https://ide.bitquery.io/Most-Traded-Tokens-on-Aerodome-Last-Month)
 
 #### Top Traders by PnL of a specific base pool
 
-Top Traders by PnL of a specific base pool. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Top Traders by PnL of a specific base pool](https://ide.bitquery.io/Top-Traders-by-PnL-of-a-specific-base-pool_1)
 
 #### Ape store token trades
 
-Ape store token trades. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
+MyQuery { EVM(network: base) { Calls( where: {Transaction: {To: {is: "0x0bf8edd756ff6caf3f583d67a9fd8b237e40f58a"}, From: {is: "0x2870cbffae4cf005dd1c3587e2f0db3cb00dbafd"}}, Call: {Signature: {Name: {is: "buy"}}}} ) { Arguments { Name Type Value { ...
 
 ▶️ [Ape store token trades](https://ide.bitquery.io/ape-store-token-trades)
 
@@ -1654,13 +1660,13 @@ Get token transactions ordered by block number in descending order.
 
 #### Newly created zora tokens
 
-Newly created zora tokens. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Returns retrieves the list of newly created tokens on Zora Launchpad by monitoring transfers where new tokens are minted (sender is the zero address) with a specific amount. Try out the API [here
 
 ▶️ [Newly created zora tokens](https://ide.bitquery.io/Newly-created-zora-tokens)
 
 #### Tx from to base address
 
-Tx from to base address. Uses the `Transfers` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+We use the `any` filter [ OR condition] to get transactions from or to a wallet.
 
 ▶️ [Tx from to base address](https://ide.bitquery.io/tx-from-to-base-address)
 
@@ -1704,25 +1710,25 @@ Get latest token balance of a wallet.
 
 #### Base balances address
 
-Base balances address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns token balances for a wallet address. Use `Amount(selectWhere: { gt: "0" })` to exclude zero balances.
 
 ▶️ [Base balances address](https://ide.bitquery.io/base-balances-address)
 
 #### Base native balances address
 
-Base native balances address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns the native ETH balance for a wallet on Base (not ERC-20 tokens). Filter with `Currency: { Native: true }` instead of a token contract address.
 
 ▶️ [Base native balances address](https://ide.bitquery.io/base-native-balances-address)
 
 #### Latest balance of an address for a specific token base
 
-Latest balance of an address for a specific token base. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+This API gives you latest balance of a specific address (here in example `0x238a358808379702088667322f80ac48bad5e6c4`) for a specific token (here we have taken example of USDC `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`). Try it out [here
 
 ▶️ [Latest balance of an address for a specific token base](https://ide.bitquery.io/Latest-balance-of-an-address-for-a-specific-token-base)
 
 #### Token holder snapshot base
 
-Token holder snapshot base. Uses the `Holders` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+The number of unique holders, token supply, and Gini coefficient for the balance amount before a specific timestamp can be derived using the query below. These stats provide a useful holder snapshot for any given time.
 
 ▶️ [Token holder snapshot base](https://ide.bitquery.io/token-holder-snapshot-base)
 
@@ -1786,7 +1792,7 @@ Retrieve the total supply and market capitalization of a specific token. This qu
 
 #### Top Tokens by Market Cap on Base
 
-Top Tokens by Market Cap on Base. Uses the `Tokens` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Top Tokens by Market Cap on Base](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-Base)
 
@@ -1804,7 +1810,7 @@ Bankr token latest marketcap OHLC. Uses the `Tokens` cube.
 
 #### Total Supply and onchain Marketcap of a specific token base
 
-Total Supply and onchain Marketcap of a specific token base. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+This API gives you latest Supply and Marketcap of a token on Base. Try it out [here
 
 ▶️ [Total Supply and onchain Marketcap of a specific token base](https://ide.bitquery.io/Total-Supply-and-onchain-Marketcap-of-a-specific-token-base)
 
@@ -1824,25 +1830,25 @@ This query retrieves the latest slippage data for a specific DEX pool on Base. U
 
 #### Latest Liquidity Changes of a Specific Pool
 
-Latest Liquidity Changes of a Specific Pool. Uses the `DEXPoolEvents` cube.
+Returns retrieves the latest liquidity events for a specific DEX pool on Base. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
 
 ▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_4)
 
 #### Latest Liquidity Pools on Aerodome
 
-Latest Liquidity Pools on Aerodome. Uses the `Events` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Track newly created liquidity pools on Aerodrome Finance in real-time. Discover fresh trading pairs and potential liquidity provision opportunities as pools are created.
 
 ▶️ [Latest Liquidity Pools on Aerodome](https://ide.bitquery.io/Latest-Liquidity-Pools-on-Aerodome)
 
 #### Top liquidity pools of cbBTC
 
-Top liquidity pools of cbBTC. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+Returns separates results by whether cbBTC is listed as the first token (`CurrencyA`) or the second token (`CurrencyB`) in the DEX pool, returning the 10 pools with the highest liquidity for each category.
 
 ▶️ [Top liquidity pools of cbBTC](https://ide.bitquery.io/top-liquidity-pools-of-cbBTC)
 
 #### Latest liquidity of a base pool
 
-Latest liquidity of a base pool. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+This API gives you latest liquidity of a Base Pool. Try it out [here
 
 ▶️ [Latest liquidity of a base pool](https://ide.bitquery.io/latest-liquidity-of-a-base-pool)
 
@@ -1856,19 +1862,19 @@ Get transactions ordered by block number in descending order.
 
 #### Latest gauge vaults claimRewards transactions
 
-Latest gauge vaults claimRewards transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Track when stakers claim accumulated AERO emissions from gauges. Use this to measure realized rewards and active participation across gauge vaults. `0xf5601f95708256a118ef5971820327f362442d2d` is the `Aerodrome : Gauge Implementation` contract.
 
 ▶️ [Latest gauge vaults claimRewards transactions](https://ide.bitquery.io/latest-gauge-vaults-claimRewards-transactions)
 
 #### Latest gauge vaults deposits transactions
 
-Latest gauge vaults deposits transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Monitor LP staking into gauge vaults. This shows recent `Deposit` events to a gauge contract, helping you track which pools are attracting liquidity ahead of weekly emissions.
 
 ▶️ [Latest gauge vaults deposits transactions](https://ide.bitquery.io/latest-gauge-vaults-deposits-transactions)
 
 #### Latest gauge vaults withdraw transactions
 
-Latest gauge vaults withdraw transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Observe LP exits from gauge vaults via `Withdraw` events. This helps you detect liquidity outflows and shifts in staking positions across pools. `0xf5601f95708256a118ef5971820327f362442d2d` is the `Aerodrome : Gauge Implementation` contract.
 
 ▶️ [Latest gauge vaults withdraw transactions](https://ide.bitquery.io/latest-gauge-vaults-withdraw-transactions_1)
 
@@ -1888,49 +1894,49 @@ Get Latest Events. Uses the `Events` cube.
 
 #### Latest Bankr launches Doppler Airlock Base
 
-Latest Bankr launches Doppler Airlock Base. Uses the `Events` cube.
+Every Bankr launch emits a `Create(address,address,address,address)` event on the Airlock contract. This query returns the most recent launches with the new token address and deployer.
 
 ▶️ [Latest Bankr launches Doppler Airlock Base](https://ide.bitquery.io/Latest-Bankr-launches-Doppler-Airlock-Base)
 
 #### All bankers tokens created by a deployer
 
-All bankers tokens created by a deployer. Uses the `Events` cube. Change the token address in the `where` clause to use it.
+Filter `Create` events on the Airlock by `Transaction.From` to list every Bankr token launched by a specific wallet. Replace the deployer address with the wallet you want to track.
 
 ▶️ [All bankers tokens created by a deployer](https://ide.bitquery.io/All-bankers-tokens-created-by-a-deployer)
 
 #### Ape store buys from a wallet
 
-Ape store buys from a wallet. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
+MyQuery { EVM(network: base) { Calls( where: {Transaction: {To: {is: "0x0bf8edd756ff6caf3f583d67a9fd8b237e40f58a"}}, Call: {Signature: {Name: {is: "buy"}}}} ) { Arguments { Name Type Value { ... on EVM_ABI_Integer_Value_Arg { integer } ...
 
 ▶️ [Ape store buys from a wallet](https://ide.bitquery.io/ape-store-buys-from-a-wallet)
 
 #### Ape store token event
 
-Ape store token event. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Firstly, we can find the smart contract address of the APE Store using [this
 
 ▶️ [Ape store token event](https://ide.bitquery.io/ape-store-token-event_1)
 
 #### Ape-store-buys
 
-Ape-store-buys. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
+MyQuery { EVM(network: base) { Calls( where: {Transaction: {To: {is: "0x0bf8edd756ff6caf3f583d67a9fd8b237e40f58a"}}} orderBy: {descendingByField: "count"} ) { Call { Signature { Name Signature } } count } } } ``` From the results we get a signature named…
 
 ▶️ [Ape-store-buys](https://ide.bitquery.io/ape-store-buys_1)
 
 #### Base jump token event
 
-Base jump token event. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Firstly, we can find the smart contract address of the Base Jump using [this
 
 ▶️ [Base jump token event](https://ide.bitquery.io/base-jump-token-event)
 
 #### Base-jump-buys
 
-Base-jump-buys. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
+MyQuery { EVM(network: base) { Calls( where: {Transaction: {To: {is: "0x31C0282Fa6D0A82aD22ab63BbaCd87F62B2a9bfD"}}} orderBy: {descendingByField: "count"} ) { Call { Signature { Name Signature } } count } } } ``` From the results we get a signature named…
 
 ▶️ [Base-jump-buys](https://ide.bitquery.io/base-jump-buys)
 
 #### Latest Coin on Base Coin
 
-Latest Coin on Base Coin. Uses the `Calls` cube.
+In the recent times, base network has seen rise of many Memecoins and token based ecosystems. In this guide, we will see some queries that could provide beneficial information about these coins, for people to take informed investment decisions.
 
 ▶️ [Latest Coin on Base Coin](https://ide.bitquery.io/Latest-Coin-on-Base-Coin_3)
 
@@ -1938,19 +1944,19 @@ Latest Coin on Base Coin. Uses the `Calls` cube.
 
 #### Aggregate Self Destruct Statistics base
 
-Aggregate Self Destruct Statistics base. Uses the `TransactionBalances` cube.
+Calculate total ETH destroyed or received from self-destructs using aggregation functions: Try the API [here
 
 ▶️ [Aggregate Self Destruct Statistics base](https://ide.bitquery.io/Aggregate-Self-Destruct-Statistics-base)
 
 #### Self Destruct Balance Decrease API base
 
-Self Destruct Balance Decrease API base. Uses the `TransactionBalances` cube.
+Monitor contract balance decrease when contracts are self-destructing. [Run Query
 
 ▶️ [Self Destruct Balance Decrease API base](https://ide.bitquery.io/Self-Destruct-Balance-Decrease-API-base)
 
 #### Self Destruct Balance Increase API base
 
-Self Destruct Balance Increase API base. Uses the `TransactionBalances` cube.
+Monitor contract balance increase when contracts are self-destructing. [Run query
 
 ▶️ [Self Destruct Balance Increase API base](https://ide.bitquery.io/Self-Destruct-Balance-Increase-API-base)
 
@@ -1964,31 +1970,31 @@ This subscription returns the real-time trades happening on Uniswap. You can mod
 
 #### Get metadata for base uniswap token
 
-Get metadata for base uniswap token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Use the below query to get Token's metadata like `Name`, `symbol`, `SmartContract Address`, `Decimals`. Try out the API [here
 
 ▶️ [Get metadata for base uniswap token](https://ide.bitquery.io/get-metadata-for-base-uniswap-token)
 
 #### Latest slippage of a pool on Uniswap v3
 
-Latest slippage of a pool on Uniswap v3. Change the token address in the `where` clause to use it.
+Returns retrieves the latest slippage data for a specific DEX pool on Arbitrum. Use this to check current liquidity depth and price impact for a particular token pair.
 
 ▶️ [Latest slippage of a pool on Uniswap v3](https://ide.bitquery.io/Latest-slippage-of-a-pool-on-Uniswap-v3)
 
 #### OHLC on BASE Uniswap v3
 
-OHLC on BASE Uniswap v3. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns retrieves the Open, High, Low, and Close (OHLC) prices in USD for a specific token traded on Uniswap v3 over a defined time period and interval. You can try out the API [here
 
 ▶️ [OHLC on BASE Uniswap v3](https://ide.bitquery.io/OHLC-on-BASE-Uniswap-v3)
 
 #### Top bought tokens on uniswap v3
 
-Top bought tokens on uniswap v3. Uses the `DEXTradeByTokens` cube.
+Returns will fetch you the top bought tokens on uniswap v3. Try out the query [here
 
 ▶️ [Top bought tokens on uniswap v3](https://ide.bitquery.io/top-bought-tokens-on-uniswap-v3)
 
 #### Top sold tokens on uniswap v3
 
-Top sold tokens on uniswap v3. Uses the `DEXTradeByTokens` cube.
+Returns will fetch you the top bought tokens on uniswap v3. Try out the query [here
 
 ▶️ [Top sold tokens on uniswap v3](https://ide.bitquery.io/top-sold-tokens-on-uniswap-v3)
 
@@ -1996,37 +2002,37 @@ Top sold tokens on uniswap v3. Uses the `DEXTradeByTokens` cube.
 
 #### Get Latest Price of a token on PancakeSwap Infinity
 
-Get Latest Price of a token on PancakeSwap Infinity. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns will get you Latest Price of a token on PancakeSwap Infinity. Try out the API [here
 
 ▶️ [Get Latest Price of a token on PancakeSwap Infinity](https://ide.bitquery.io/Get-Latest-Price-of-a-token-on-PancakeSwap-Infinity)
 
 #### Pancakeswap infinity trades
 
-Pancakeswap infinity trades. Uses the `DEXTrades` cube.
+Returns will subscribe you to the latest DEX Trades on PancakeSwap Infinity. Try out the API [here
 
 ▶️ [Pancakeswap infinity trades](https://ide.bitquery.io/pancakeswap-infinity-trades)
 
 #### Top bought tokens on pancakeswap_infinity
 
-Top bought tokens on pancakeswap_infinity. Uses the `DEXTradeByTokens` cube.
+Returns will fetch you the top bought tokens on PancakeSwap Infinity. Try out the query [here
 
 ▶️ [Top bought tokens on pancakeswap_infinity](https://ide.bitquery.io/top-bought-tokens-on-pancakeswap_infinity)
 
 #### Top sold tokens on pancake infinty
 
-Top sold tokens on pancake infinty. Uses the `DEXTradeByTokens` cube.
+Returns will fetch you the top bought tokens on PancakeSwap Infinity. Try out the query [here
 
 ▶️ [Top sold tokens on pancake infinty](https://ide.bitquery.io/top-sold-tokens-on-pancake-infinty)
 
 #### Get metadata for base pancakeswap infnity token
 
-Get metadata for base pancakeswap infnity token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Use the below query to get Token's metadata like `Name`, `symbol`, `SmartContract Address`, `Decimals`. Try out the API [here
 
 ▶️ [Get metadata for base pancakeswap infnity token](https://ide.bitquery.io/get-metadata-for-base-pancakeswap-infnity-token)
 
 #### OHLC on BASE pancakeswap infinity
 
-OHLC on BASE pancakeswap infinity. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns retrieves the Open, High, Low, and Close (OHLC) prices in USD for a specific token traded on PancakeSwap Infinity over a defined time period and interval. You can try out the API [here
 
 ▶️ [OHLC on BASE pancakeswap infinity](https://ide.bitquery.io/OHLC-on-BASE-pancakeswap-infinity)
 
@@ -2034,19 +2040,19 @@ OHLC on BASE pancakeswap infinity. Uses the `DEXTradeByTokens` cube. Change the 
 
 #### Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge claimRewards Transactions
 
-Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge claimRewards Transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+See reward claims for a particular gauge pool to quantify realized emissions by its stakers over time. `0x5d05ef25a5f933271e1f0fdc02dc3eab6a4ea687` is the `Aerodrome Finance CL100 WETHVVV Pool Gauge` contract.
 
 ▶️ [Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge claimRewards Transactions](https://ide.bitquery.io/latest-Aerodrome-Finance-CL100-WETHVVV-Pool-Gauge-claimRewards-Transactions)
 
 #### Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge deposits
 
-Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge deposits. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+View deposit activity for a specific gauge pool to understand where LPs are allocating capital and how staking momentum evolves. `0x5d05ef25a5f933271e1f0fdc02dc3eab6a4ea687` is the `Aerodrome Finance CL100 WETHVVV Pool Gauge` contract.
 
 ▶️ [Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge deposits](https://ide.bitquery.io/latest-Aerodrome-Finance-CL100-WETHVVV-Pool-Gauge-deposits)
 
 #### Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge withdraw transactions
 
-Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge withdraw transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Filter withdraw activity for a single gauge pool. Useful for monitoring liquidity changes and unstaking patterns of a targeted pool. `0x5d05ef25a5f933271e1f0fdc02dc3eab6a4ea687` is the `Aerodrome Finance CL100 WETHVVV Pool Gauge` contract.
 
 ▶️ [Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge withdraw transactions](https://ide.bitquery.io/latest-Aerodrome-Finance-CL100-WETHVVV-Pool-Gauge-withdraw-transactions_1)
 
@@ -2056,25 +2062,25 @@ Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge withdraw transactions. Uses 
 
 #### Pair last trades
 
-Pair last trades. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns retrieves all DEX trades on the arbitrum where the Arbitrum currency is `ArbitrumCurrency` and the quote currency is `quoteCurrency` that occurred between the specified dates. You can find the query [here
 
 ▶️ [Pair last trades](https://ide.bitquery.io/Pair-last-trades_2)
 
 #### Swap Events Arbitrum
 
-Swap Events Arbitrum. Uses the `Events` cube. Needs the historical data add-on — see the comment at the top of the query.
+The query returns the 10 most recent `swap` events on the Arbitrum network. We get this by using the signature hash `c42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67` for the swap event.
 
 ▶️ [Swap Events Arbitrum](https://ide.bitquery.io/Swap-Events-Arbitrum)
 
 #### Top Sold Tokens on Arbitrum
 
-Top Sold Tokens on Arbitrum. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
+Returns will give you top sold tokens on Arbitrum network in last 1 hour. Change the timestamp in `{Block: {Time: {since: "2024-12-24T08:20:00Z"}}}` accordingly. You can find the query [here
 
 ▶️ [Top Sold Tokens on Arbitrum](https://ide.bitquery.io/Top-Sold-Tokens-on-Arbitrum)
 
 #### Top bought tokens on Arbitrum
 
-Top bought tokens on Arbitrum. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
+Returns will give you top bought tokens on Arbitrum network in last 1 hour. Change the timestamp in `{Block: {Time: {since: "2024-12-24T08:20:00Z"}}}` accordingly. You can find the query [here
 
 ▶️ [Top bought tokens on Arbitrum](https://ide.bitquery.io/top-bought-tokens-on-Arbitrum)
 
@@ -2086,7 +2092,7 @@ Top traders for a token on Arbitrum. Uses the `DEXTradeByTokens` cube. Change th
 
 #### Trending token pairs on Arbitrum
 
-Trending token pairs on Arbitrum. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Crypto Trades API: one row per swap, with USD and supply. Filter `Pair.Market.Network: Arbitrum`. When to use this vs chain DEX APIs.
 
 ▶️ [Trending token pairs on Arbitrum](https://ide.bitquery.io/trending-token-pairs-on-Arbitrum)
 
@@ -2094,37 +2100,37 @@ Trending token pairs on Arbitrum. Uses the `DEXTradeByTokens` cube. Change the t
 
 #### Arbitrum Balance of an Address
 
-Arbitrum Balance of an Address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns token balances for a wallet address. Use `Amount(selectWhere: { gt: "0" })` to exclude zero balances.
 
 ▶️ [Arbitrum Balance of an Address](https://ide.bitquery.io/Arbitrum-Balance-of-an-Address)
 
 #### Arbitrum balances by date
 
-Arbitrum balances by date. Uses the `Balances` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+Use `Block.Date.till` for a point-in-time snapshot. Use `dataset: archive` for historical dates and addresses not recently active.
 
 ▶️ [Arbitrum balances by date](https://ide.bitquery.io/arbitrum-balances-by-date)
 
 #### Arbitrum balances history
 
-Arbitrum balances history. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+Returns balance snapshots over time for an address. Use `dataset: archive`. Order by `Block_Date` descending and use `limit` to paginate. Add `Currency.SmartContract` under `Currency` to filter by a specific token.
 
 ▶️ [Arbitrum balances history](https://ide.bitquery.io/arbitrum-balances-history)
 
 #### Arbitrum balances specific token
 
-Arbitrum balances specific token. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+Add a `Currency.SmartContract` filter. Always use the contract address, not the token name. Use `0x` for native ETH on Arbitrum, or the ERC-20 contract address for a token.
 
 ▶️ [Arbitrum balances specific token](https://ide.bitquery.io/arbitrum-balances-specific-token)
 
 #### Arbitrum native balances address
 
-Arbitrum native balances address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns the native ETH balance for a wallet on Arbitrum (not ERC-20 tokens). Filter with `Currency: { Native: true }` instead of a token contract address.
 
 ▶️ [Arbitrum native balances address](https://ide.bitquery.io/arbitrum-native-balances-address)
 
 #### Token holder snapshot arbitrum
 
-Token holder snapshot arbitrum. Uses the `Holders` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+The number of unique holders, token supply, and Gini coefficient for the balance amount before a specific timestamp can be derived using the query below. These stats provide a useful holder snapshot for any given time.
 
 ▶️ [Token holder snapshot arbitrum](https://ide.bitquery.io/token-holder-snapshot-arbitrum)
 
@@ -2152,7 +2158,7 @@ Top 10 arb tokens by price change in last 1 hr. Uses the `DEXTradeByTokens` cube
 
 #### Top Tokens by Market Cap on Arbitrum
 
-Top Tokens by Market Cap on Arbitrum. Uses the `Tokens` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Top Tokens by Market Cap on Arbitrum](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-Arbitrum)
 
@@ -2160,7 +2166,7 @@ Top Tokens by Market Cap on Arbitrum. Uses the `Tokens` cube.
 
 #### Latest liquidity changes of a specific pool
 
-Latest liquidity changes of a specific pool. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+Returns retrieves the latest liquidity events for a specific DEX pool on Arbitrum. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
 
 ▶️ [Latest liquidity changes of a specific pool](https://ide.bitquery.io/latest-liquidity-changes-of-a-specific-pool)
 
@@ -2168,13 +2174,13 @@ Latest liquidity changes of a specific pool. Uses the `DEXPoolEvents` cube. Chan
 
 #### Latest Transactions
 
-Latest Transactions. Uses the `Transactions` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+The query below retrieves the latest 10 transactions on the Arbitrum network. You can find the query [here
 
 ▶️ [Latest Transactions](https://ide.bitquery.io/Latest-Transactions_3)
 
 #### Transaction Call Trace Arbitrum
 
-Transaction Call Trace Arbitrum. Uses the `Calls` cube. Needs the historical data add-on — see the comment at the top of the query.
+Returns gets the transaction call trace for an Arbitrum transaction. The `Calls` API in the query returns a list of all calls made by the transaction. You can find the query [here
 
 ▶️ [Transaction Call Trace Arbitrum](https://ide.bitquery.io/Transaction-Call-Trace-Arbitrum)
 
@@ -2182,25 +2188,25 @@ Transaction Call Trace Arbitrum. Uses the `Calls` cube. Needs the historical dat
 
 #### Latest GMX Events
 
-Latest GMX Events. Uses the `Events` cube. Change the token address in the `where` clause to use it.
+Returns retrieves the latest liquidated positions on the GMX DEX, providing information on the account, collateral token, index token, position, reserve amount, realised PnL, and mark price.
 
 ▶️ [Latest GMX Events](https://ide.bitquery.io/latest-GMX-Events)
 
 #### Latest vGLP Withdraw Events
 
-Latest vGLP Withdraw Events. Uses the `Events` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns retrieves the latest vGLP withdrawals on the Arbitrum network:
 
 ▶️ [Latest vGLP Withdraw Events](https://ide.bitquery.io/latest-vGLP-Withdraw-Events)
 
 #### Latest deposits on Across Bridge
 
-Latest deposits on Across Bridge. Uses the `Events` cube. Change the token address in the `where` clause to use it.
+SpokePool events in Across Protocol can be used to monitor the status of bridge transfers effectively. Below are queries that retrieve the latest deposits and transfers related to the Arbitrum SpokePool.
 
 ▶️ [Latest deposits on Across Bridge](https://ide.bitquery.io/Latest-deposits-on-Across-Bridge)
 
 #### Latest vGLP Deposit Events
 
-Latest vGLP Deposit Events. Uses the `Events` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns retrieves the latest vGLP deposits on the Arbitrum network:
 
 ▶️ [Latest vGLP Deposit Events](https://ide.bitquery.io/latest-vGLP-Deposit-Events)
 
@@ -2208,7 +2214,7 @@ Latest vGLP Deposit Events. Uses the `Events` cube. Change the token address in 
 
 #### Latest Arbitrum blocks
 
-Latest Arbitrum blocks. Uses the `Blocks` cube.
+The query below retrieves the latest 10 blocks on the Arbitrum network. You can find the query [here
 
 ▶️ [Latest Arbitrum blocks](https://ide.bitquery.io/Latest-Arbitrum-blocks)
 
@@ -2256,7 +2262,7 @@ Top tokens on optimism. Uses the `DEXTradeByTokens` cube. Adjust the date range 
 
 #### Top traders for wld usdc pair
 
-Top traders for wld usdc pair. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+You can checkout a completed product using this info on DEXRabbit.
 
 ▶️ [Top traders for wld usdc pair](https://ide.bitquery.io/top-traders-for-wld-usdc-pair)
 
@@ -2270,37 +2276,37 @@ Top traders on optimism. Uses the `DEXTradeByTokens` cube. Adjust the date range
 
 #### Optimism Balance of an Address
 
-Optimism Balance of an Address. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+Returns token balances for a wallet address. Use `Amount(selectWhere: { gt: "0" })` to exclude zero balances.
 
 ▶️ [Optimism Balance of an Address](https://ide.bitquery.io/Optimism-Balance-of-an-Address)
 
 #### Optimism balances by date
 
-Optimism balances by date. Uses the `Balances` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+Use `Block.Date.till` for a point-in-time snapshot. Use `dataset: archive` for historical dates and addresses not recently active.
 
 ▶️ [Optimism balances by date](https://ide.bitquery.io/optimism-balances-by-date)
 
 #### Optimism balances history address
 
-Optimism balances history address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns balance snapshots over time for an address. Use `dataset: archive`. Order by `Block_Date` descending and use `limit` to paginate. Add `Currency.SmartContract` under `Currency` to filter by a specific token.
 
 ▶️ [Optimism balances history address](https://ide.bitquery.io/optimism-balances-history-address)
 
 #### Optimism balances specific token
 
-Optimism balances specific token. Uses the `Balances` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Add a `Currency.SmartContract` filter. Always use the contract address, not the token name. Use `0x` for native ETH on Optimism, or the ERC-20 contract address for a token.
 
 ▶️ [Optimism balances specific token](https://ide.bitquery.io/optimism-balances-specific-token)
 
 #### Optimism native balances address
 
-Optimism native balances address. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+Returns the native ETH balance for a wallet on Optimism (not ERC-20 tokens). Filter with `Currency: { Native: true }` instead of a token contract address.
 
 ▶️ [Optimism native balances address](https://ide.bitquery.io/optimism-native-balances-address)
 
 #### Token holder snapshot optimism
 
-Token holder snapshot optimism. Uses the `Holders` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+The number of unique holders, token supply, and Gini coefficient for the balance amount before a specific timestamp can be derived using the query below. These stats provide a useful holder snapshot for any given time.
 
 ▶️ [Token holder snapshot optimism](https://ide.bitquery.io/token-holder-snapshot-optimism)
 
@@ -2336,13 +2342,13 @@ Trade stats for a token pair on uniswap v4 optimism. Uses the `DEXTradeByTokens`
 
 #### Top Traders by PnL of a specific polygon pool
 
-Top Traders by PnL of a specific polygon pool. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Top Traders by PnL of a specific polygon pool](https://ide.bitquery.io/Top-Traders-by-PnL-of-a-specific-polygon-pool)
 
 #### Top traders of a token on matic
 
-Top traders of a token on matic. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns ranks traders of one token by volume, splitting bought and sold amounts and totalling volume in native and USD terms. `since_relative` keeps the window rolling.
 
 ▶️ [Top traders of a token on matic](https://ide.bitquery.io/top-traders-of-a-token-on-matic_1)
 
@@ -2350,7 +2356,7 @@ Top traders of a token on matic. Uses the `DEXTradeByTokens` cube. Change the to
 
 #### Check if an address interacted with polymarket ever
 
-Check if an address interacted with polymarket ever. Uses the `Transfers` cube. Needs the historical data add-on — see the comment at the top of the query.
+This is cheaper than scanning all `PredictionTrades` when you only need a yes/no signal. Narrow the pattern (e.g. also filter by counterparties) if you need stronger guarantees.
 
 ▶️ [Check if an address interacted with polymarket ever](https://ide.bitquery.io/check-if-an-address-interacted-with-polymarket-ever)
 
@@ -2370,37 +2376,37 @@ Returns all token balances for a wallet on Polygon using `EVM.Balances` with `ne
 
 #### Matic balances address
 
-Matic balances address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns token balances for a wallet address. Use `Amount(selectWhere: { gt: "0" })` to exclude zero balances.
 
 ▶️ [Matic balances address](https://ide.bitquery.io/matic-balances-address)
 
 #### Matic balances history
 
-Matic balances history. Uses the `Balances` cube.
+Returns balance snapshots over time for an address. Use `dataset: archive`. Order by `Block_Date` descending and use `limit` to paginate. Add `Currency.SmartContract` under `Currency` to filter by a specific token.
 
 ▶️ [Matic balances history](https://ide.bitquery.io/matic-balances-history)
 
 #### Matic balances specific token
 
-Matic balances specific token. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+Add a `Currency.SmartContract` filter. Always use the contract address, not the token name. Use `0x` for native MATIC on Polygon, or the ERC-20 contract address for a token.
 
 ▶️ [Matic balances specific token](https://ide.bitquery.io/matic-balances-specific-token)
 
 #### Matic native balances address
 
-Matic native balances address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns the native MATIC balance for a wallet (not ERC-20 tokens). Filter with `Currency: { Native: true }` instead of a token contract address.
 
 ▶️ [Matic native balances address](https://ide.bitquery.io/matic-native-balances-address)
 
 #### Matic wallet balance token at date
 
-Matic wallet balance token at date. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+Get a wallet's balance for a specific token with `Balance.Address` and `Currency.SmartContract`. This example uses native MATIC (`SmartContract: "0x"`) with `dataset: combined`.
 
 ▶️ [Matic wallet balance token at date](https://ide.bitquery.io/matic-wallet-balance-token-at-date)
 
 #### Token holder snapshot matic
 
-Token holder snapshot matic. Uses the `Holders` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+The number of unique holders, token supply, and Gini coefficient for the balance amount before a specific timestamp can be derived using the query below. These stats provide a useful holder snapshot for any given time.
 
 ▶️ [Token holder snapshot matic](https://ide.bitquery.io/token-holder-snapshot-matic)
 
@@ -2408,7 +2414,7 @@ Token holder snapshot matic. Uses the `Holders` cube. Change the token address i
 
 #### Top Tokens by Market Cap on Polygon
 
-Top Tokens by Market Cap on Polygon. Uses the `Tokens` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Top Tokens by Market Cap on Polygon](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-Polygon_1)
 
@@ -2416,7 +2422,7 @@ Top Tokens by Market Cap on Polygon. Uses the `Tokens` cube.
 
 #### Latest Liquidity Changes of a Specific Pool
 
-Latest Liquidity Changes of a Specific Pool. Uses the `DEXPoolEvents` cube.
+Returns retrieves the latest liquidity events for a specific DEX pool on Matic. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
 
 ▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_6)
 
@@ -2430,31 +2436,31 @@ Get virtual pool address for a token on uniswap v4 matic. Uses the `DEXTradeByTo
 
 #### OHLCV on MATIC uniswap v3
 
-OHLCV on MATIC uniswap v3. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns retrieves the Open, High, Low, and Close (OHLC) prices in USD for a specific token traded on Uniswap v3 over a defined time period and interval. You can try out the API [here
 
 ▶️ [OHLCV on MATIC uniswap v3](https://ide.bitquery.io/OHLCV-on-MATIC-uniswap-v3)
 
 #### Top bought tokens on matic uniswap v3
 
-Top bought tokens on matic uniswap v3. Uses the `DEXTradeByTokens` cube.
+Returns will fetch you the top bought tokens on uniswap v3. Try out the query [here
 
 ▶️ [Top bought tokens on matic uniswap v3](https://ide.bitquery.io/top-bought-tokens-on-matic-uniswap-v3_4)
 
 #### Top sold tokens on matic uniswap v3
 
-Top sold tokens on matic uniswap v3. Uses the `DEXTradeByTokens` cube.
+Returns will fetch you the top bought tokens on uniswap v3. Try out the query [here
 
 ▶️ [Top sold tokens on matic uniswap v3](https://ide.bitquery.io/top-sold-tokens-on-matic-uniswap-v3)
 
 #### Top traders of a token on uniswapv3 matic
 
-Top traders of a token on uniswapv3 matic. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns will fetch you top traders of a token for the selected network. You can test the query [here
 
 ▶️ [Top traders of a token on uniswapv3 matic](https://ide.bitquery.io/top-traders-of-a-token-on-uniswapv3-matic)
 
 #### Trade volume matic uniswapv3
 
-Trade volume matic uniswapv3. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns fetches you the traded volume, buy volume and sell volume of a token `0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270`. Try out the API [here
 
 ▶️ [Trade volume matic uniswapv3](https://ide.bitquery.io/trade_volume_matic_uniswapv3)
 
@@ -2488,37 +2494,37 @@ This query returns the latest token trades on the TRON network.
 
 #### All dexs info
 
-All dexs info.
+Returns fetches you all the DEXs information on Tron network such as unique sellers, unique buyers etc. You can try the query [here
 
 ▶️ [All dexs info](https://ide.bitquery.io/all-dexs-info)
 
 #### DEX Markets for a token
 
-DEX Markets for a token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns fetches you the DEXs where a specific token is being traded on Tron network. You can try the query [here
 
 ▶️ [DEX Markets for a token](https://ide.bitquery.io/DEX-Markets-for-a-token_1)
 
 #### First 100 buyers tron token
 
-First 100 buyers tron token. Uses the `DEXTradeByTokens` cube.
+Find the earliest buyers of any Tron token by using Tron `DEXTradeByTokens` API. This is widely used for memecoin sniper detection, early-holder analysis, and alpha groups monitoring SunPump / SunSwap launches.
 
 ▶️ [First 100 buyers tron token](https://ide.bitquery.io/first-100-buyers-tron-token)
 
 #### Peg health tron
 
-Peg health tron. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Browse multi-chain stablecoin DEX prices on DEXrabbit's Stablecoins category.
 
 ▶️ [Peg health tron](https://ide.bitquery.io/peg-health-tron)
 
 #### Sunmpump launchtoDEX
 
-Sunmpump launchtoDEX. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
+Returns allows you to track when tokens are launched on SunSwap using the `launchToDEX` function. It returns the most recent 10 token launches, displaying details such as the token address, transaction hash, block timestamp, and the method call signature.
 
 ▶️ [Sunmpump launchtoDEX](https://ide.bitquery.io/sunmpump-launchtoDEX_1)
 
 #### Sunswap v2 latest Trades
 
-Sunswap v2 latest Trades. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
+The query retrieves details about each trade, including the amounts and prices of tokens bought and sold, as well as information about the trading pair. You can find the query [here
 
 ▶️ [Sunswap v2 latest Trades](https://ide.bitquery.io/sunswap-v2-latest-Trades)
 
@@ -2538,37 +2544,37 @@ This query returns the most recent transfers on the TRON network and includes de
 
 #### Daily transfer volume tron
 
-Daily transfer volume tron. Uses the `Transfers` cube. Adjust the date range in the `where` clause.
+Aggregate daily transfer volume in USD for any TRC20 token for analytics dashboards, weekly newsletters, and on-chain reports for stablecoins, governance tokens, and memecoins on Tron.
 
 ▶️ [Daily transfer volume tron](https://ide.bitquery.io/daily-transfer-volume-tron)
 
 #### Top transfers of a token
 
-Top transfers of a token. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+Returns retrieves the top 10 transfers by amount of the token `TXL6rJbvmjD46zeN1JssfgxvSo99qC8MRT`. Try the query [here
 
 ▶️ [Top transfers of a token](https://ide.bitquery.io/top-transfers-of-a-token_2)
 
 #### Tron total txn fees paid by the Account
 
-Tron total txn fees paid by the Account. Uses the `Transfers` cube.
+Get the total fees (in SOL and USD) paid by a specific Tron account across all transfers. You can test the query [here
 
 ▶️ [Tron total txn fees paid by the Account](https://ide.bitquery.io/Tron-total-txn-fees-paid-by-the-Account)
 
 #### Transfers of a wallet API
 
-Transfers of a wallet API. Uses the `Transfers` cube.
+Returns fetches you the recent 10 transfers of a specific wallet address `TFXttAWURRrXrd9JvFPVLEh1esJK8NHxn7`. Try the query [here
 
 ▶️ [Transfers of a wallet API](https://ide.bitquery.io/Transfers-of-a-wallet-API)
 
 #### Tron Transaction fees paid by Account aggregated by currency
 
-Tron Transaction fees paid by Account aggregated by currency. Uses the `Transfers` cube.
+Get total fees paid by a Tron account for transferring each type of token. You can test the query [here
 
 ▶️ [Tron Transaction fees paid by Account aggregated by currency](https://ide.bitquery.io/Tron-Transaction-fees-paid-by-Account-aggregated-by-currency)
 
 #### Tron wallet transfers with transaction fees paid
 
-Tron wallet transfers with transaction fees paid. Uses the `Transfers` cube.
+Track wallet token transfers and get the fees paid for each by the address. You can test the query [here
 
 ▶️ [Tron wallet transfers with transaction fees paid](https://ide.bitquery.io/tron-wallet-transfers-with-transaction-fees-paid)
 
@@ -2582,49 +2588,49 @@ This query returns the current balance of a wallet for all currencies on the TRO
 
 #### Top token holders of a token
 
-Top token holders of a token. Uses the `Holders` cube. Needs the historical data add-on — see the comment at the top of the query.
+Returns the top holders of a token ranked by current balance. Use the Holders API with `orderBy` and `limit`.
 
 ▶️ [Top token holders of a token](https://ide.bitquery.io/top-token-holders-of-a-token)
 
 #### Tron Balances for Native currency
 
-Tron Balances for Native currency. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+Returns the native TRX balance for a wallet (not TRC10 or TRC20 tokens). Filter with `Currency: { Native: true }` instead of a token contract address.
 
 ▶️ [Tron Balances for Native currency](https://ide.bitquery.io/Tron-Balances-for-Native-currency)
 
 #### Tron USDT Balance At Date (Balances Cube)
 
-Tron USDT Balance At Date (Balances Cube). Uses the `Balances` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+Unlike summing Transfers, this includes mints, burns, and genesis supply.
 
 ▶️ [Tron USDT Balance At Date (Balances Cube)](https://ide.bitquery.io/tron-usdt-balance-at-date)
 
 #### Tron balances by date
 
-Tron balances by date. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+Returns balance snapshots over time for an address. Use `dataset: archive`. Order by `Block_Date` descending and use `limit` to paginate. Add `Currency.SmartContract` under `Currency` to filter by a specific token.
 
 ▶️ [Tron balances by date](https://ide.bitquery.io/tron-balances-by-date)
 
 #### Tron token balance
 
-Tron token balance. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+Add a `Currency.SmartContract` filter. Always use the contract address, not the token name.
 
 ▶️ [Tron token balance](https://ide.bitquery.io/tron-token-balance)
 
 #### TronWalletPortfolio Tron
 
-TronWalletPortfolio Tron. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+Returns balances for all the currecies owned by a wallet address. Use `Amount(selectWhere: { gt: "0" })` to exclude zero balances and `dataset: combined` for the latest balances.
 
 ▶️ [TronWalletPortfolio Tron](https://ide.bitquery.io/TronWalletPortfolio-Tron)
 
 #### SunPump Bonding Curve TRX Balance
 
-SunPump Bonding Curve TRX Balance. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+TRX balance in bonding curve based on dex trades. Calculated as `balance = in_sum - out_sum`
 
 ▶️ [SunPump Bonding Curve TRX Balance](https://ide.bitquery.io/SunPump-Bonding-Curve-TRX-Balance)
 
 #### SunPump Historical Bonding Curve TRX Balance
 
-SunPump Historical Bonding Curve TRX Balance. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Calculated as `balance = in_sum - out_sum`
 
 ▶️ [SunPump Historical Bonding Curve TRX Balance](https://ide.bitquery.io/SunPump-Historical-Bonding-Curve-TRX-Balance)
 
@@ -2632,7 +2638,7 @@ SunPump Historical Bonding Curve TRX Balance. Uses the `DEXTrades` cube. Change 
 
 #### Sun Pump Virtual Liquidity Pools
 
-Sun Pump Virtual Liquidity Pools. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Sun Pump does not use a dedicated pool for each pair; instead, all liquidity is managed within a single contract. You can query the virtual liquidity pools directly by running the following query
 
 ▶️ [Sun Pump Virtual Liquidity Pools](https://ide.bitquery.io/Sun-Pump-Virtual-Liquidity-Pools_1)
 
@@ -2640,19 +2646,19 @@ Sun Pump Virtual Liquidity Pools. Uses the `Balances` cube. Replace the address 
 
 #### Latest created Sunpump tokens
 
-Latest created Sunpump tokens. Uses the `Events` cube.
+If you remove `subscription` from the below GraphQL query it will become API, for example check [this api
 
 ▶️ [Latest created Sunpump tokens](https://ide.bitquery.io/latest-created-Sunpump-tokens)
 
 #### Latest tokens created on Sunpump
 
-Latest tokens created on Sunpump. Uses the `Events` cube.
+The `Arguments` include the token address, creator, and token index. You can run it [here
 
 ▶️ [Latest tokens created on Sunpump](https://ide.bitquery.io/Latest-tokens-created-on-Sunpump_2)
 
 #### TokenPurchased on Sunpump
 
-TokenPurchased on Sunpump. Uses the `Events` cube.
+Returns allows you to track `TokenPurchased` events on SunPump. It retrieves the 10 most recent token purchase events, showing important details such as the token address, buyer information, transaction hash, and token amount involved.
 
 ▶️ [TokenPurchased on Sunpump](https://ide.bitquery.io/TokenPurchased-on-Sunpump)
 
@@ -2668,31 +2674,31 @@ Largest Trades on Robinhood Chain (24h, USD). Uses the `Trades` cube.
 
 #### Pools trade Crowd Launch bids
 
-Pools trade Crowd Launch bids. Uses the `Events` cube.
+The launch transaction also contains the token's mint, the entry contract's `TokenCreated`, and the auction's first `TickInitialized` / `ClearingPriceUpdated` events, so one transaction hash links token, creator, and auction contract.
 
 ▶️ [Pools trade Crowd Launch bids](https://ide.bitquery.io/Pools-trade-Crowd-Launch-bids)
 
 #### Pools trade Latest launches
 
-Pools trade Latest launches. Uses the `Events` cube.
+The decoded `TokenCreated` event on the two entry contracts is the cleanest launch feed — one row per launch.
 
 ▶️ [Pools trade Latest launches](https://ide.bitquery.io/Pools-trade-Latest-launches)
 
 #### Pools trade Latest trades for a token
 
-Pools trade Latest trades for a token. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+Tokens also migrate onto other venues once liquid — the same token can show `uniswap_v3` and `pancake_swap_v3` markets with `WETH` and `USDG` quotes. :::
 
 ▶️ [Pools trade Latest trades for a token](https://ide.bitquery.io/Pools-trade-Latest-trades-for-a-token)
 
 #### Pools trade Launches per day
 
-Pools trade Launches per day. Uses the `Events` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+Grouping by `LogHeader.Address` too shows the split between the two entry contracts.
 
 ▶️ [Pools trade Launches per day](https://ide.bitquery.io/Pools-trade-Launches-per-day)
 
 #### Pools trade Most active token creators
 
-Pools trade Most active token creators. Uses the `Events` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+Useful for spotting spam-bot deployers — a single wallet can mint hundreds of tokens a day.
 
 ▶️ [Pools trade Most active token creators](https://ide.bitquery.io/Pools-trade-Most-active-token-creators)
 
@@ -2704,19 +2710,19 @@ Pools trade PoolKey from TokenLaunched. Uses the `Events` cube.
 
 #### Pools trade Token description and image
 
-Pools trade Token description and image. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+The filter below pins the factory by address because the entry contract emits a *different* `TokenCreated` under the same name (see Reading decoded arguments).
 
 ▶️ [Pools trade Token description and image](https://ide.bitquery.io/Pools-trade-Token-description-and-image)
 
 #### Pools trade TokenDistributed decoded event
 
-Pools trade TokenDistributed decoded event. Uses the `Events` cube.
+Topic0 filtering remains available and is the precise way to pin one exact signature — useful for the overloaded `TokenCreated` above. Supply the hash without a `0x` prefix; see the dataset note below for its one limitation.
 
 ▶️ [Pools trade TokenDistributed decoded event](https://ide.bitquery.io/Pools-trade-raw-event-by-topic0)
 
 #### Pools trade Top tokens by volume
 
-Pools trade Top tokens by volume. Uses the `Tokens` cube. Adjust the date range in the `where` clause.
+The two-step pattern: pass a token set harvested from `TokenCreated` into the `Trading` cube.
 
 ▶️ [Pools trade Top tokens by volume](https://ide.bitquery.io/Pools-trade-Top-tokens-by-volume)
 
@@ -2724,31 +2730,31 @@ Pools trade Top tokens by volume. Uses the `Tokens` cube. Adjust the date range 
 
 #### Ape.store Newly created tokens
 
-Ape.store Newly created tokens. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
 
 ▶️ [Ape.store Newly created tokens](https://ide.bitquery.io/Apestore-Newly-created-tokens)
 
 #### Bags.fm Newly created tokens
 
-Bags.fm Newly created tokens. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
 
 ▶️ [Bags.fm Newly created tokens](https://ide.bitquery.io/Bagsfm-Newly-created-tokens)
 
 #### Bankr Bot Newly created tokens
 
-Bankr Bot Newly created tokens. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
 
 ▶️ [Bankr Bot Newly created tokens](https://ide.bitquery.io/Bankr-Bot-Newly-created-tokens)
 
 #### Flap.sh Newly created tokens using transfer data
 
-Flap.sh Newly created tokens using transfer data. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Track Flap.sh mints as transfers from the zero address with amount `1000000000` in transactions sent to the Flap.sh contract.
 
 ▶️ [Flap.sh Newly created tokens using transfer data](https://ide.bitquery.io/Flapsh-Newly-created-tokens-using-transfer-data)
 
 #### Klik Finance Newly created tokens using transfers
 
-Klik Finance Newly created tokens using transfers. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
 
 ▶️ [Klik Finance Newly created tokens using transfers](https://ide.bitquery.io/Klik-Finance-Newly-created-tokens-using-transfers)
 
@@ -2760,25 +2766,25 @@ Robinhood Chain API - Latest Token Transfers. Uses the `Transfers` cube.
 
 #### Robinhood Chain Token Lookup by Contract Address
 
-Robinhood Chain Token Lookup by Contract Address. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Metadata splits across two sources. Name, symbol, decimals, and contract are indexed on every transfer's `Currency` object — one query against the launch mint gives you all four for any token:
 
 ▶️ [Robinhood Chain Token Lookup by Contract Address](https://ide.bitquery.io/Pools-trade-Token-name-symbol-decimals)
 
 #### Token Lookup by Contract Address - Robinhood Chain
 
-Token Lookup by Contract Address - Robinhood Chain. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Follow the steps here: How to generate Bitquery API token ➤ :::
 
 ▶️ [Token Lookup by Contract Address - Robinhood Chain](https://ide.bitquery.io/token-lookup-by-address-robinhood-chain)
 
 #### Transfers for a token on robinhood
 
-Transfers for a token on robinhood. Uses the `Transfers` cube.
+Filter with `Transfer.Currency.SmartContract`. Example: WETH on Robinhood.
 
 ▶️ [Transfers for a token on robinhood](https://ide.bitquery.io/Transfers-for-a-token-on-robinhood)
 
 #### Transfers for a wallet on Robinhood
 
-Transfers for a wallet on Robinhood. Uses the `Transfers` cube.
+Filter where the address is either `Transfer.Sender` or `Transfer.Receiver` to build a full transfer history. Replace the sample address with your wallet or contract.
 
 ▶️ [Transfers for a wallet on Robinhood](https://ide.bitquery.io/transfers-for-a-wallet-on-Robinhood)
 
@@ -2786,7 +2792,7 @@ Transfers for a wallet on Robinhood. Uses the `Transfers` cube.
 
 #### Pools trade Per-transaction balance changes
 
-Pools trade Per-transaction balance changes. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+A stream of this filtered to `SlippageBasisPoints: {gt: 100}` is a ready-made "toxic fill" alert for a token's pool.
 
 ▶️ [Pools trade Per-transaction balance changes](https://ide.bitquery.io/Pools-trade-Per-transaction-balance-changes)
 
@@ -2800,19 +2806,19 @@ Wallet Token Balances on Robinhood Chain. Uses the `Balances` cube. Replace the 
 
 #### Latest price of a token
 
-Latest price of a token. Uses the `Tokens` cube. Replace the address in the `where` clause to use it.
+If you want to monitor price for a particular pool, we suggest usage of `Trading.Pairs` instead of `Trading.Tokens` where you could specify the pool address. :::
 
 ▶️ [Latest price of a token](https://ide.bitquery.io/latest-price-of-a-token_10)
 
 #### Latest price of a token on a pool
 
-Latest price of a token on a pool. Uses the `Pairs` cube.
+This API endpoint retrieves the latest price of a token for a particular token pair or liquidity pool using the `Trading.Pairs` cube.
 
 ▶️ [Latest price of a token on a pool](https://ide.bitquery.io/latest-price-of-a-token-on-a-pool)
 
 #### Pools trade OHLCV price candles
 
-Pools trade OHLCV price candles. Uses the `Tokens` cube. Replace the address in the `where` clause to use it.
+Deduplicate on `(TransactionHeader.Hash, Block.Time, Side, Amounts.Base, Pair.QuoteToken.Symbol, Trader.Address)` before aggregating.
 
 ▶️ [Pools trade OHLCV price candles](https://ide.bitquery.io/Pools-trade-OHLCV-price-candles)
 
@@ -2834,7 +2840,7 @@ Pools trade Per-swap slippage.
 
 #### Pools trade Pool creation Initialize
 
-Pools trade Pool creation Initialize. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+The v4 PoolManager's `Initialize` is decoded, so you can read the same `PoolKey` without manual decoding — at the cost of having to scope it to a token.
 
 ▶️ [Pools trade Pool creation Initialize](https://ide.bitquery.io/Pools-trade-Pool-creation-Initialize)
 
@@ -2842,19 +2848,19 @@ Pools trade Pool creation Initialize. Uses the `Events` cube. Replace the addres
 
 #### Daily Active Wallets on Robinhood Chain
 
-Daily Active Wallets on Robinhood Chain. Uses the `Transactions` cube. Needs the historical data add-on — see the comment at the top of the query.
+Swap the filter to `Block: { Number: { eq: "…" } }` for every log in a block (the `eth_getBlockReceipts` logs, flattened).
 
 ▶️ [Daily Active Wallets on Robinhood Chain](https://ide.bitquery.io/robinhood-chain-active-wallets)
 
 #### Robinhood Chain Daily Transaction Count
 
-Robinhood Chain Daily Transaction Count. Uses the `Transactions` cube. Needs the historical data add-on — see the comment at the top of the query.
+Swap the filter to `Block: { Number: { eq: "…" } }` for every log in a block (the `eth_getBlockReceipts` logs, flattened).
 
 ▶️ [Robinhood Chain Daily Transaction Count](https://ide.bitquery.io/robinhood-chain-daily-transactions)
 
 #### Robinhood Chain Gas Usage and Gas Price
 
-Robinhood Chain Gas Usage and Gas Price. Uses the `Transactions` cube.
+Swap the filter to `Block: { Number: { eq: "…" } }` for every log in a block (the `eth_getBlockReceipts` logs, flattened).
 
 ▶️ [Robinhood Chain Gas Usage and Gas Price](https://ide.bitquery.io/robinhood-chain-gas-fees)
 
@@ -2862,19 +2868,19 @@ Robinhood Chain Gas Usage and Gas Price. Uses the `Transactions` cube.
 
 #### All events from Flap.sh
 
-All events from Flap.sh. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
 
 ▶️ [All events from Flap.sh](https://ide.bitquery.io/All-events-from-Flapsh)
 
 #### Flap.sh Newly created tokens using logs TokenCreated
 
-Flap.sh Newly created tokens using logs TokenCreated. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Filter Flap.sh `TokenCreated` events and decode argument values (token address, metadata fields, and related parameters).
 
 ▶️ [Flap.sh Newly created tokens using logs TokenCreated](https://ide.bitquery.io/Flapsh-Newly-created-tokens-using-logs-TokenCreated)
 
 #### New Contracts Deployed on Robinhood Chain
 
-New Contracts Deployed on Robinhood Chain. Uses the `Calls` cube. Needs the historical data add-on — see the comment at the top of the query.
+To pin one exact ABI variant — or to match an undecoded method — filter the 4-byte selector instead (uppercase hex, no `0x`):
 
 ▶️ [New Contracts Deployed on Robinhood Chain](https://ide.bitquery.io/new-contracts-deployed-robinhood-chain)
 
@@ -2882,7 +2888,7 @@ New Contracts Deployed on Robinhood Chain. Uses the `Calls` cube. Needs the hist
 
 #### Robinhood Chain Blocks per Day and Block Time
 
-Robinhood Chain Blocks per Day and Block Time. Uses the `Blocks` cube. Needs the historical data add-on — see the comment at the top of the query.
+Swap the filter to `Block: { Number: { eq: "…" } }` for every log in a block (the `eth_getBlockReceipts` logs, flattened).
 
 ▶️ [Robinhood Chain Blocks per Day and Block Time](https://ide.bitquery.io/robinhood-chain-block-time)
 
@@ -2902,7 +2908,7 @@ Uniswap v4 Hooks in Use on Robinhood Chain. Uses the `Events` cube. Replace the 
 
 #### Uniswap v4 Pool Liquidity on Robinhood Chain (pools.trade)
 
-Uniswap v4 Pool Liquidity on Robinhood Chain (pools.trade). Uses the `DEXPoolEvents` cube.
+Three realtime cubes carry data traders usually have to compute themselves. All three are realtime-only on Robinhood — `dataset: archive` and `dataset: combined` both error — so use them for live monitoring and persist what you need.
 
 ▶️ [Uniswap v4 Pool Liquidity on Robinhood Chain (pools.trade)](https://ide.bitquery.io/Pools-trade-Live-pool-liquidity)
 
@@ -2926,25 +2932,25 @@ This query calculates the combined balance of multiple Bitcoin wallet addresses 
 
 #### BTC balance api for multiple addresses
 
-BTC balance api for multiple addresses.
+Pass an array of addresses to `inputAddress` and `outputAddress` with `{in: [...]}` to get per-wallet totals in a single request. Useful for exchanges, custodians, and portfolio dashboards that monitor many wallets at once. [Run query
 
 ▶️ [BTC balance api for multiple addresses](https://ide.bitquery.io/BTC-balance-API-for-multiple-addresses)
 
 #### Bitcoin balance
 
-Bitcoin balance.
+Returns total BTC sent (inputs) and received (outputs) for an address, along with USD-equivalent values and first / last activity dates. Subtract `inputs.value` from `outputs.value` to get the current balance.
 
 ▶️ [Bitcoin balance](https://ide.bitquery.io/Bitcoin-balance_5)
 
 #### Bitcoin balance at a given height
 
-Bitcoin balance at a given height. Replace the address in the `where` clause to use it.
+Need to know what a wallet held at a particular point in time? The `height` filter caps inputs and outputs at a given block number, which is exactly what you need for audits, tax reporting, and point-in-time portfolio snapshots.
 
 ▶️ [Bitcoin balance at a given height](https://ide.bitquery.io/bitcoin-balance-at-a-given-height)
 
 #### Bitcoin balance on a given block height
 
-Bitcoin balance on a given block height. Replace the address in the `where` clause to use it.
+Sum outputs and subtract inputs with a `height: {lteq: N}` cap to get the wallet's balance at a specific point on-chain. Useful for audits, tax snapshots, and point-in-time portfolio reporting. [Run query
 
 ▶️ [Bitcoin balance on a given block height](https://ide.bitquery.io/bitcoin-balance-on-a-given-block-height)
 
@@ -2952,7 +2958,7 @@ Bitcoin balance on a given block height. Replace the address in the `where` clau
 
 #### Btc price in 2016
 
-Btc price in 2016.
+Pulls the BTC/USD price implied by any output on a given date — Bitquery stores the spot value at the time of each transaction, so you can derive a historical price by dividing USD value by BTC value. [Run query
 
 ▶️ [Btc price in 2016](https://ide.bitquery.io/btc-price-in-2016)
 
@@ -2968,21 +2974,297 @@ This API provides comprehensive details of a specific Bitcoin transaction in a s
 
 #### Bitcoin miners rewards
 
-Bitcoin miners rewards. Adjust the date range in the `where` clause.
+Mining rewards live in coinbase outputs (the first transaction in every block, `txIndex: 0`) with `outputDirection: mining`.
 
 ▶️ [Bitcoin miners rewards](https://ide.bitquery.io/bitcoin-miners-rewards)
 
 #### Get miners activity in a specific timeframe
 
-Get miners activity in a specific timeframe. Adjust the date range in the `where` clause.
+Pulls the activity count per miner address inside a date range. Drop or extend the date window to size the cohort however you need. [Run query
 
 ▶️ [Get miners activity in a specific timeframe](https://ide.bitquery.io/get-miners-activity-in-a-specific-timeframe)
 
 #### Get miners first activity
 
-Get miners first activity.
+For a specific set of miner addresses, this query returns the first block each one mined. Useful for cohort analysis, miner onboarding studies, or building "first seen" timelines. [Run query
 
 ▶️ [Get miners first activity](https://ide.bitquery.io/get-miners-first-activity)
+
+## Litecoin
+
+### Transfers
+
+#### Largest transfers in the last 24 hours
+
+The biggest Litecoin outputs of the past day, ranked by value — a quick way to spot whale movement. Change the `since` date to widen the window.
+
+▶️ [Largest transfers in the last 24 hours](https://ide.bitquery.io/Litecoin-Largest-transfers-in-the-last-24-hours)
+
+### Balances & Holders
+
+#### Total received by an address
+
+Sums everything an address has ever received on Litecoin, with a first-and-last-seen window. Replace the address to use it.
+
+▶️ [Total received by an address](https://ide.bitquery.io/Litecoin-Total-received-by-an-address)
+
+#### Total sent from an address
+
+Sums everything an address has ever spent on Litecoin. Subtract this from total received to get the current balance.
+
+▶️ [Total sent from an address](https://ide.bitquery.io/Litecoin-Total-sent-from-an-address)
+
+#### Address activity summary
+
+First seen, last seen, and lifetime in/out totals for one Litecoin address in a single request.
+
+▶️ [Address activity summary](https://ide.bitquery.io/Litecoin-Address-activity-summary)
+
+### Transactions
+
+#### Latest transactions
+
+The most recent transactions on Litecoin, with value, fee and input/output counts. Raise the limit to page further back.
+
+▶️ [Latest transactions](https://ide.bitquery.io/Litecoin-Latest-transactions)
+
+### Blocks & Validators
+
+#### Latest blocks
+
+The most recent blocks on Litecoin, with height, time, transaction count and size.
+
+▶️ [Latest blocks](https://ide.bitquery.io/Litecoin-Latest-blocks)
+
+## Bitcoin Cash
+
+### Transfers
+
+#### Largest transfers in the last 24 hours
+
+The biggest Bitcoin Cash outputs of the past day, ranked by value — a quick way to spot whale movement. Change the `since` date to widen the window.
+
+▶️ [Largest transfers in the last 24 hours](https://ide.bitquery.io/Bitcoin-Cash-Largest-transfers-in-the-last-24-hours)
+
+### Balances & Holders
+
+#### Total received by an address
+
+Sums everything an address has ever received on Bitcoin Cash, with a first-and-last-seen window. Replace the address to use it.
+
+▶️ [Total received by an address](https://ide.bitquery.io/Bitcoin-Cash-Total-received-by-an-address)
+
+#### Total sent from an address
+
+Sums everything an address has ever spent on Bitcoin Cash. Subtract this from total received to get the current balance.
+
+▶️ [Total sent from an address](https://ide.bitquery.io/Bitcoin-Cash-Total-sent-from-an-address)
+
+#### Address activity summary
+
+First seen, last seen, and lifetime in/out totals for one Bitcoin Cash address in a single request.
+
+▶️ [Address activity summary](https://ide.bitquery.io/Bitcoin-Cash-Address-activity-summary)
+
+### Transactions
+
+#### Latest transactions
+
+The most recent transactions on Bitcoin Cash, with value, fee and input/output counts. Raise the limit to page further back.
+
+▶️ [Latest transactions](https://ide.bitquery.io/Bitcoin-Cash-Latest-transactions)
+
+### Blocks & Validators
+
+#### Latest blocks
+
+The most recent blocks on Bitcoin Cash, with height, time, transaction count and size.
+
+▶️ [Latest blocks](https://ide.bitquery.io/Bitcoin-Cash-Latest-blocks)
+
+## Dogecoin
+
+### Transfers
+
+#### Largest transfers in the last 24 hours
+
+The biggest Dogecoin outputs of the past day, ranked by value — a quick way to spot whale movement. Change the `since` date to widen the window.
+
+▶️ [Largest transfers in the last 24 hours](https://ide.bitquery.io/Dogecoin-Largest-transfers-in-the-last-24-hours)
+
+### Balances & Holders
+
+#### Total received by an address
+
+Sums everything an address has ever received on Dogecoin, with a first-and-last-seen window. Replace the address to use it.
+
+▶️ [Total received by an address](https://ide.bitquery.io/Dogecoin-Total-received-by-an-address)
+
+#### Total sent from an address
+
+Sums everything an address has ever spent on Dogecoin. Subtract this from total received to get the current balance.
+
+▶️ [Total sent from an address](https://ide.bitquery.io/Dogecoin-Total-sent-from-an-address)
+
+#### Address activity summary
+
+First seen, last seen, and lifetime in/out totals for one Dogecoin address in a single request.
+
+▶️ [Address activity summary](https://ide.bitquery.io/Dogecoin-Address-activity-summary)
+
+### Transactions
+
+#### Latest transactions
+
+The most recent transactions on Dogecoin, with value, fee and input/output counts. Raise the limit to page further back.
+
+▶️ [Latest transactions](https://ide.bitquery.io/Dogecoin-Latest-transactions)
+
+### Blocks & Validators
+
+#### Latest blocks
+
+The most recent blocks on Dogecoin, with height, time, transaction count and size.
+
+▶️ [Latest blocks](https://ide.bitquery.io/Dogecoin-Latest-blocks)
+
+## Dash
+
+### Transfers
+
+#### Largest transfers in the last 24 hours
+
+The biggest Dash outputs of the past day, ranked by value — a quick way to spot whale movement. Change the `since` date to widen the window.
+
+▶️ [Largest transfers in the last 24 hours](https://ide.bitquery.io/Dash-Largest-transfers-in-the-last-24-hours)
+
+### Balances & Holders
+
+#### Total received by an address
+
+Sums everything an address has ever received on Dash, with a first-and-last-seen window. Replace the address to use it.
+
+▶️ [Total received by an address](https://ide.bitquery.io/Dash-Total-received-by-an-address)
+
+#### Total sent from an address
+
+Sums everything an address has ever spent on Dash. Subtract this from total received to get the current balance.
+
+▶️ [Total sent from an address](https://ide.bitquery.io/Dash-Total-sent-from-an-address)
+
+#### Address activity summary
+
+First seen, last seen, and lifetime in/out totals for one Dash address in a single request.
+
+▶️ [Address activity summary](https://ide.bitquery.io/Dash-Address-activity-summary)
+
+### Transactions
+
+#### Latest transactions
+
+The most recent transactions on Dash, with value, fee and input/output counts. Raise the limit to page further back.
+
+▶️ [Latest transactions](https://ide.bitquery.io/Dash-Latest-transactions)
+
+### Blocks & Validators
+
+#### Latest blocks
+
+The most recent blocks on Dash, with height, time, transaction count and size.
+
+▶️ [Latest blocks](https://ide.bitquery.io/Dash-Latest-blocks)
+
+## Zcash
+
+### Transfers
+
+#### Largest transfers in the last 24 hours
+
+The biggest Zcash outputs of the past day, ranked by value — a quick way to spot whale movement. Change the `since` date to widen the window.
+
+▶️ [Largest transfers in the last 24 hours](https://ide.bitquery.io/Zcash-Largest-transfers-in-the-last-24-hours)
+
+### Balances & Holders
+
+#### Total received by an address
+
+Sums everything an address has ever received on Zcash, with a first-and-last-seen window. Replace the address to use it.
+
+▶️ [Total received by an address](https://ide.bitquery.io/Zcash-Total-received-by-an-address)
+
+#### Total sent from an address
+
+Sums everything an address has ever spent on Zcash. Subtract this from total received to get the current balance.
+
+▶️ [Total sent from an address](https://ide.bitquery.io/Zcash-Total-sent-from-an-address)
+
+#### Address activity summary
+
+First seen, last seen, and lifetime in/out totals for one Zcash address in a single request.
+
+▶️ [Address activity summary](https://ide.bitquery.io/Zcash-Address-activity-summary)
+
+### Transactions
+
+#### Latest transactions
+
+The most recent transactions on Zcash, with value, fee and input/output counts. Raise the limit to page further back.
+
+▶️ [Latest transactions](https://ide.bitquery.io/Zcash-Latest-transactions)
+
+### Blocks & Validators
+
+#### Latest blocks
+
+The most recent blocks on Zcash, with height, time, transaction count and size.
+
+▶️ [Latest blocks](https://ide.bitquery.io/Zcash-Latest-blocks)
+
+## Bitcoin SV
+
+### Transfers
+
+#### Largest transfers in the last 24 hours
+
+The biggest Bitcoin SV outputs of the past day, ranked by value — a quick way to spot whale movement. Change the `since` date to widen the window.
+
+▶️ [Largest transfers in the last 24 hours](https://ide.bitquery.io/Bitcoin-SV-Largest-transfers-in-the-last-24-hours)
+
+### Balances & Holders
+
+#### Total received by an address
+
+Sums everything an address has ever received on Bitcoin SV, with a first-and-last-seen window. Replace the address to use it.
+
+▶️ [Total received by an address](https://ide.bitquery.io/Bitcoin-SV-Total-received-by-an-address)
+
+#### Total sent from an address
+
+Sums everything an address has ever spent on Bitcoin SV. Subtract this from total received to get the current balance.
+
+▶️ [Total sent from an address](https://ide.bitquery.io/Bitcoin-SV-Total-sent-from-an-address)
+
+#### Address activity summary
+
+First seen, last seen, and lifetime in/out totals for one Bitcoin SV address in a single request.
+
+▶️ [Address activity summary](https://ide.bitquery.io/Bitcoin-SV-Address-activity-summary)
+
+### Transactions
+
+#### Latest transactions
+
+The most recent transactions on Bitcoin SV, with value, fee and input/output counts. Raise the limit to page further back.
+
+▶️ [Latest transactions](https://ide.bitquery.io/Bitcoin-SV-Latest-transactions)
+
+### Blocks & Validators
+
+#### Latest blocks
+
+The most recent blocks on Bitcoin SV, with height, time, transaction count and size.
+
+▶️ [Latest blocks](https://ide.bitquery.io/Bitcoin-SV-Latest-blocks)
 
 ## Cardano
 
@@ -3056,13 +3338,13 @@ This query uses transaction hash and date range as filter to fetch tx details.
 
 #### All the transfers of an asset on Algorand Mainnet in a specific timeframe
 
-All the transfers of an asset on Algorand Mainnet in a specific timeframe. Adjust the date range in the `where` clause.
+Returns transfers for asset ID `31566704` between two dates, ordered by block height descending. Swap the `currency` filter for any ASA ID or ALGO. [Run query
 
 ▶️ [All the transfers of an asset on Algorand Mainnet in a specific timeframe](https://ide.bitquery.io/All-the-transfers-of-an-asset-on-Algorand-Mainnet-in-a-specific-timeframe)
 
 #### Traansfers where a currency is sent from or sent to a particular address
 
-Traansfers where a currency is sent from or sent to a particular address. Adjust the date range in the `where` clause.
+Uses the `any` filter to match transfers where the address appears as either sender or receiver. [Run query
 
 ▶️ [Traansfers where a currency is sent from or sent to a particular address](https://ide.bitquery.io/traansfers-where-a-currency-is-sent-from-or-sent-to-a-particular-address)
 
@@ -3070,7 +3352,7 @@ Traansfers where a currency is sent from or sent to a particular address. Adjust
 
 #### Get Count of Smart Contract Calls in Latest Block
 
-Get Count of Smart Contract Calls in Latest Block.
+Returns the count of unique smart contract calls in the most recent block after a given date. [Run query
 
 ▶️ [Get Count of Smart Contract Calls in Latest Block](https://ide.bitquery.io/Get-Count-of-Smart-Contract-Calls-in-Latest-Block_1)
 
@@ -3078,19 +3360,19 @@ Get Count of Smart Contract Calls in Latest Block.
 
 #### All Transactions on Algorand
 
-All Transactions on Algorand. Adjust the date range in the `where` clause.
+Paginated query for all transactions in a specific window. [Run query
 
 ▶️ [All Transactions on Algorand](https://ide.bitquery.io/All-Transactions-on-Algorand)
 
 #### Daily Transaction Count for last 10 days
 
-Daily Transaction Count for last 10 days.
+Returns the number of transactions per day over the last 10 days, ordered by date descending. [Run query
 
 ▶️ [Daily Transaction Count for last 10 days](https://ide.bitquery.io/Daily-Transaction-Count-for-last-10-days)
 
 #### Daily Unique Txn Senders on algorand
 
-Daily Unique Txn Senders on algorand.
+Counts distinct transaction senders on a specific date. [Run query
 
 ▶️ [Daily Unique Txn Senders on algorand](https://ide.bitquery.io/Daily-Unique-Txn-Senders-on-algorand)
 
@@ -3100,61 +3382,61 @@ Daily Unique Txn Senders on algorand.
 
 #### Average fee per trade, Total fees, total volume, trades count per DEX program
 
-Average fee per trade, Total fees, total volume, trades count per DEX program. Uses the `Trades` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Average fee per trade, Total fees, total volume, trades count per DEX program](https://ide.bitquery.io/Average-fee-per-trade-Total-fees-total-volume-trades-count-per-DEX-program)
 
 #### Last 10 WSOL USDC Token pair trades
 
-Last 10 WSOL USDC Token pair trades. Uses the `Trades` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Last 10 WSOL USDC Token pair trades](https://ide.bitquery.io/Last-10-WSOL-USDC-Token-pair-trades)
 
 #### Most active market pools by trades
 
-Most active market pools by trades. Uses the `Trades` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Most active market pools by trades](https://ide.bitquery.io/Most-active-market-pools-by-trades)
 
 #### Most active traders by trade count
 
-Most active traders by trade count. Uses the `Trades` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Most active traders by trade count](https://ide.bitquery.io/Most-active-traders-by-trade-count)
 
 #### Most traded token in last 1 hour on solana and it's average trade amount and total volume
 
-Most traded token in last 1 hour on solana and it's average trade amount and total volume. Uses the `Trades` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Most traded token in last 1 hour on solana and it's average trade amount and total volume](https://ide.bitquery.io/Most-traded-token-in-last-1-hour-on-solana-and-its-average-trade-amount-and-total-volume)
 
 #### Net flow (buys - sells) per token symbol
 
-Net flow (buys - sells) per token symbol. Uses the `Trades` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Net flow (buys - sells) per token symbol](https://ide.bitquery.io/Net-flow-buys---sells-per-token-symbol_2)
 
 #### Tokens with highest trade frequency
 
-Tokens with highest trade frequency. Uses the `Trades` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Tokens with highest trade frequency](https://ide.bitquery.io/Tokens-with-highest-trade-frequency)
 
 #### Tokens with most unique buyers
 
-Tokens with most unique buyers. Uses the `Trades` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Tokens with most unique buyers](https://ide.bitquery.io/Tokens-with-most-unique-buyers)
 
 #### Top Traders on Solana
 
-Top Traders on Solana. Uses the `Trades` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Top Traders on Solana](https://ide.bitquery.io/Top-Traders-on-Solana_2)
 
 #### Total SOL fees, Total Volume, Total count trades
 
-Total SOL fees, Total Volume, Total count trades. Uses the `Trades` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Total SOL fees, Total Volume, Total count trades](https://ide.bitquery.io/Total-SOL-fees-Total-Volume-Total-count-trades)
 
@@ -3162,13 +3444,13 @@ Total SOL fees, Total Volume, Total count trades. Uses the `Trades` cube.
 
 #### Historical Bitcoin OHLC data for the last 7 days
 
-Historical Bitcoin OHLC data for the last 7 days. Uses the `Currencies` cube.
+Recent Bitcoin OHLC using the Crypto Price API (time range in the query matches what the Price Index supports).
 
 ▶️ [Historical Bitcoin OHLC data for the last 7 days](https://ide.bitquery.io/historical-Bitcoin-OHLC-data-for-the-last-7-days)
 
 #### OHLC of a currency on multiple blockchains
 
-OHLC of a currency on multiple blockchains. Uses the `Currencies` cube.
+Stream real-time Bitcoin OHLC data aggregated from all supported blockchains (Bitcoin, Ethereum WBTC, Solana, etc.) with 60-second intervals:
 
 ▶️ [OHLC of a currency on multiple blockchains](https://ide.bitquery.io/OHLC-of-a-currency-on-multiple-blockchains)
 
@@ -3176,13 +3458,13 @@ OHLC of a currency on multiple blockchains. Uses the `Currencies` cube.
 
 #### Marketcap of pump token
 
-Marketcap of pump token. Uses the `Tokens` cube. Replace the address in the `where` clause to use it.
+Set token address and read `Supply.MarketCap` from the query below. See the Supply fields reference for related supply fields. You can also stream this in real-time by adding the keyword "subscription" at the top.
 
 ▶️ [Marketcap of pump token](https://ide.bitquery.io/marketcap-of-pump-token)
 
 #### Tokens ranked by market cap
 
-Tokens ranked by market cap. Uses the `Trades` cube.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Tokens ranked by market cap](https://ide.bitquery.io/Tokens-ranked-by-market-cap_1)
 
@@ -3192,7 +3474,7 @@ Tokens ranked by market cap. Uses the `Trades` cube.
 
 #### Solana USDT trades query
 
-Solana USDT trades query. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Returns is to track USDT trading activity on Solana.
 
 ▶️ [Solana USDT trades query](https://ide.bitquery.io/solana-USDT-trades-query)
 
@@ -3200,49 +3482,49 @@ Solana USDT trades query. Uses the `DEXTrades` cube. Change the token address in
 
 #### Latest Tron USDT Transfers
 
-Latest Tron USDT Transfers. Uses the `Transfers` cube.
+Listen to stablecoin payments across all major blockchains. The Mempool option lets you detect a payment *before* it is confirmed — useful for instant merchant UX.
 
 ▶️ [Latest Tron USDT Transfers](https://ide.bitquery.io/Latest-Tron-USDT-Transfers)
 
 #### Latest USDT/USDC Transfer api on base
 
-Latest USDT/USDC Transfer api on base. Uses the `Transfers` cube.
+Listen to stablecoin payments across all major blockchains. The Mempool option lets you detect a payment *before* it is confirmed — useful for instant merchant UX.
 
 ▶️ [Latest USDT/USDC Transfer api on base](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-api-on-base)
 
 #### Latest USDT/USDC Transfer api on ethereum
 
-Latest USDT/USDC Transfer api on ethereum. Uses the `Transfers` cube.
+Listen to stablecoin payments across all major blockchains. The Mempool option lets you detect a payment *before* it is confirmed — useful for instant merchant UX.
 
 ▶️ [Latest USDT/USDC Transfer api on ethereum](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-api-on-ethereum)
 
 #### Stablecoin Transfers from/to an address
 
-Stablecoin Transfers from/to an address. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+Returns will give you `EURC` transfers from/to `cHxJ2uC6vgcCfoFSfupkfCWbKHAkekrGfG39DXRamXT` on Solana. Test the query [here
 
 ▶️ [Stablecoin Transfers from/to an address](https://ide.bitquery.io/stablecoin-Transfers-fromto-an-address)
 
 #### Stablecoin recieved and sent by an address
 
-Stablecoin recieved and sent by an address. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Returns will give you `USDT` transfers from/to `TUTQj7VJ1QjR3t2GJByvrP25yZNFcj38VJ` on Tron. Test the query [here
 
 ▶️ [Stablecoin recieved and sent by an address](https://ide.bitquery.io/Stablecoin-recieved-and-sent-by-an-address)
 
 #### USDT Stablecoin reserves on Ethereum
 
-USDT Stablecoin reserves on Ethereum. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Below API query will give you realtime reserves data of `USDT` on Ethereum. Test the API [here
 
 ▶️ [USDT Stablecoin reserves on Ethereum](https://ide.bitquery.io/USDT-Stablecoin-reserves-on-Ethereum)
 
 #### USDT and USDC token Transfers api on solana
 
-USDT and USDC token Transfers api on solana. Uses the `Transfers` cube.
+This GraphQL stream provides live USDT and USDC stablecoin transfers on Solana.
 
 ▶️ [USDT and USDC token Transfers api on solana](https://ide.bitquery.io/USDT-and-USDC-token-Transfers-api-on-solana)
 
 #### USDT token Transfers api on solana
 
-USDT token Transfers api on solana. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+Track live USDT stablecoin transfers. USDT is ideal for payments, settlements, etc and you can track those in real-time using this API/Stream -
 
 ▶️ [USDT token Transfers api on solana](https://ide.bitquery.io/USDT-token-Transfers-api-on-solana)
 
@@ -3256,13 +3538,13 @@ USDT token Transfers api on solana. Uses the `Transfers` cube. Change the token 
 
 #### Stablecoin price query of USDT
 
-Stablecoin price query of USDT. Uses the `Tokens` cube.
+Get real-time and historical USDT prices, OHLCV, and moving averages across supported networks and markets.
 
 ▶️ [Stablecoin price query of USDT](https://ide.bitquery.io/stablecoin-price-query-of-USDT_1)
 
 #### Usdt latest price arbitrage
 
-Usdt latest price arbitrage. Uses the `Tokens` cube.
+Returns compares USDT prices across different blockchain networks in real-time. It fetches the latest price data for USDT from different networks, showing you where the same stablecoin trades at different prices.
 
 ▶️ [Usdt latest price arbitrage](https://ide.bitquery.io/usdt-latest-price-arbitrage)
 
@@ -3270,13 +3552,13 @@ Usdt latest price arbitrage. Uses the `Tokens` cube.
 
 #### USDC Stablecoin reserves on Solana
 
-USDC Stablecoin reserves on Solana. Uses the `TokenSupplyUpdates` cube. Change the token address in the `where` clause to use it.
+Below API query will give you realtime reserves data of `USDC` on Solana. Test the API [here
 
 ▶️ [USDC Stablecoin reserves on Solana](https://ide.bitquery.io/USDC-Stablecoin-reserves-on-Solana)
 
 #### USDT Stablecoin reserves on Solana query
 
-USDT Stablecoin reserves on Solana query. Uses the `TokenSupplyUpdates` cube. Change the token address in the `where` clause to use it.
+Monitor USDT reserve or get lateast reserve value on Solana using below Stream/API.
 
 ▶️ [USDT Stablecoin reserves on Solana query](https://ide.bitquery.io/USDT-Stablecoin-reserves-on-Solana--query)
 
@@ -3286,37 +3568,37 @@ USDT Stablecoin reserves on Solana query. Uses the `TokenSupplyUpdates` cube. Ch
 
 #### Hyperliquid BTC Perp Trades
 
-Hyperliquid BTC Perp Trades. Uses the `Trades` cube.
+Run it in the IDE: [Hyperliquid BTC Perp Trades ➤
 
 ▶️ [Hyperliquid BTC Perp Trades](https://ide.bitquery.io/hyperliquid-btc-perp-trades)
 
 #### Hyperliquid Latest Trades (Perps + Spot + HIP-3)
 
-Hyperliquid Latest Trades (Perps + Spot + HIP-3). Uses the `Trades` cube.
+Run it in the IDE: [Hyperliquid Latest Trades ➤
 
 ▶️ [Hyperliquid Latest Trades (Perps + Spot + HIP-3)](https://ide.bitquery.io/hyperliquid-latest-trades)
 
 #### Hyperliquid Trader Leverage Updates
 
-Hyperliquid Trader Leverage Updates.
+Run it in the IDE: [Hyperliquid Leverage Updates ➤
 
 ▶️ [Hyperliquid Trader Leverage Updates](https://ide.bitquery.io/hyperliquid-leverage-updates)
 
 #### Phoenix Perps Fills by Trader Wallet - Solana
 
-Phoenix Perps Fills by Trader Wallet - Solana.
+You can run the wallet-fills version [in the Bitquery IDE
 
 ▶️ [Phoenix Perps Fills by Trader Wallet - Solana](https://ide.bitquery.io/sol_perps_filled_orders_by_signer)
 
 #### Trader Realized PnL on Solana Perps
 
-Trader Realized PnL on Solana Perps.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Trader Realized PnL on Solana Perps](https://ide.bitquery.io/solana-perps-trader-pnl)
 
 #### Whale Trades on Solana Perps (Phoenix)
 
-Whale Trades on Solana Perps (Phoenix).
+You can run the query version [in the Bitquery IDE
 
 ▶️ [Whale Trades on Solana Perps (Phoenix)](https://ide.bitquery.io/solana-perps-whale-trades)
 
@@ -3324,19 +3606,19 @@ Whale Trades on Solana Perps (Phoenix).
 
 #### Hyperliquid BTC OHLCV Candles (1 minute)
 
-Hyperliquid BTC OHLCV Candles (1 minute).
+Run it in the IDE: [Hyperliquid BTC OHLCV Candles ➤
 
 ▶️ [Hyperliquid BTC OHLCV Candles (1 minute)](https://ide.bitquery.io/hyperliquid-btc-ohlcv-candles)
 
 #### Hyperliquid Mark Prices (All Markets)
 
-Hyperliquid Mark Prices (All Markets).
+Run it in the IDE: [Hyperliquid Mark Prices ➤
 
 ▶️ [Hyperliquid Mark Prices (All Markets)](https://ide.bitquery.io/hyperliquid-mark-prices)
 
 #### Solana Perps OHLC Candles from Mark Price
 
-Solana Perps OHLC Candles from Mark Price.
+You can run this query [in the Bitquery IDE
 
 ▶️ [Solana Perps OHLC Candles from Mark Price](https://ide.bitquery.io/solana-perps-ohlc-candles)
 
@@ -3382,13 +3664,13 @@ Latests OpenSea Trades.
 
 #### Latest NFT trades on Ethereum network
 
-Latest NFT trades on Ethereum network.
+Returns retrieves the latest NFT Trades on Ethereum for Seaport v1.4 protocol. Many marketplaces utilize the Seaport protocol, we can add a Smart contract in Trade → Dex → SmartContract to get a specific marketplace for this protocol.
 
 ▶️ [Latest NFT trades on Ethereum network](https://ide.bitquery.io/latest-NFT-trades-on-Ethereum-network)
 
 #### Pairs of blur token new dataset
 
-Pairs of blur token new dataset.
+Open the above query on GraphQL IDE using this [link
 
 ▶️ [Pairs of blur token new dataset](https://ide.bitquery.io/pairs-of-blur-token-new-dataset_1)
 
@@ -3400,7 +3682,7 @@ Position NFTs as they are minted — who is adding liquidity to v3 pools, and to
 
 #### NFT currencies on Solana by DEX'es
 
-NFT currencies on Solana by DEX'es.
+The subscription query provided fetches the most-traded NFTs in the last few hours. For Solana, only realtime information is available, so the aggregate might not be accurate beyond a few hours. You can find the query [here
 
 ▶️ [NFT currencies on Solana by DEX'es](https://ide.bitquery.io/NFT-currencies-on-Solana-by-DEXes_1)
 
@@ -3414,7 +3696,7 @@ Get transfers of NFTs given the wallet.
 
 #### All transfers of an NFT
 
-All transfers of an NFT.
+Returns retrieves the most recent transfers of a specific non-fungible token (NFT) on the Ethereum network. You can find the GraphQL query [here
 
 ▶️ [All transfers of an NFT](https://ide.bitquery.io/All-transfers-of-an-NFT)
 
@@ -3426,19 +3708,19 @@ NFT Token Transfers By Date.
 
 #### Top transfered NFT tokens in network
 
-Top transfered NFT tokens in network.
+Returns fetches the most frequently transferred NFTs on the Ethereum Blockchain within the specified date range.
 
 ▶️ [Top transfered NFT tokens in network](https://ide.bitquery.io/Top-transfered-NFT-tokens-in-network)
 
 #### Array_intersect example for NFT
 
-Array_intersect example for NFT.
+Read more about using `array_intersect` here
 
 ▶️ [Array_intersect example for NFT](https://ide.bitquery.io/array_intersect-example-for-NFT)
 
 #### Get all transfers of a specific nft
 
-Get all transfers of a specific nft.
+This below query will give you all the transfers of a particular NFT `0xb68CA010776B4584cf49893E75b66583eb884948`.
 
 ▶️ [Get all transfers of a specific nft](https://ide.bitquery.io/get-all-transfers-of-a-specific-nft)
 
@@ -3464,13 +3746,13 @@ Check the current owner of a specific NFT token ID. This query returns ownership
 
 #### Get NFT Balances for Multiple Addresses
 
-Get NFT Balances for Multiple Addresses.
+Get NFT balances for multiple addresses in a single query. Useful for portfolio tracking or wallet monitoring applications. Try the API [here
 
 ▶️ [Get NFT Balances for Multiple Addresses](https://ide.bitquery.io/Get-NFT-Balances-for-Multiple-Addresses_1)
 
 #### Get NFT Ownership History
 
-Get NFT Ownership History.
+Retrieve the NFT ownership history of a specific NFT over a specific time period. This helps track NFT transfers and ownership changes. Try the API [here
 
 ▶️ [Get NFT Ownership History](https://ide.bitquery.io/Get-NFT-Ownership-History_2)
 
@@ -3486,13 +3768,13 @@ Smart contract calls to an nft contract.
 
 #### All refinance loans for specific NFT collection
 
-All refinance loans for specific NFT collection.
+To retrieve all refinance loans for a specific NFT collection, we filter Refinance event arguments in [this
 
 ▶️ [All refinance loans for specific NFT collection](https://ide.bitquery.io/All-refinance-loans-for-specificNFT-collection)
 
 #### Auction on blur marketplace
 
-Auction on blur marketplace.
+The 'StartAuction' event is triggered when an NFT auction starts on the Blur : Blend Contract. The following [query
 
 ▶️ [Auction on blur marketplace](https://ide.bitquery.io/Auction-on-blur-marketplace)
 
@@ -3504,19 +3786,19 @@ Creator_of_an_NFT.
 
 #### Latest Cancelled offers on Blur NFT marketplace
 
-Latest Cancelled offers on Blur NFT marketplace.
+On the BLUR market, the 'OfferCancelled' event initiates when an offer is withdrawn or cancelled. The following [query
 
 ▶️ [Latest Cancelled offers on Blur NFT marketplace](https://ide.bitquery.io/Latest-Cancelled-offers-on-Blur-NFT-marketplace)
 
 #### Latest Loans for a specific borrower on Blur marketplace
 
-Latest Loans for a specific borrower on Blur marketplace.
+Same as previous queries, this query will return details about the block, transaction, log, and arguments. By modifying the 'Arguments.includes' filter, you can track loan activities for different NFT collections on the Blur marketplace.
 
 ▶️ [Latest Loans for a specific borrower on Blur marketplace](https://ide.bitquery.io/Latest-Loans-for-a-specificborrower-on-Blur-marketplace)
 
 #### Latest Seized NFTs on Blur marketplace
 
-Latest Seized NFTs on Blur marketplace.
+When a seizure event happens, control of the NFT shifts to the lender or an enforcing third party. The [query
 
 ▶️ [Latest Seized NFTs on Blur marketplace](https://ide.bitquery.io/Latest-Seized-NFTs-on-Blur-marketplace)
 
@@ -3534,19 +3816,19 @@ Loan history for specific NFT ID.
 
 #### Loan repayment of blur marketplace
 
-Loan repayment of blur marketplace.
+For loan repayment transactions on the BLUR market, use the [following
 
 ▶️ [Loan repayment of blur marketplace](https://ide.bitquery.io/Loan-repayment-of-blur-marketplace)
 
 #### Loans above a specific amount on the Blur NFT marketplace
 
-Loans above a specific amount on the Blur NFT marketplace.
+If we want to track loans above a specific amount on the Blur marketplace, we can use the following [query
 
 ▶️ [Loans above a specific amount on the Blur NFT marketplace](https://ide.bitquery.io/Loans-above-a-specific-amount-on-the-Blur-NFT-marketplace)
 
 #### Locked NFT bought on Blur marketplace
 
-Locked NFT bought on Blur marketplace.
+Locked NFTs are temporarily non-transferrable and can be traded or transferred after the lock period. These NFTs are often cheaper than non-locked. The following [query
 
 ▶️ [Locked NFT bought on Blur marketplace](https://ide.bitquery.io/Locked-NFT-bought-on-Blur-marketplace)
 
@@ -3574,43 +3856,43 @@ Fetch all trades where the given address is either Buyer or Seller. Pass the tra
 
 #### How do I count trades for a specific Polymarket trader?
 
-How do I count trades for a specific Polymarket trader?. Replace the address in the `where` clause to use it.
+Use `PredictionTrades` with `any` filter on `Buyer` or `Seller` to return the total trade count for a wallet. Add `ProtocolName: "polymarket"` to restrict to Polymarket only. Replace the address with your target wallet.
 
 ▶️ [How do I count trades for a specific Polymarket trader?](https://ide.bitquery.io/How-do-I-count-trades-for-a-specific-Polymarket-trader)
 
 #### How do I get top buyers and sellers on Polymarket by volume?
 
-How do I get top buyers and sellers on Polymarket by volume?.
+Use `PredictionTrades` with `limitBy` and `sum(of: Trade_OutcomeTrade_CollateralAmountInUSD)` grouped by Buyer (or Seller) to rank the top 100 wallets by volume over the last 5 days. Useful for leaderboards, whale tracking, and trader analytics.
 
 ▶️ [How do I get top buyers and sellers on Polymarket by volume?](https://ide.bitquery.io/How-do-I-get-top-buyers-and-sellers-on-Polymarket-by-volume)
 
 #### Latest prediction market trades
 
-Latest prediction market trades.
+Fetch the most recent prediction market trades with full details, ordered by block time.
 
 ▶️ [Latest prediction market trades](https://ide.bitquery.io/latest-prediction-market-trades)
 
 #### Prediction_trades
 
-Prediction_trades.
+Use Bitquery's `PredictionTrades` GraphQL query filtered by `ProtocolName: "polymarket"` on Polygon (`network: matic`). For live streaming, use a subscription or Kafka.
 
 ▶️ [Prediction_trades](https://ide.bitquery.io/prediction_trades)
 
 #### Top 100 markets by volumein last24 hrs
 
-Top 100 markets by volumein last24 hrs.
+Rank Polymarket markets by buy + sell collateral USD, with buy/sell breakdown, trade count, distinct buyers/sellers, and optional resolution join. Uses `limitBy: Trade_Prediction_Question_Id` so each row is one market.
 
 ▶️ [Top 100 markets by volumein last24 hrs](https://ide.bitquery.io/top-100-markets-by-volumein-last24-hrs_1)
 
 #### Top AI markets by volume Polymarket
 
-Top AI markets by volume Polymarket.
+Returns AI markets (title includes the standalone word " AI ") ranked by USD trading volume in the last 24 hours, with buyer and seller counts. Adjust `time_ago`, `limit`, and the title keyword as needed.
 
 ▶️ [Top AI markets by volume Polymarket](https://ide.bitquery.io/Top-AI-markets-by-volume-Polymarket)
 
 #### Top Buyers/Sellers of Bitcoin up down market
 
-Top Buyers/Sellers of Bitcoin up down market.
+Returns returns the top 10 buyers and top 10 sellers by traded volume in Bitcoin Up or Down markets on Polymarket over the last 24 hours. Results are aggregated by trader address and ordered by `buy_amount` (buyers) or `sell_amount` (sellers).
 
 ▶️ [Top Buyers/Sellers of Bitcoin up down market](https://ide.bitquery.io/Top-BuyersSellers-of-Bitcoin-up-down-market)
 
@@ -3642,13 +3924,13 @@ Query that returns the 10 most recent Resolved events. Winning outcome is in Pre
 
 #### Latest Prediction managements (resolutions, creations)
 
-Latest Prediction managements (resolutions, creations).
+Fetch the most recent creation and resolution events with full details, ordered by block time.
 
 ▶️ [Latest Prediction managements (resolutions, creations)](https://ide.bitquery.io/latest-Prediction-managements-resolutions-creations)
 
 #### Latest polymarket creations
 
-Latest polymarket creations.
+Fetch the most recent Created events. For each market, all possible outcomes are listed under Prediction.Condition.Outcomes.
 
 ▶️ [Latest polymarket creations](https://ide.bitquery.io/latest-polymarket-creations)
 
@@ -3660,13 +3942,13 @@ Latest polymarket resolutions.
 
 #### Latest resolved crudeoil markets
 
-Latest resolved crudeoil markets.
+Returns the 10 most recent Resolved events for Polymarket Crude Oil markets.
 
 ▶️ [Latest resolved crudeoil markets](https://ide.bitquery.io/latest-resolved-crudeoil-markets)
 
 #### Latest resolved sports markets
 
-Latest resolved sports markets.
+Returns the 10 most recent Resolved sports markets (management description includes `"sports"`), including the resolved/winning Outcome and full question metadata. Use this to grade results and settle bets.
 
 ▶️ [Latest resolved sports markets](https://ide.bitquery.io/Latest-resolved-sports-markets)
 
@@ -3716,25 +3998,25 @@ Rank holders by total redeemed amount for one market (filter by question title).
 
 #### Latest prediction market settlements
 
-Latest prediction market settlements.
+Fetch the most recent settlements with full details, ordered by block time.
 
 ▶️ [Latest prediction market settlements](https://ide.bitquery.io/latest-prediction-market-settlements_2)
 
 #### Latest whale settlements on prediction market
 
-Latest whale settlements on prediction market.
+Find the most recent high-value redemptions (e.g. amount ≥ 10,000 USD). Useful for tracking large payouts and whale activity.
 
 ▶️ [Latest whale settlements on prediction market](https://ide.bitquery.io/latest-whale-settlements-on-prediction-market_2)
 
 #### Redemptions, merge, split count in last 1 hour
 
-Redemptions, merge, split count in last 1 hour.
+Count how many settlement events occurred in the last hour, grouped by event signature (Split, Merge, Redemption).
 
 ▶️ [Redemptions, merge, split count in last 1 hour](https://ide.bitquery.io/redemptions-merge-split-count-in-last-1-hour)
 
 #### Top 10 redeemers
 
-Top 10 redeemers.
+Rank addresses by total amount redeemed in the last hour across all markets. Useful for leaderboards and whale tracking.
 
 ▶️ [Top 10 redeemers](https://ide.bitquery.io/top-10-redeemers)
 
@@ -3742,19 +4024,19 @@ Top 10 redeemers.
 
 #### Freshwallet check for polymarket
 
-Freshwallet check for polymarket. Uses the `Transfers` cube. Needs the historical data add-on — see the comment at the top of the query.
+Look up the buyer's earliest on-chain activity. If the wallet's first transfer is close to the time of its first big bet, it is a fresh wallet and scores high. Replace the address with the buyer from Step 1.
 
 ▶️ [Freshwallet check for polymarket](https://ide.bitquery.io/freshwallet-check-for-polymarket)
 
 #### FundingSource for poylmarket
 
-FundingSource for poylmarket. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Find where the wallet's money came from. The first inbound USDC transfer is usually the original funder, often a centralized exchange withdrawal or a parent wallet. This query uses bridged USDC.e on Polygon (`0x2791bca1f2de4661ed88a30c99a7a9449aa84174`).
 
 ▶️ [FundingSource for poylmarket](https://ide.bitquery.io/FundingSource-for-poylmarket)
 
 #### SiblingWallets for polymarket
 
-SiblingWallets for polymarket. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Take the funder from Step 3 and list every other wallet it funded. Wallets sharing a funder are likely controlled by the same operator. A large cluster placing correlated bets is a strong signal.
 
 ▶️ [SiblingWallets for polymarket](https://ide.bitquery.io/SiblingWallets-for-polymarket)
 
@@ -3762,7 +4044,7 @@ SiblingWallets for polymarket. Uses the `Transfers` cube. Change the token addre
 
 #### Polymarket TVL
 
-Polymarket TVL. Uses the `TransactionBalances` cube.
+Summarize USDC.e (`0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`) held by Conditional Tokens and neg-risk wrapped collateral contracts. Extend the `Address` list if you track additional custodians.
 
 ▶️ [Polymarket TVL](https://ide.bitquery.io/Polymarket-TVL)
 
@@ -3776,31 +4058,31 @@ Get the latest trade price for each outcome in a market. Uses `limitBy` for one 
 
 #### Current price inside the market for all options based on latest trade
 
-Current price inside the market for all options based on latest trade.
+Get the latest trade price for each outcome in a market (e.g. Yes/No, Up/Down—each market defines its own outcome labels).
 
 ▶️ [Current price inside the market for all options based on latest trade](https://ide.bitquery.io/Current-price-inside-the-market-for-all-options-based-on-latest-trade)
 
 #### Latest price of outcomes of a crude oil market
 
-Latest price of outcomes of a crude oil market.
+Returns the latest trade price (and price in USD) per outcome for a single market by `MarketId`. Replace `"1570893"` with the target Crude Oil market ID from Polymarket or from the creation/resolution queries above.
 
 ▶️ [Latest price of outcomes of a crude oil market](https://ide.bitquery.io/latest-price-of-outcomes-of-a-crude-oil-market)
 
 #### OHLC of a outcome of a gold market
 
-OHLC of a outcome of a gold market.
+Returns OHLC (Open, High, Low, Close) in USD for one outcome of a Gold market, bucketed by time (e.g. 1-minute intervals). Replace `MarketId` `"1606192"` and outcome `"Down"` with the desired market and outcome label (e.g. `"Up"` or `"Down"`).
 
 ▶️ [OHLC of a outcome of a gold market](https://ide.bitquery.io/OHLC-of-a-outcome-of-a-gold-market)
 
 #### Polymarket AI odds movement OHLC
 
-Polymarket AI odds movement OHLC.
+Returns OHLC (Open, High, Low, Close) in USD for one outcome of an AI market, bucketed by interval (here 5 minutes). It shows how the implied probability moved over time, and powers charts and backtests. Replace `"<MARKET_ID>"` and `"<OUTCOME_LABEL>"` (e.g.
 
 ▶️ [Polymarket AI odds movement OHLC](https://ide.bitquery.io/Polymarket-AI-odds-movement-OHLC)
 
 #### Polymarket sports odds movement OHLC
 
-Polymarket sports odds movement OHLC.
+Returns OHLC (Open, High, Low, Close) in USD for one outcome of a game, bucketed by interval (here 5 minutes). It shows how the win probability moved over time, and powers line-movement charts and strategy backtests.
 
 ▶️ [Polymarket sports odds movement OHLC](https://ide.bitquery.io/Polymarket-sports-odds-movement-OHLC)
 
@@ -3808,13 +4090,13 @@ Polymarket sports odds movement OHLC.
 
 #### Top cricket Markets by Liquidity
 
-Top cricket Markets by Liquidity.
+Returns the top 100 cricket related polymarkets sorted by liquidity position in the past 24 hours.
 
 ▶️ [Top cricket Markets by Liquidity](https://ide.bitquery.io/Top-cricket-Markets-by-Liquidity)
 
 #### Top FIFA World Cup Markets by Liquidity
 
-Top FIFA World Cup Markets by Liquidity.
+Returns the top 100 FIFA World Cup related polymarkets sorted by liquidity position in the past 24 hours. Here `position` is the metric used for sorting, hence it could be regarded as the liquidity position of the particular market.
 
 ▶️ [Top FIFA World Cup Markets by Liquidity](https://ide.bitquery.io/Top-FIFA-World-Cup-Markets-by-Liquidity)
 
@@ -3824,13 +4106,13 @@ Top FIFA World Cup Markets by Liquidity.
 
 #### All events of AsterDEX
 
-All events of AsterDEX. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Monitor all events emitted by the AsterDEX contract to track all platform activities.
 
 ▶️ [All events of AsterDEX](https://ide.bitquery.io/All-events-of-AsterDEX)
 
 #### AsterDEX - All latest Liquidations
 
-AsterDEX - All latest Liquidations. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+When there is a liquidation event on AsterDEX, it emits `ExecuteCloseSuccessful` event with `executionType` 2.
 
 ▶️ [AsterDEX - All latest Liquidations](https://ide.bitquery.io/AsterDEX---All-latest-Liquidations)
 
@@ -3842,19 +4124,19 @@ AsterDEX - OpenMarketTrade. Uses the `Events` cube. Replace the address in the `
 
 #### Trader's specific event
 
-Trader's specific event. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+You can look for `Transaction -> From` or in some cases the address might be in arguments, for example: [Traders specific event
 
 ▶️ [Trader's specific event](https://ide.bitquery.io/Traders-specific-event)
 
 #### Traders data - 0x01554d63537d3c62715826a268d4eab645d64b92
 
-Traders data - 0x01554d63537d3c62715826a268d4eab645d64b92. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+You can actually merge these two queries. Here is an example: [Combined Traders data - 0x01554d63537d3c62715826a268d4eab645d64b92
 
 ▶️ [Traders data - 0x01554d63537d3c62715826a268d4eab645d64b92](https://ide.bitquery.io/Copy-of-Traders-data---0x01554d63537d3c62715826a268d4eab645d64b92)
 
 #### Traders data - 0x2b7363708984aa25a90450cfca7bedaf6804115c
 
-Traders data - 0x2b7363708984aa25a90450cfca7bedaf6804115c. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Using Bitquery's APIs you can follow specific traders on AsterDEX to check all their latest activities.
 
 ▶️ [Traders data - 0x2b7363708984aa25a90450cfca7bedaf6804115c](https://ide.bitquery.io/Traders-data---0x2b7363708984aa25a90450cfca7bedaf6804115c)
 

--- a/docs/start/starter-queries.md
+++ b/docs/start/starter-queries.md
@@ -1,1076 +1,1386 @@
 ---
 title: "Starter Queries - Bitquery API Examples by Chain"
-description: "Starter Queries - Bitquery API Examples by Chain: practical Bitquery setup guidance with examples for authentication, endpoints, and first queries."
+description: "Curated, tested Bitquery API queries organised by chain and data type — trades, transfers, balances, holders, prices, liquidity, events and mempool."
 keywords:
   [
     "Bitquery starter queries",
     "Bitquery examples",
     "blockchain API examples",
     "GraphQL blockchain",
-    "Bitquery IDE",
+    "Bitquery IDE"
   ]
 ---
 # Starter Queries
 
-Below is a set of queries that are curated for you to get started with Bitquery.
+Every query below is saved in the [Bitquery IDE](https://ide.bitquery.io) and was executed against the live API before publishing. Pick a chain, then a data type. Queries marked as needing history use the `archive` or `combined` dataset — the comment at the top of each of those queries shows the single line to change.
 
 ## Table of Contents
 
-- [Cross-Chain / Multi-Chain APIs](#cross-chain--multi-chain-apis)
-- [Polymarket](#polymarket)
 - [Ethereum](#ethereum)
-- [Polygon (MATIC)](#polygon-matic)
 - [Solana](#solana)
+- [BSC](#bsc)
 - [Base](#base)
-- [Robinhood Chain](#robinhood-chain)
-- [BSC (Binance Smart Chain)](#bsc-binance-smart-chain)
+- [Arbitrum](#arbitrum)
+- [Optimism](#optimism)
+- [Polygon](#polygon)
 - [TRON](#tron)
+- [Robinhood Chain](#robinhood-chain)
 - [Bitcoin](#bitcoin)
 - [Cardano](#cardano)
 - [Ripple](#ripple)
-- [Cosmos](#cosmos)
-- [NFT APIs](#nft-apis)
-- [x402 APIs](#x402-apis)
+- [Algorand](#algorand)
+- [Trading API](#trading-api)
+- [Stablecoins](#stablecoins)
+- [Perpetuals](#perpetuals)
+- [NFTs](#nfts)
+- [Polymarket](#polymarket)
+- [Futures DEXs](#futures-dexs)
+- [x402](#x402)
+- [Cross-Chain](#cross-chain)
 
-## Cross-Chain / Multi-Chain APIs
+## Ethereum
 
-### Real Time Data
+### Trades
 
-#### Latest Price of Any Token
+#### Latest DEX trades for a token
 
-This query gives you bitcoin currency 1-sec OHLC across different blockchains. You can adjust duration in `Duration: {eq: 1}` filter.
+Most recent swaps for one token across every Ethereum DEX. Change the token address in the `Currency: {SmartContract:}` filter.
 
-▶️ [Latest Price of Token Across Chains](https://ide.bitquery.io/Latest-bitcoin-price-on-across-chains_5)
+▶️ [Latest DEX trades for a token](https://ide.bitquery.io/Ethereum-Trades-of-a-Token_1)
 
-#### Crypto Price Change API
+#### Realised PnL, buy and sell volume
 
-This query gives you change in price (Close-Open) of all tokens on Ethereum, BNB, Solana and Tron.
-You can adjust duration in `Duration: {eq: 60}` filter.
+Profit and loss for a wallet on one token, from its own trade history. Needs the historical data add-on — see the comment at the top of the query.
 
-▶️ [Crypto Price Change API](https://ide.bitquery.io/1-minute-price-change-api_1)
+▶️ [Realised PnL, buy and sell volume](https://ide.bitquery.io/Realised-Pnl-Buy-volume-Sell-Volume-Ethereum_1)
 
-#### OHLC of a currency on multiple blockchains
+#### Trades by a wallet
 
-This query retrieves the OHLC (Open, High, Low, Close) prices of a currency(in this eg Bitcoin; it will include all sorts of currencies whose underlying asset is Bitcoin like cbBTC, WBTC, etc) across all supported blockchains, aggregated into a given time interval (e.g., 60 seconds in this example).
+Every buy and sell made by one address. Replace the wallet in `Transaction: {From:}`.
 
-▶️ [OHLC of a currency on multiple blockchains](https://ide.bitquery.io/OHLC-of-a-currency-on-multiple-blockchains_2)
+▶️ [Trades by a wallet](https://ide.bitquery.io/Ethereum-Trades-of-a-Trader_1)
 
-#### OHLC of a Token Pair Across Chains
+#### Address is Buyer or Seller V2
 
-This subscription fetches real-time OHLC (Open, High, Low, Close) price data for a token pair across different blockchains.  
-For **native tokens**, you only need to specify their ID (e.g., `bid:eth` for ETH).
+Address is Buyer or Seller V2. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
 
-▶️ [OHLC of a Token Pair Across Chains](https://ide.bitquery.io/Token-OHLC-Stream-1-second-Multi-Chains_3)
+▶️ [Address is Buyer or Seller V2](https://ide.bitquery.io/Address-is-Buyer-or-Seller-V2)
 
-#### Volume of Multiple Tokens Across Different Chains
+#### All events on fluid DEX VaultFactory
 
-Get volume and price change data for multiple tokens trading on different chains (Solana, Ethereum, BSC, Tron) in a single query. Returns volume for 1h, 4h, and 24h periods, plus price change percentages.
+All events on fluid DEX VaultFactory. Uses the `Events` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
 
-> **Note:** For EVM chains (Ethereum, BSC, etc.) in the Trading API, use **all lowercase addresses** in the token ID format (e.g., `bid:eth:0x...` with lowercase hex). Mixed-case addresses may not match.
+▶️ [All events on fluid DEX VaultFactory](https://ide.bitquery.io/all-events-on-fluid-DEX-VaultFactory)
 
-▶️ [Volume of Multiple Tokens Across Chains](https://ide.bitquery.io/volume-of-a-token_2)
+#### Buys, Sells, BuyVolume, SellVolume, Makers, TotalTradedVolume, PriceinUSD for a eth pair
 
-### Historical Data
+Buys, Sells, BuyVolume, SellVolume, Makers, TotalTradedVolume, PriceinUSD for a eth pair. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-#### SMA and Volume Data (for past 28, 14 and 7 Days Time)
+▶️ [Buys, Sells, BuyVolume, SellVolume, Makers, TotalTradedVolume, PriceinUSD for a eth pair](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-a-eth-pair)
 
-Use this API to get SMA and volume over the past 28 days, with 14 days, and 7 days breakdowns. Note that the oldest possible data it could return is 30 days ago.
+#### Coin ticker api
 
-▶️ [SMA and Volume Data for upto 28 Days](https://ide.bitquery.io/multiple-tokens-volume-and-SMA)
+Coin ticker api. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-#### Historical OHLC of a Token Pair Across Chains
+▶️ [Coin ticker api](https://ide.bitquery.io/Coin-ticker-api_4)
 
-This query fetches historical OHLC (Open, High, Low, Close) price data for a token pair across different blockchains for as long back as 30 days.  
-For **native tokens**, you only need to specify their ID (e.g., `bid:eth` for ETH).
+#### Dex info
 
-▶️ [OHLC of a Token Pair Across Chains](https://ide.bitquery.io/Historical-Token-OHLC-Multi-Chains_1)
+Dex info. Uses the `DEXTradeByTokens` cube.
+
+▶️ [Dex info](https://ide.bitquery.io/dex-info)
+
+#### Dex markets
+
+Dex markets.
+
+▶️ [Dex markets](https://ide.bitquery.io/dex-markets)
+
+#### First 500 buyers of a token
+
+Earliest buyers of a token in order, useful for launch and insider analysis. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [First 500 buyers of a token](https://ide.bitquery.io/first-500-buyers-of-a-ERC20-token_1)
+
+### Transfers
+
+#### ERC-20 transfers by wallet
+
+Recent token transfers in and out of one address. Replace the address in the `where` clause.
+
+▶️ [ERC-20 transfers by wallet](https://ide.bitquery.io/Get-ERC20-token-transfers-by-wallet_7)
+
+#### ERC-20 transfers over a past period
+
+Token transfers for a wallet between two dates. Change `since` and `till`. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [ERC-20 transfers over a past period](https://ide.bitquery.io/Get-historical-ERC20-token-transfers-by-wallet_1)
+
+#### Array_intersect example for 2 addresses
+
+Array_intersect example for 2 addresses. Uses the `Transfers` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Array_intersect example for 2 addresses](https://ide.bitquery.io/array_intersect-example-for-2-addresses_2)
+
+#### Binance:hot wallet transfers with transaction fees
+
+Binance:hot wallet transfers with transaction fees. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Binance:hot wallet transfers with transaction fees](https://ide.bitquery.io/binancehot-wallet-transfers-with-transaction-fees)
+
+#### Find earliest transfer to an account
+
+Find earliest transfer to an account. Uses the `Transfers` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Find earliest transfer to an account](https://ide.bitquery.io/Copy-of-find-earliest-transfer-to-an-account)
+
+#### Get Contract Type in v2
+
+Get Contract Type in v2. Uses the `Transfers` cube.
+
+▶️ [Get Contract Type in v2](https://ide.bitquery.io/Get-Contract-Type-in-v2)
+
+#### Get Minted Address of the ICO Token
+
+Get Minted Address of the ICO Token. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Get Minted Address of the ICO Token](https://ide.bitquery.io/Get-Minted-Address-of-the-ICO-Token)
+
+#### Number of Purchasers in ICO
+
+Number of Purchasers in ICO. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Number of Purchasers in ICO](https://ide.bitquery.io/Number-of-Purchasers-in-ICO)
+
+#### Transfers sent OR received by an address
+
+Both sides of an address's transfer history in one result, using an OR filter. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Transfers sent OR received by an address](https://ide.bitquery.io/Sender-OR-Receiver-Transfer-on-Ethereum)
+
+#### Total txn fees paid by binance hot wallet in a day
+
+Total txn fees paid by binance hot wallet in a day. Uses the `Transfers` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Total txn fees paid by binance hot wallet in a day](https://ide.bitquery.io/total-txn-fees-paid-by-binance-hot-wallet-in-a-day)
+
+### Balances & Holders
+
+#### Current balance of an address
+
+Every token balance held by one wallet, with USD value. Balances are cumulative, so this reads the full history. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Current balance of an address](https://ide.bitquery.io/Ethereum-Balance-of-an-Address_2)
+
+#### Token holder count
+
+How many addresses hold a token right now. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Token holder count](https://ide.bitquery.io/Copy-of-token-holders-count-eth)
+
+#### Balance of an address at a past date
+
+What a wallet held on a given day. Change the `date` argument. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Balance of an address at a past date](https://ide.bitquery.io/Historical-Balance-of-an-Address_1)
+
+#### Token holders on a specific date
+
+A holder snapshot for any past day, with per-holder stats. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Token holders on a specific date](https://ide.bitquery.io/tokens-holders-of-a-token_10)
+
+#### Token Holders of Multiple Tokens until last month
+
+This API provides a list of top holders along with relevant statistics for a given token liston a specific date using BalanceUpdates API.
+
+▶️ [Token Holders of Multiple Tokens until last month](https://ide.bitquery.io/Top-10-historical-holders-of-multiple-tokens-on-ETH)
+
+#### Average Tip in terms of avg gas Fee
+
+Average Tip in terms of avg gas Fee. Uses the `TransactionBalances` cube.
+
+▶️ [Average Tip in terms of avg gas Fee](https://ide.bitquery.io/Average-Tip-in-terms-of-avg-gas-Fee_4)
+
+#### Balance Updates for multiple addresses transfer in last 24 hours
+
+Balance Updates for multiple addresses transfer in last 24 hours. Uses the `TransactionBalances` cube.
+
+▶️ [Balance Updates for multiple addresses transfer in last 24 hours](https://ide.bitquery.io/Balance-Updates-for-multiple-addresses-transfer-in-last-24-hours)
+
+#### Balance Updates for transfer in last 24 hours
+
+Balance Updates for transfer in last 24 hours. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Balance Updates for transfer in last 24 hours](https://ide.bitquery.io/Balance-Updates-for-transfer-in-last-24-hours)
+
+#### Balance update after transfer received from multiple addresses
+
+Balance update after transfer received from multiple addresses. Uses the `TransactionBalances` cube.
+
+▶️ [Balance update after transfer received from multiple addresses](https://ide.bitquery.io/Balance-update-after-transfer-received-from-multiple-addresses_2)
+
+#### Balance update after transfer sent from multiple addresses
+
+Balance update after transfer sent from multiple addresses. Uses the `TransactionBalances` cube.
+
+▶️ [Balance update after transfer sent from multiple addresses](https://ide.bitquery.io/Balance-update-after-transfer-sent-from-multiple-addresses)
+
+### Price & OHLC
+
+#### All-time high price of a token
+
+Highest price a token has ever traded at, with the date it happened. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [All-time high price of a token](https://ide.bitquery.io/ATH-of-eth-token)
+
+#### Prices for multiple tokens at once
+
+Latest USD price for a list of tokens in a single request. Add addresses to the `in` filter.
+
+▶️ [Prices for multiple tokens at once](https://ide.bitquery.io/Price-of-multiple-tokens-in-realtime)
+
+#### OHLCV by pair address
+
+Open, high, low, close and volume candles for one pair. Change the interval to re-bucket the candles.
+
+▶️ [OHLCV by pair address](https://ide.bitquery.io/OHLC0_8)
+
+#### Price change over 5m, 1h, 6h and 24h
+
+Percentage moves across four windows for one token in one query.
+
+▶️ [Price change over 5m, 1h, 6h and 24h](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_4)
+
+#### Top 10 tokens by price change, last hour
+
+Biggest movers on Ethereum over the past hour, ranked.
+
+▶️ [Top 10 tokens by price change, last hour](https://ide.bitquery.io/Top-10-eth-tokens-by-price-change-in-last-1-hr_2)
 
 #### Historical Price and Volume Data for a Token Pair beyond 30 days
 
 Use this API to get historical price and volume for a specific token pair address on a specific network for the time window beyond the 30 days.
 
-▶️ [Historical Price and Volume Data](https://ide.bitquery.io/historical-price-and-historical-volume)
+▶️ [Historical Price and Volume Data for a Token Pair beyond 30 days](https://ide.bitquery.io/historical-price-and-historical-volume)
 
-#### All time High Trade Price for a Token
+#### Ohlc of a token pair 1 hour interval
 
-Retrieves the all-time high (ATH) price in USD for a specified token contract. All time high price could lie beyond the 30 days window provided by Trading API, hence we use these network specific APIs to get the ATH for a token. While this provides the option to go beyond the 30 days time window, it also restricts the records to a single network.
+Ohlc of a token pair 1 hour interval. Uses the `Pairs` cube.
 
-▶️ [Get ATH Price of a token](https://ide.bitquery.io/ATH-of-eth-token_1)
+▶️ [Ohlc of a token pair 1 hour interval](https://ide.bitquery.io/ohlc-of-a-token-pair-1-hour-interval)
 
-## PolyMarket
+#### Pepe historical ohlcv 30days
 
-### Prediction Market Trades
+Pepe historical ohlcv 30days. Uses the `Tokens` cube.
 
-Prediction market buy/sell activity on outcome tokens on Polygon. See [Prediction Market Trades API](/docs/examples/prediction-market/prediction-trades-api) for full details.
-
-#### Latest Trades
-
-Fetch the most recent prediction market trades with full details, ordered by block time.
-▶️ [Latest Prediction Market Trades](https://ide.bitquery.io/latest-prediction-market-trades_8)
-
-#### Trades for a Specific Trader
-
-Fetch all trades where the given address is either Buyer or Seller. Pass the trader address as the `$trader` variable.
-▶️ [Trades for a Specific Trader](https://ide.bitquery.io/Trades-for-a-specific-trader_1)
-
-#### Total Volume and Yes/No Volume for a Market
-
-Aggregate USD volume for a market over a time window: total volume plus volume per outcome (e.g. Yes/No). Pass the market's outcome token AssetIds in `$marketAssets`.
-▶️ [Total Volume and Yes/No Volume for a Market](https://ide.bitquery.io/total-volume-outcome-1-volume-outcome-2-volume-of-a-market_1)
-
-#### Current Price per Outcome (Latest Trade)
-
-Get the latest trade price for each outcome in a market. Uses `limitBy` for one row per outcome, with Price and PriceInUSD at the most recent block time.
-▶️ [Current Price per Outcome](https://ide.bitquery.io/Current-price-inside-the-market-for-all-options-based-on-latest-trade_1)
-
-### Prediction Market Managements
-
-Prediction market lifecycle events (Created, Resolved) on Polygon. See [Prediction Market Managements API](/docs/examples/prediction-market/prediction-managements-api) for full details.
-
-#### Latest Creations + Resolutions
-
-Fetch the most recent creation and resolution events with full details, ordered by block time.
-▶️ [Latest Prediction Managements](https://ide.bitquery.io/latest-Prediction-managements-resolutions-creations_1)
-
-#### Created vs Resolved Count (Last 24 Hours)
-
-Count how many Created and Resolved events occurred in the last 24 hours.
-▶️ [Created vs Resolved Count Last 24h](https://ide.bitquery.io/last-24-hr-resolution-and-ceated-count_1)
-
-#### Latest Market Creations
-
-Fetch the most recent Created events (new markets). All possible outcomes per market are in Prediction.Condition.Outcomes.
-▶️ [Latest Market Creations](https://ide.bitquery.io/latest-polymarket-creations_1)
-
-#### Latest Market Resolutions
-
-Query that returns the 10 most recent Resolved events. Winning outcome is in Prediction.Outcome; Prediction.OutcomeToken holds the asset ID and contract details.
-▶️ [Latest Market Resolutions](https://ide.bitquery.io/latest-polymarket-resolutions_2)
-
-### Prediction Market Settlements
-
-Prediction market settlement events (Split, Merge, Redemption) on Polygon. See [Prediction Market Settlements API](/docs/examples/prediction-market/prediction-settlements-api) for full details.
-
-#### Latest Settlements
-
-Fetch the most recent settlements with full details, ordered by block time.
-▶️ [Latest Prediction Market Settlements](https://ide.bitquery.io/latest-prediction-market-settlements_3)
-
-#### Redemption / Merge / Split Count (Last 1 Hour)
-
-Count how many settlement events occurred in the last hour, grouped by event signature (Split, Merge, Redemption).
-▶️ [Redemptions Merge Split Count](https://ide.bitquery.io/redemptions-merge-split-count-in-last-1-hour_1)
-
-#### Latest Whale Settlements
-
-Find the most recent high-value redemptions (e.g. amount ≥ 10,000 in outcome token units). Useful for tracking large payouts and whale activity.
-▶️ [Latest Whale Settlements](https://ide.bitquery.io/latest-whale-settlements-on-prediction-market_3)
-
-#### Top 10 Winners of a Specific Market Question
-
-Rank holders by total redeemed amount for one market (filter by question title).
-▶️ [Top 10 Winners of a Market Question](https://ide.bitquery.io/top-10-winners-of-a-market-question_2)
-
-#### Top 10 Market Questions by Redeemed Amount (Last 1 Hour)
-
-Aggregate redemptions by market question and sort by total redeemed amount. See which markets had the most payout activity recently.
-▶️ [Top 10 Market Questions by Redeemed Amount](https://ide.bitquery.io/top-10-market-questions-in-last-1-hour_3)
-
-#### Top 10 Redeemers (Last 1 Hour)
-
-Rank addresses by total amount redeemed in the last hour across all markets. Useful for leaderboards and whale tracking.
-▶️ [Top 10 Redeemers](https://ide.bitquery.io/top-10-redeemers_1)
-
-## Ethereum
-
-### Real Time Balance APIs
-
-#### Current Balance of an address
-
-Returns all token balances for a wallet on Ethereum using `EVM.Balances` with `dataset: combined`.
-▶️ [Balance of an Address](https://ide.bitquery.io/Ethereum-Balance-of-an-Address_2)
-
-#### Latest Liquidity of EVM Pool
-
-Get the latest liquidity of an EVM DEX pool (e.g., Uniswap v3 pool).
-
-▶️ [Latest Liquidity of EVM Pool](https://ide.bitquery.io/latest-liquidity-of-a-EVM-pool_1)
-
-### Historical Balance APIs
-
-#### Historical Balance of an address
-Returns all token balances for a wallet on Ethereum on a certain date, using `EVM.Balances` with `dataset: archive`.
-▶️ [Historical Balance of an Address](https://ide.bitquery.io/Historical-Balance-of-an-Address_1)
-
-### Token Supply
-
-#### Latest Token Supply on ETH chain
-
-Latest Token Supply for all active token
-
-▶️ [Latest Token Supply for all active token](https://ide.bitquery.io/latest-token-supply-of-all-active-tokens-on-ETH-chain_1)
-
-#### Latest Token Supply of USDT-USDC on ETH chain
-
-Latest Token Supply for stablecoin like USDC-USDT.
-
-▶️ [Latest Token Supply for stablecoin like USDC-USDT](https://ide.bitquery.io/latest-token-supply-on-USDT-and-USDC-on-ethereum-chain_1)
-
-### MarketCap APIs
-
-Trading API **`Tokens`** query for the latest **market cap**, **FDV**, **supply**, **price**, and **volume** for one Ethereum token. Use **`eth:`** + **lowercase** contract in **`Token.Id`**. Full examples: **[Ethereum Token Market Cap API](/docs/blockchain/Ethereum/token-supply/ethereum-token-marketcap-api)**.
-
-#### Latest market cap for a specific Ethereum token (Trading API)
-
-▶️ [Specific Ethereum Token Latest Market Cap](https://ide.bitquery.io/specific-ethereum-token-latest-marketcap_2)
-
-### Real Time Transfers
-
-#### Get ERC20 token transfers by wallet
-
-Get ERC20 token transfers ordered by block number in descending order.  
-▶️ [Get ERC20 token transfers by wallet](https://ide.bitquery.io/Get-ERC20-token-transfers-by-wallet_7)
-
-### Historical Transfers
-
-#### Get Historical ERC20 token transfers by wallet
-
-Get ERC20 token transfers for an address in a given historical time window
-▶️ [Get Historical ERC20 token transfers by wallet](https://ide.bitquery.io/Get-historical-ERC20-token-transfers-by-wallet_1)
-
-### Real Time Transactions
-
-#### Get transactions by wallet
-
-Get transactions ordered by block number in descending order.  
-▶️ [Get transactions by wallet](https://ide.bitquery.io/Get-transactions-by-wallet_7)
-
-### Historical Transactions
-
-#### Get historical transactions by wallet in a given period
-
-Get historical transactions for a given period of time ordered by block number in descending order.  
-▶️ [Get historical transactions by wallet](https://ide.bitquery.io/Get-historical-transactions-by-wallet-etc_1)
-
-### Trades
-
-#### Ethereum DEXTrades latest trades for a token
-
-This query returns the latest trades on the Ethereum network where distinction of the buy and sell sides is present.
-
-▶️ [Ethereum DEX Trades](https://ide.bitquery.io/Ethereum-Trades-of-a-Token_1)
-
-#### Get Swaps by Wallet Address
-
-Get all swap related transactions (buy, sell).  
-▶️ [Get Swaps by Wallet Address](https://ide.bitquery.io/Ethereum-Trades-of-a-Trader_1)
-
-### Events & Calls
-
-#### Get Latest Events
-
-▶️ [Get Latest Events](https://ide.bitquery.io/Recents-Events-and-Logs-on-Ethereum_3)
-
-#### Get Latest Calls
-
-▶️ [Get Latest Calls](https://ide.bitquery.io/Recent-Calls-on-Ethereum_2)
-
-### OHLC & Price Data
-
-#### Get OHLCV by Pair Address
-
-Get the OHLCV candle stick by using pair address.  
-▶️ [Get OHLCV by Pair Address](https://ide.bitquery.io/OHLC0_8)
-
-#### Get Multiple ERC20 Token Prices
-
-Returns an array of token prices denominated in the blockchain's native token and USD for a given token contract address.  
-▶️ [Get Multiple ERC20 Token Prices](https://ide.bitquery.io/Price-of-multiple-tokens-in-realtime)
-
-#### Get ATH Price of a token
-
-Retrieves the all-time high (ATH) price in USD for a specified token contract.
-▶️ [Get ATH Price of a token](https://ide.bitquery.io/ATH-of-eth-token)
-
-#### Get Price Change 5min, 1h, 6h and 24h of a specific Eth token
-
-This query gets you Price Change 5min, 1h, 6h and 24h of a specific token on the Ethereum network.
-▶️ [Get Price Change 5min, 1h, 6h and 24h of a specific token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_4)
-
-#### Historical Price and Volume Data (Volume & Price, Last 24h using Trading API)
-
-Use this API to get historical price and volume for a specific token over the past 24 hours, with 1h, 4h, and 24h breakdowns.
-
-▶️ [Historical Price and Volume Data](https://ide.bitquery.io/historical-price-and-historical-volume)
-
-#### Top 10 Eth Tokens by Price Change in last 1h
-
-This query gets you top 10 Eth Tokens by Price Change in last 1h.
-▶️ [Top 10 Eth Tokens by Price Change in last 1h](https://ide.bitquery.io/Top-10-eth-tokens-by-price-change-in-last-1-hr_2)
-
-#### Uniswap v3 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders
-
-1-second OHLC and volume stream for tokens traded on Uniswap v3 (Ethereum). Great for bot trading strategies.
-▶️ [Uniswap v3 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders](https://ide.bitquery.io/Uniswap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
-
-### Real Time Token Analytics
-
-#### Get Latest Token Total Supply and Market Cap
-
-Retrieve the total supply and market capitalization of a specific ERC-20 token. This query provides on-chain market cap data.
-▶️ [Get Token Total Supply and Market Cap](https://ide.bitquery.io/Get-Token-Total-Supply-and-Market-Cap_4)
-
-#### Current Token Holder Count
-
-This API returns the total number of holders for a specific token on a given date.
-▶️ [Token Holder Count on a Specific Date](https://ide.bitquery.io/Copy-of-token-holders-count-eth)
-
-#### Real-Time Holders of Multiple Tokens
-
-This API leverages the Holders endpoint to deliver real-time holder data for multiple tokens.
-▶️ [Real-Time Holders of Multiple Tokens](https://ide.bitquery.io/Top-10-holders-of-multiple-tokens-on-ETH_4)
-
-#### Realised PnL, buy volume, sell volume
-
-Get realised PnL, buy volume, and sell volume for a token on EVM of a trader for over a time window.
-▶️ [Realised PnL, buy volume, sell volume](https://ide.bitquery.io/Realised-Pnl-Buy-volume-Sell-Volume-Ethereum_1)
-
-### Historical Token Analytics
-
-#### Token Holders of Multiple Tokens until last month
-
-This API provides a list of top holders along with relevant statistics for a given token liston a specific date using BalanceUpdates API.
-▶️ [Real-Time Holders of Multiple Tokens](https://ide.bitquery.io/Top-10-historical-holders-of-multiple-tokens-on-ETH)
-
-#### Token Holders and Stats on a Specific Date
-
-This API provides a list of all holders along with relevant statistics for a given token on a specific date.
-
-▶️ [Token Holders and Stats on a Specific Date](https://ide.bitquery.io/tokens-holders-of-a-token_10)
-
-### Slippage APIs
-
-#### Latest Slippage for a Specific Pool on Uniswap V3
-
-This query retrieves the latest slippage data for a specific DEX pool on Ethereum. Use this to check current liquidity depth and price impact for a particular token pair.
-
-▶️ [Latest Slippage for a Specific Pool on Uniswap V3](https://ide.bitquery.io/Latest-slippage-of-a-pool-on-Uniswap-v3-Ethereum_1)
-
-### Liquidity APIs
-
-#### Latest Liquidity Changes of a Specific Pool
-
-This query retrieves the latest liquidity events for a specific DEX pool on Ethereum. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
-
-▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool-on-ETH_1)
-
-#### Top Liquidity Pools of a token on Ethereum
-
-▶️ [Top Liquidity Pools of a token on Ethereum](https://ide.bitquery.io/top-liquidity-pools-of-atoken-on-ethereum_1)
-
-#### Liquidity of All Pools of a Token on Ethereum
-
-Get latest liquidity across all pools where the token appears as either pool side.
-▶️ [Liquidity of All Pools of a Token on Ethereum](https://ide.bitquery.io/liquidiy-of-all-token-pools_2)
-
-## Polygon (MATIC)
-
-### Real Time Balance APIs
-
-#### Balance of an address
-
-Returns all token balances for a wallet on Polygon using `EVM.Balances` with `network: matic` and `dataset: combined`. See [Polygon Address Balance API](/docs/blockchain/Matic/matic-balance-api/#balance-of-an-address).
-▶️ [Balance of an Address](https://ide.bitquery.io/matic-balances-address_1)
-
-### Historical Balance APIs
-
-#### Balance of an address
-
-Returns all token balances for a wallet on Polygon using `EVM.Balances` with `network: matic` and `dataset: combined` until a particular period. For this example we will find the Balnce of the address one month ago.
-
-▶️ [Balance of an Address](https://ide.bitquery.io/matic-historical-balances-address_1)
-
-## Solana
-
-### Balance APIs
-
-#### Get Native and SPL Token Balance by Wallet
-
-Gets the portfolio for an address.
-▶️ [Get Native and SPL Token Balance by Wallet](https://ide.bitquery.io/tokens-owned-by-an-address_3)
-
-#### Historical Solana Balance
-
-This API returns all token inflows and outflows for a Solana address within a specified timeframe, enabling balance calculation based on transaction history.
-▶️ [Solana Token Inflows and Outflows for Balance Calculation](https://ide.bitquery.io/currency-sent-and-received-by-an-address-between-a-time_6)
-
-#### Solana Balance Update
-
-This query returns Solana balance update info for any balance update event. It includes the address, amount, currency details, and the amount of tokens present in a particular address before and after the update.  
-▶️ [Balance Update](https://ide.bitquery.io/solana-balance-update)
-
-#### Solana Instruction Balance Updates
-
-This query returns Solana balance update info for any balance update event, including the address, amount, currency details, and the details of the program responsible for this update.  
-▶️ [Instruction Balance Updates](https://ide.bitquery.io/Solana-InstructionBalanceUpdates)
-
-### MarketCap APIs
-
-Trading API **`Tokens`** query for the latest **market cap**, **FDV**, **supply**, **price**, and **volume** for one Solana token. Use **`solana:`** + mint in **`Token.Id`**. Full examples: **[Solana Token Market Cap API](/docs/blockchain/Solana/solana-token-marketcap-api)**.
-
-#### Latest market cap for a specific Solana token (Trading API)
-
-▶️ [Specific Solana Token Latest Market Cap](https://ide.bitquery.io/specific-solana-token-latest-marketcap)
-
-### Transfers
-
-#### Solana Transfers
-
-This query gets the latest 10 transfers on Solana. You can increase the limit to get more transfers. This query only uses real-time data.  
-▶️ [Solana Transfers](https://ide.bitquery.io/Solana-transfers0_5)
-
-#### Solana Historical Transfers
-
-▶️ [Solana Historical Transfers](https://ide.bitquery.io/solana-historical-transfers_1)
-
-#### Find who funded the specific Solana wallet
-
-To determine who funded a specific Solana wallet with SOL, you can utilise the following API.
-▶️[Find who funded the specific Solana wallet](https://ide.bitquery.io/Who-funded-a-given-wallet)
-
-#### Solana Token creator and Time
-
-▶️[Solana Token creator and Time](https://ide.bitquery.io/Solana-token-creation-date-and-creator)
-
-#### Solana Historical Token Transfers Over Time
-
-This API provides historical data on all Solana token transfers that occurred within a specified time range.
-▶️ [Solana Historical Token Transfers Over Time](https://ide.bitquery.io/Solana-historical-token-transfers-between-a-time_2)
-
-#### Solana Token Transfers for a Specific Address
-
-This API retrieves the history of token transfers (both sent and received) for a specific Solana address within a defined time period.
-▶️ [Solana Token Transfers for a Specific Address](https://ide.bitquery.io/Solana-historical-token-transfers-of-an-address-between-a-time)
-
-#### Solana Token Inflows and Outflows for Balance Calculation
-
-This API returns all token inflows and outflows for a Solana address within a specified timeframe, enabling balance calculation based on transaction history.
-▶️ [Solana Token Inflows and Outflows for Balance Calculation](https://ide.bitquery.io/currency-sent-and-received-by-an-address-between-a-time_6)
-
-#### Simple SOL transfers (Transactions not trades)
-
-This API returns simple SOL transfers; in other words, it contains transactions that are simple token transfers, not trades.
-▶️ [Simple SOL transfers (Transactions not trades)](https://ide.bitquery.io/Simple-SOL-transfers-Transactions-not-trades)
-
-### Trades
-
-#### Solana Chain Trades
-
-This query gets the latest 10 trades on Solana. You can increase the limit to get more trades. This query only uses real-time data.  
-▶️ [Solana Trades](https://ide.bitquery.io/Solana-dextrades00_10)
-
-#### Solana Trades of a Token
-
-With this, you can query the trades of a token on Solana.  
-▶️ [Trades of a Token](https://ide.bitquery.io/Solana-dextrades-for-a-token_1#)
-
-#### Get Trades by Wallet Address
-
-Get all trades related transactions (buy, sell) for a specific wallet address.
-▶️ [Get Swaps by Wallet Address](https://ide.bitquery.io/Solana-dextrades-by-a-trader_2)
-
-#### Get Swaps by Pair Address
-
-Get all trades related transactions for a specific pair address.
-▶️ [Get Swaps by Pair Address](https://ide.bitquery.io/swaps-for-a-market-address-on-Solana)
-
-#### Latest Trades for a specific currency on Raydium
-
-This query returns the latest trades for a token on Raydium. You can set the limit here also.
-▶️ [Latest trades of a token on Raydium](https://ide.bitquery.io/Trades-for-a-token-on-Raydium-on-Solana)
-
-#### Latest Trades in Real Time of a specific DEX
-
-This subscription query returns the latest PumpFun trades in real time.  
-▶️ [Real-time Trades](https://ide.bitquery.io/Latest-Pumpfun-trades-on-Solana)
-
-### OHLC & Price Data
-
-#### Get OHLCV by Pair Address
-
-You can get charting data easily with this query. Adjust the intervals as necessary. This query supports historical data.  
-▶️ [Get OHLCV by Pair Address](https://ide.bitquery.io/OHLC-for-a-token_8)
-
-#### Real-Time Token Prices in USD on Solana
-
-Stream live OHLC (Open, High, Low, Close) price and volume data for all tokens on Solana, quoted directly in USD. Useful for dashboards, analytics, or bots that need stable fiat-based prices.
-▶️ [Real-Time Token Prices in USD on Solana](https://ide.bitquery.io/Real-Time-usd-price-on-solana-chain)
-
-#### Get ATH Price of a token
-
-Retrieves the all-time high (ATH) price in USD for a specified token contract.
-▶️ [Get ATH Price of a token](https://ide.bitquery.io/solana-ATH_9)
-
-#### Latest Token Prices in Quote Pair (USDC, USDT, etc.)
-
-Get latest OHLC prices for Solana tokens denominated in their trading pair token (e.g., USDC, USDT, or another crypto), instead of direct USD. Great for analyzing token behavior relative to stablecoins or other assets.
-▶️ [Latest Token Prices in Quote pair](https://ide.bitquery.io/Latest-usd-price-on-solana-chain)
+▶️ [Pepe historical ohlcv 30days](https://ide.bitquery.io/pepe-historical-ohlcv-30days)
 
 #### Price change 5min, 1hr, 6hr precentage of a specific token
 
-With this, you can get the price change 5min, 1hr, 6hr precentage of a specific token.
-▶️ [Price change 5min, 1hr, 6hr precentage](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_5)
+Price change 5min, 1hr, 6hr precentage of a specific token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
 
-#### Top 10 solana tokens by price change in last 1 hr
+▶️ [Price change 5min, 1hr, 6hr precentage of a specific token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_1)
 
-With this, you can get top 10 solana tokens by price change in last 1 hr.
-▶️ [Top 10 solana tokens by price change in last 1 hr](https://ide.bitquery.io/Top-10-solana-tokens-by-price-change-in-last-1-hr_4)
+#### Price of a token in realtime
 
-#### PumpAMM 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders
+Price of a token in realtime. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
 
-Real-time (1-second interval) price, OHLC, volume, and moving averages for Pump.fun AMM tokens on Solana. Useful for high-frequency trading bots.
-▶️ [PumpAMM 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders](https://ide.bitquery.io/PumpAMM-tokens-1-second-price-stream-with-OHLC_1)
+▶️ [Price of a token in realtime](https://ide.bitquery.io/Price-of-a-token-in-realtime)
 
-#### Raydium Launchlab 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders
+### Supply & Market Cap
 
-Monitor Raydium Launchlab token listings on Solana with 1-second OHLC and volume streams. Perfect for tracking new token launches.
-▶️ [Raydium Launchlab 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders](https://ide.bitquery.io/Raydium-Launchpad-DEX-tokens-1-second-price-stream-with-OHLC)
+#### Total supply and market cap of a token
 
-#### Latest Price of a Token on Raydium Launchpad
+Current circulating supply and market cap for one token.
 
-This query returns the latest price of a token on the Raydium launchpad.  
-▶️ [Latest Token Price on Launchpad](https://ide.bitquery.io/Latest-Price-of-a-Token-on-Launchpad)
+▶️ [Total supply and market cap of a token](https://ide.bitquery.io/Get-Token-Total-Supply-and-Market-Cap_4)
 
-#### Latest Price of a LetsBonk.fun
+#### Latest supply of USDT and USDC
 
-This query returns the latest price of a LetsBonk.fun token.  
-▶️ [Latest LetsBonk.fun Token Price](https://ide.bitquery.io/Latest-Price-of-a-LetsBonkfun-Token-on-Launchpad?)
+Live supply for the two largest stablecoins; swap the addresses for any other tokens.
 
-### Token Analytics
+▶️ [Latest supply of USDT and USDC](https://ide.bitquery.io/latest-token-supply-on-USDT-and-USDC-on-ethereum-chain_1)
 
-#### Get Token Prices on Solana
+#### Get Token Total Supply and Market Cap
 
-Returns price information for multiple Solana tokens in a single request.
-▶️ [Get Multiple Token Prices on Solana](https://ide.bitquery.io/Get-multiple-Token-Prices)
+Get Token Total Supply and Market Cap. Uses the `TransactionBalances` cube.
+
+▶️ [Get Token Total Supply and Market Cap](https://ide.bitquery.io/Get-Token-Total-Supply-and-Market-Cap)
+
+#### Latest token supply on USDT and USDC on ethereum chain
+
+Latest token supply on USDT and USDC on ethereum chain. Uses the `TransactionBalances` cube.
+
+▶️ [Latest token supply on USDT and USDC on ethereum chain](https://ide.bitquery.io/latest-token-supply-on-USDT-and-USDC-on-ethereum-chain)
+
+#### Pepe volume marketcap
+
+Pepe volume marketcap. Uses the `Tokens` cube.
+
+▶️ [Pepe volume marketcap](https://ide.bitquery.io/pepe-volume-marketcap)
+
+#### Top tokens by market cap
+
+Ethereum tokens ranked by market capitalisation.
+
+▶️ [Top tokens by market cap](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-Ethereum)
+
+#### Total Supply and onchain Marketcap of a specific token
+
+Total Supply and onchain Marketcap of a specific token. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Total Supply and onchain Marketcap of a specific token](https://ide.bitquery.io/Total-Supply-and-onchain-Marketcap-of-a-specific-token)
+
+### Liquidity & Pools
+
+#### Latest liquidity of a pool
+
+Current reserves on both sides of one pool. Replace the pool address.
+
+▶️ [Latest liquidity of a pool](https://ide.bitquery.io/latest-liquidity-of-a-EVM-pool_1)
+
+#### Liquidity across all pools of a token
+
+Total liquidity for a token summed across every pool it trades in.
+
+▶️ [Liquidity across all pools of a token](https://ide.bitquery.io/liquidiy-of-all-token-pools_2)
+
+#### Top liquidity pools for a token
+
+The deepest pools holding a token, ranked by liquidity.
+
+▶️ [Top liquidity pools for a token](https://ide.bitquery.io/top-liquidity-pools-of-atoken-on-ethereum_1)
+
+#### Decoded arguments of a specific function call
+
+Every call to one function with its arguments decoded. Change the method name to track a different function. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Decoded arguments of a specific function call](https://ide.bitquery.io/addLiquidityETH_function)
+
+#### BlackRock USD Institutional Digital Liquidity Fund Latest Issuance
+
+BlackRock USD Institutional Digital Liquidity Fund Latest Issuance. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [BlackRock USD Institutional Digital Liquidity Fund Latest Issuance](https://ide.bitquery.io/BlackRock-USD-Institutional-Digital-Liquidity-Fund-Latest-Issuance)
+
+#### Liquidiy of all token pools
+
+Liquidiy of all token pools. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Liquidiy of all token pools](https://ide.bitquery.io/liquidiy-of-all-token-pools_1)
+
+#### Top liquidity pools of atoken on ethereum
+
+Top liquidity pools of atoken on ethereum. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top liquidity pools of atoken on ethereum](https://ide.bitquery.io/top-liquidity-pools-of-atoken-on-ethereum)
+
+#### Top liquidity pools on Ethereum
+
+Top liquidity pools on Ethereum. Uses the `DEXPoolEvents` cube.
+
+▶️ [Top liquidity pools on Ethereum](https://ide.bitquery.io/top-liquidity-pools-on-Ethereum)
+
+#### Latest Liquidity Changes of a Specific Pool
+
+Latest Liquidity Changes of a Specific Pool. Uses the `DEXPoolEvents` cube.
+
+▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_5)
+
+### Transactions
+
+#### Transactions by wallet
+
+Recent transactions sent from or to an address.
+
+▶️ [Transactions by wallet](https://ide.bitquery.io/Get-transactions-by-wallet_7)
+
+#### Look up a transaction by hash
+
+Full detail for a single transaction. Paste the hash into the `where` clause.
+
+▶️ [Look up a transaction by hash](https://ide.bitquery.io/Get-a-transaction-by-hash)
+
+#### Transaction value in USD
+
+Converts transaction value to USD at the time it was mined.
+
+▶️ [Transaction value in USD](https://ide.bitquery.io/Transaction-value-in-USD)
+
+#### Debug traceTransaction
+
+Debug traceTransaction. Uses the `Calls` cube.
+
+▶️ [Debug traceTransaction](https://ide.bitquery.io/debug_traceTransaction)
+
+#### Eth getBlockReceipt
+
+Eth getBlockReceipt. Uses the `Transactions` cube.
+
+▶️ [Eth getBlockReceipt](https://ide.bitquery.io/eth_getBlockReceipt)
+
+#### Eth getTransactionByHash
+
+Eth getTransactionByHash. Uses the `Transactions` cube.
+
+▶️ [Eth getTransactionByHash](https://ide.bitquery.io/eth_getTransactionByHash_1)
+
+#### Eth getTransactionReceipt
+
+Eth getTransactionReceipt. Uses the `Transactions` cube.
+
+▶️ [Eth getTransactionReceipt](https://ide.bitquery.io/eth_getTransactionReceipt_1)
+
+#### Internal transactions of a transaction
+
+The internal calls a transaction produced — what a block explorer shows as internal txns.
+
+▶️ [Internal transactions of a transaction](https://ide.bitquery.io/internal-transactions-for-a-particular-tx)
+
+### Events & Calls
+
+#### Latest smart contract calls
+
+Decoded contract calls with their arguments.
+
+▶️ [Latest smart contract calls](https://ide.bitquery.io/Recent-Calls-on-Ethereum_2)
+
+#### Latest events and logs
+
+Decoded event logs as they land. Filter by contract or by event name.
+
+▶️ [Latest events and logs](https://ide.bitquery.io/Recents-Events-and-Logs-on-Ethereum_3)
+
+#### All aave v3 events latest
+
+All aave v3 events latest. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [All aave v3 events latest](https://ide.bitquery.io/All-aave-v3-events-latest)
+
+#### ByteCode of A Token
+
+ByteCode of A Token. Uses the `Calls` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [ByteCode of A Token](https://ide.bitquery.io/ByteCode-of-A-Token)
+
+#### Find the deployer of a contract
+
+Returns which address created a given contract, and when. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Find the deployer of a contract](https://ide.bitquery.io/creator--deployer-of-an-address_1)
+
+#### Debug_traceCall
+
+Debug_traceCall. Uses the `Calls` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Debug_traceCall](https://ide.bitquery.io/debug_traceCall)
+
+#### ETH/BSC SC creates count over date
+
+ETH/BSC SC creates count over date. Uses the `Calls` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [ETH/BSC SC creates count over date](https://ide.bitquery.io/ETHBSC-SC-creates-count-over-date)
+
+#### Eth getLogs with filters
+
+Eth getLogs with filters. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Eth getLogs with filters](https://ide.bitquery.io/eth_getLogs-with-filters)
+
+### Mempool
+
+#### Get next available nonce
+
+Get next available nonce. Uses the `Transactions` cube.
+
+▶️ [Get next available nonce](https://ide.bitquery.io/get-next-available-nonce)
+
+#### Simulating Pending Transactions
+
+Simulating Pending Transactions.
+
+▶️ [Simulating Pending Transactions](https://ide.bitquery.io/Simulating-Pending-Transactions_1)
+
+### Blocks & Validators
+
+#### Aggregate Self-Destruct Statistics
+
+Aggregate Self-Destruct Statistics. Uses the `TransactionBalances` cube.
+
+▶️ [Aggregate Self-Destruct Statistics](https://ide.bitquery.io/Aggregate-Self-Destruct-Statistics)
+
+#### QuasarBuilder MEV Payout Transaction Balance
+
+QuasarBuilder MEV Payout Transaction Balance. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [QuasarBuilder MEV Payout Transaction Balance](https://ide.bitquery.io/QuasarBuilder-MEV-Payout-Transaction-Balance)
+
+#### Self-Destruct Balance Decrease API
+
+Self-Destruct Balance Decrease API. Uses the `TransactionBalances` cube.
+
+▶️ [Self-Destruct Balance Decrease API](https://ide.bitquery.io/Self-Destruct-Balance-Decrease-API)
+
+#### Self-Destruct Balance Increase API
+
+Self-Destruct Balance Increase API. Uses the `TransactionBalances` cube.
+
+▶️ [Self-Destruct Balance Increase API](https://ide.bitquery.io/Self-Destruct-Balance-Increase-API)
+
+#### Top validators by total tips in last 24 hrs
+
+Top validators by total tips in last 24 hrs. Uses the `TransactionBalances` cube.
+
+▶️ [Top validators by total tips in last 24 hrs](https://ide.bitquery.io/top-validators-by-total-tips-in-last-24-hrs)
+
+#### Total tips received by a validator in last 24 hrs
+
+Total tips received by a validator in last 24 hrs. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Total tips received by a validator in last 24 hrs](https://ide.bitquery.io/total-tips-received-by-a-validator-in-last-24-hrs)
+
+### Uniswap
+
+#### Latest slippage on a Uniswap v3 pool
+
+Per-trade slippage for one v3 pool, to size orders before sending them.
+
+▶️ [Latest slippage on a Uniswap v3 pool](https://ide.bitquery.io/Latest-slippage-of-a-pool-on-Uniswap-v3-Ethereum_1)
+
+#### All Pool_Ids for currency
+
+All Pool_Ids for currency. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [All Pool_Ids for currency](https://ide.bitquery.io/All-Pool_Ids-for-currency)
+
+#### Fee collection on Uniswap v3 Positions
+
+Fee collection on Uniswap v3 Positions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Fee collection on Uniswap v3 Positions](https://ide.bitquery.io/Fee-collection-on-Uniswap-v3-Positions)
+
+#### Latest ModifyLiquidity Events on Uniswap v4
+
+Latest ModifyLiquidity Events on Uniswap v4. Uses the `Events` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Latest ModifyLiquidity Events on Uniswap v4](https://ide.bitquery.io/Latest-ModifyLiquidity-Events-on-Uniswap-v4)
+
+#### Latest trades of a Uniswap pair
+
+Trades for one Uniswap pair. Replace the pair address.
+
+▶️ [Latest trades of a Uniswap pair](https://ide.bitquery.io/Latest-Trades-of-a-Pair-on-Uniswap)
+
+#### Latest liquidity for a currency pair across all v4 pools
+
+Latest liquidity for a currency pair across all v4 pools. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Latest liquidity for a currency pair across all v4 pools](https://ide.bitquery.io/latest-liquidity-for-a-currency-pair-across-all-v4-pools_1)
+
+### PancakeSwap
+
+#### Latest Trades on PancakeSwap V3 ETH
+
+Latest Trades on PancakeSwap V3 ETH. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
+
+▶️ [Latest Trades on PancakeSwap V3 ETH](https://ide.bitquery.io/Latest-Trades-on-PancakeSwap-V3-ETH)
+
+#### Top Traders of a token on PancakeSwap on ETH
+
+Top Traders of a token on PancakeSwap on ETH. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top Traders of a token on PancakeSwap on ETH](https://ide.bitquery.io/Top-Traders-of-a-token-on-PancakeSwap-on-ETH)
+
+#### Top token pairs on PancakeSwap v3
+
+Top token pairs on PancakeSwap v3. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top token pairs on PancakeSwap v3](https://ide.bitquery.io/Top-token-pairs-on-PancakeSwap-v3)
+
+## Solana
+
+### Trades
+
+#### Get Multiple Token Analytics
+
+Returns analytics data for multiple token addresses.
+
+▶️ [Get Multiple Token Analytics](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-multiple-solana-tokens)
 
 #### Get Token Metadata
 
 Get the token metadata for contract (mint, standard, name, symbol).
+
 ▶️ [Get Token Metadata](https://ide.bitquery.io/Solana-currency-details)
-
-#### Get Top Token Holders
-
-Get a list of top token holders for a specific Solana token address.
-▶️ [Get Top Token Holders](https://ide.bitquery.io/top-100-holders-of-USDC-token-on-Solana)
-
-#### Get Token Pairs by Address
-
-Get the supported pairs for a specific token address.
-▶️ [Get Token Pairs by Address](https://ide.bitquery.io/traded-pairs-of-a-token_2)
 
 #### Get Token Pair Stats
 
 Get the pair stats by using pair address.
+
 ▶️ [Get Token Pair Stats](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-solana-token-pair)
 
-#### Get Aggregated Token Pair Stats
+#### Get Token Pairs by Address
 
-Get aggregated statistics across supported pairs of a token.
-▶️ [Get Aggregated Token Pair Stats](https://ide.bitquery.io/traded-pairs-stats-of-a-token)
+Get the supported pairs for a specific token address.
+
+▶️ [Get Token Pairs by Address](https://ide.bitquery.io/traded-pairs-of-a-token_2)
+
+#### Get Volume Stats for Solana Chain
+
+Returns volume statistics, active wallets, and total transactions for Solana.
+
+▶️ [Get Volume Stats for Solana Chain](https://ide.bitquery.io/Chain-stats-like-total-volume-traded-total-transactions-active-wallets_1)
 
 #### Realised PnL, avg buy price, buy volume, sell volume of a Trader for specific token
 
 Get realised PnL, average buy price, buy volume, and sell volume for a token on Solana of a trader for over a time window.
-▶️ [Realised PnL, avg buy price, buy volume, sell volume](https://ide.bitquery.io/Realised-Pnl-avg-buy-price-Buy-volume-Sell-Volume-Solana_2)
+
+▶️ [Realised PnL, avg buy price, buy volume, sell volume of a Trader for specific token](https://ide.bitquery.io/Realised-Pnl-avg-buy-price-Buy-volume-Sell-Volume-Solana_2)
+
+#### Search tokens by name, symbol, mint address
+
+Search for tokens based on contract address, token name or token symbol.
+
+▶️ [Search tokens by name, symbol, mint address](https://ide.bitquery.io/Token-Search-API---trump-symbol)
+
+#### Get Swaps by Pair Address
+
+Get all trades related transactions for a specific pair address.
+
+▶️ [Get Swaps by Pair Address](https://ide.bitquery.io/swaps-for-a-market-address-on-Solana)
+
+#### Get Trades by Wallet Address
+
+Get all trades related transactions (buy, sell) for a specific wallet address.
+
+▶️ [Get Trades by Wallet Address](https://ide.bitquery.io/Solana-dextrades-by-a-trader_2)
+
+#### Buys Sells BuyVolume SellVolume Makers TotalTradedVolume PriceinUSD for solana token pair
+
+Buys Sells BuyVolume SellVolume Makers TotalTradedVolume PriceinUSD for solana token pair. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Buys Sells BuyVolume SellVolume Makers TotalTradedVolume PriceinUSD for solana token pair](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-solana-token-pair00_2)
+
+### Transfers
+
+#### Simple SOL transfers (Transactions not trades)
+
+This API returns simple SOL transfers; in other words, it contains transactions that are simple token transfers, not trades.
+
+▶️ [Simple SOL transfers (Transactions not trades)](https://ide.bitquery.io/Simple-SOL-transfers-Transactions-not-trades)
+
+#### Solana Token Transfers for a Specific Address
+
+This API retrieves the history of token transfers (both sent and received) for a specific Solana address within a defined time period.
+
+▶️ [Solana Token Transfers for a Specific Address](https://ide.bitquery.io/Solana-historical-token-transfers-of-an-address-between-a-time)
+
+#### Solana Transfers
+
+This query gets the latest 10 transfers on Solana. You can increase the limit to get more transfers. This query only uses real-time data.
+
+▶️ [Solana Transfers](https://ide.bitquery.io/Solana-transfers0_5)
+
+#### Solana Historical Transfers
+
+Solana Historical Transfers.
+
+▶️ [Solana Historical Transfers](https://ide.bitquery.io/solana-historical-transfers_1)
+
+#### Currency with elon inclusion
+
+Currency with elon inclusion. Uses the `Transfers` cube.
+
+▶️ [Currency with elon inclusion](https://ide.bitquery.io/Currency-with-elon-inclusion)
+
+#### Solana token transfers of Bags fm tokens
+
+Solana token transfers of Bags fm tokens. Uses the `Transfers` cube.
+
+▶️ [Solana token transfers of Bags fm tokens](https://ide.bitquery.io/Solana-token-transfers-of-Bags-fm-tokens)
+
+#### Total txn fees paid by the Account
+
+Total txn fees paid by the Account. Uses the `Transfers` cube.
+
+▶️ [Total txn fees paid by the Account](https://ide.bitquery.io/total-txn-fees-paid-by-the-Account)
+
+#### Transaction fees paid by Account aggregated by currency
+
+Transaction fees paid by Account aggregated by currency. Uses the `Transfers` cube.
+
+▶️ [Transaction fees paid by Account aggregated by currency](https://ide.bitquery.io/Transaction-fees-paid-by-Account-aggregated-by-currency)
+
+#### Transfers of a wallet
+
+Transfers of a wallet. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Transfers of a wallet](https://ide.bitquery.io/Transfers-of-a-wallet_1)
+
+#### Wallet transfers with transaction fees paid
+
+Wallet transfers with transaction fees paid. Uses the `Transfers` cube.
+
+▶️ [Wallet transfers with transaction fees paid](https://ide.bitquery.io/wallet-transfers-with-transaction-fees-paid)
+
+### Balances & Holders
+
+#### Solana Instruction Balance Updates
+
+This query returns Solana balance update info for any balance update event, including the address, amount, currency details, and the details of the program responsible for this update.
+
+▶️ [Solana Instruction Balance Updates](https://ide.bitquery.io/Solana-InstructionBalanceUpdates)
+
+#### Balance updates
+
+Balance updates. Uses the `InstructionBalanceUpdates` cube.
+
+▶️ [Balance updates](https://ide.bitquery.io/balance-updates)
+
+#### Solana balance updates executing burn instruction
+
+Solana balance updates executing burn instruction. Uses the `InstructionBalanceUpdates` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Solana balance updates executing burn instruction](https://ide.bitquery.io/solana-balance-updates-executing-burn-instruction)
+
+#### Trades of wallets with balance Updates in that trades
+
+Trades of wallets with balance Updates in that trades. Uses the `DEXTrades` cube.
+
+▶️ [Trades of wallets with balance Updates in that trades](https://ide.bitquery.io/Trades-of-wallets-with-balance-Updates-in-that-trades)
+
+### Price & OHLC
+
+#### Get OHLCV by Pair Address
+
+You can get charting data easily with this query. Adjust the intervals as necessary. This query supports historical data.
+
+▶️ [Get OHLCV by Pair Address](https://ide.bitquery.io/OHLC-for-a-token_8)
+
+#### Get Token Prices on Solana
+
+Returns price information for multiple Solana tokens in a single request.
+
+▶️ [Get Token Prices on Solana](https://ide.bitquery.io/Get-multiple-Token-Prices)
 
 #### Historical Price and Volume Data (Volume & Price, Last 24h using Trading API)
 
 Use this API to get historical price and volume for a specific token over the past 24 hours.
 
-▶️ [Historical Price and Volume Data](https://ide.bitquery.io/24h-historical-price-and-historical-volume-on-Solana)
+▶️ [Historical Price and Volume Data (Volume & Price, Last 24h using Trading API)](https://ide.bitquery.io/24h-historical-price-and-historical-volume-on-Solana)
 
-#### Get Multiple Token Analytics
+#### Price change 5min, 1hr, 6hr precentage of a specific token
 
-Returns analytics data for multiple token addresses.
-▶️ [Get Multiple Token Analytics](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-multiple-solana-tokens)
+With this, you can get the price change 5min, 1hr, 6hr precentage of a specific token.
 
-#### Get Volume Stats for Solana Chain
+▶️ [Price change 5min, 1hr, 6hr precentage of a specific token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_5)
 
-Returns volume statistics, active wallets, and total transactions for Solana.
-▶️ [Get Volume Stats By Chain](https://ide.bitquery.io/Chain-stats-like-total-volume-traded-total-transactions-active-wallets_1)
+#### Top 10 solana tokens by price change in last 1 hr
+
+With this, you can get top 10 solana tokens by price change in last 1 hr.
+
+▶️ [Top 10 solana tokens by price change in last 1 hr](https://ide.bitquery.io/Top-10-solana-tokens-by-price-change-in-last-1-hr_4)
+
+#### Get Latest Price of a Token in USD
+
+Get Latest Price of a Token in USD. Uses the `Pairs` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Get Latest Price of a Token in USD](https://ide.bitquery.io/Pumpfun-token-latest-price-USD)
+
+#### ATH of multiple tokens quantile Solana
+
+ATH of multiple tokens quantile Solana. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [ATH of multiple tokens quantile Solana](https://ide.bitquery.io/ATH-of-multiple-tokens-quantile-Solana)
+
+#### ATH with price delta Solana
+
+ATH with price delta Solana. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [ATH with price delta Solana](https://ide.bitquery.io/ATH-with-price-delta-Solana)
+
+#### AldrinAmm OHLC for specific pair
+
+AldrinAmm OHLC for specific pair. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [AldrinAmm OHLC for specific pair](https://ide.bitquery.io/AldrinAmm-OHLC-for-specific-pair)
+
+#### Get Latest Price of Apple xStock in USD Real-time
+
+Get Latest Price of Apple xStock in USD Real-time. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get Latest Price of Apple xStock in USD Real-time](https://ide.bitquery.io/Get-Latest-Price-of-Apple-xStock-in--USD-Real-time)
+
+### Supply & Market Cap
+
+#### Bags.fm token creation using Solana token supply updates
+
+Bags.fm token creation using Solana token supply updates. Uses the `TokenSupplyUpdates` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Bags.fm token creation using Solana token supply updates](https://ide.bitquery.io/Bagsfm-token-creation-using-Solana-token-supply-updates)
+
+#### Market cap of token
+
+Market cap of token. Uses the `TokenSupplyUpdates` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Market cap of token](https://ide.bitquery.io/market-cap-of-token_1)
+
+#### Marketcap of tokens
+
+Marketcap of tokens. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Marketcap of tokens](https://ide.bitquery.io/Marketcap-of-tokens)
+
+#### Sandisk - Backpack Securities MCAP
+
+Sandisk - Backpack Securities MCAP. Uses the `Pairs` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Sandisk - Backpack Securities MCAP](https://ide.bitquery.io/Sandisk---Backpack-Securities-MCAP)
+
+#### Token burn example solana
+
+Token burn example solana. Uses the `TokenSupplyUpdates` cube.
+
+▶️ [Token burn example solana](https://ide.bitquery.io/token-burn-example-solana)
+
+#### Token supply
+
+Token supply. Uses the `TokenSupplyUpdates` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Token supply](https://ide.bitquery.io/token-supply_2)
+
+#### Tokens with market cap range
+
+Tokens with market cap range. Uses the `TokenSupplyUpdates` cube.
+
+▶️ [Tokens with market cap range](https://ide.bitquery.io/tokens-with-market-cap-range)
 
 #### Top 10 marketcap jump tokens in last 1hr
 
-This query retrieves top 10 marketcap jump tokens in last 1hr.
-▶️ [Top 10 marketcap jump tokens in last 1hr](https://ide.bitquery.io/top-10-marketcap-jump-tokens-in-last-1hr#)
+Top 10 marketcap jump tokens in last 1hr. Uses the `TokenSupplyUpdates` cube.
 
-### Search Tokens
+▶️ [Top 10 marketcap jump tokens in last 1hr](https://ide.bitquery.io/top-10-marketcap-jump-tokens-in-last-1hr)
 
-#### Search tokens by name, symbol, mint address
+#### Top Solana tokens based on market cap
 
-Search for tokens based on contract address, token name or token symbol.
-▶️ [Search Tokens based on token symbol](https://ide.bitquery.io/Token-Search-API---trump-symbol)
+Top Solana tokens based on market cap. Uses the `TokenSupplyUpdates` cube.
 
-### Pool/Liquidity APIs
+▶️ [Top Solana tokens based on market cap](https://ide.bitquery.io/top-Solana-tokens-based-on-market-cap)
+
+#### Top Tokens by Market Cap on solana
+
+Top Tokens by Market Cap on solana. Uses the `Tokens` cube.
+
+▶️ [Top Tokens by Market Cap on solana](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-solana)
+
+### Liquidity & Pools
 
 #### All Token Pairs Across DEXs with Current Liquidity
 
 This query retrieves all instances of a specific token pair across decentralized exchanges (DEXs) on Solana, along with their current liquidity.
+
 ▶️ [All Token Pairs Across DEXs with Current Liquidity](https://ide.bitquery.io/All-Liquidity-pairs-of-a-token-and-current-liquidity-on-solana)
 
-#### Solana Pool Liquidity Changes
+#### Latest Pools Created on Launchpad
 
-This query retrieves the latest changes to liquidity pools on Solana, including the change amount and the price at which the change happened. This query also uses only the real-time data set.  
-▶️ [Solana Liquidity Changes](https://ide.bitquery.io/Solana-DEXPools)
+This query returns the latest created pools on Raydium launchpad. You can set the limit here also.
+
+▶️ [Latest Pools Created on Launchpad](https://ide.bitquery.io/Launchpad-latest-pool-created)
 
 #### Liquidity of All Pools of a Token on Solana
 
 Get latest liquidity snapshots for all pools where a token is either base or quote currency.
+
 ▶️ [Liquidity of All Pools of a Token on Solana](https://ide.bitquery.io/liqidity-of-all-pools-of-a-token)
 
-#### Latest Pools Created on Raydium
+#### Solana Pool Liquidity Changes
 
-This query returns the latest created pools on Raydium. You can set the limit here also.  
-▶️ [Raydium Latest Created Pools](https://ide.bitquery.io/Latest-Radiyum-V4-pools-created_1)
+This query retrieves the latest changes to liquidity pools on Solana, including the change amount and the price at which the change happened. This query also uses only the real-time data set.
 
-#### Latest Pools Created on Launchpad
+▶️ [Solana Pool Liquidity Changes](https://ide.bitquery.io/Solana-DEXPools)
 
-This query returns the latest created pools on Raydium launchpad. You can set the limit here also.  
-▶️ [Launchpad Latest Created Pools](https://ide.bitquery.io/Launchpad-latest-pool-created)
+#### All liquidity add instructions track on Solana
 
-#### Liquidity Addition for Four Meme Token
+All liquidity add instructions track on Solana. Uses the `DEXPools` cube.
 
-Get the liquidity addition events for a specific token on the Four Meme Exchange.  
-▶️[Liquidity Addition](https://ide.bitquery.io/Liquidity-Added-to-specific-tokens-on-Four-meme)
+▶️ [All liquidity add instructions track on Solana](https://ide.bitquery.io/All-liquidity-add-instructions-track-on-Solana)
 
-### PumpFun APIs
+#### CPMM pools created
 
-#### Get New Tokens for PumpFun
+CPMM pools created. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
 
-Returns a list of newly created tokens on the Pump Fun.
-▶️ [Get New Tokens for PumpFun](https://ide.bitquery.io/newly-created-PF-token-dev-address-metadata--query#)
+▶️ [CPMM pools created](https://ide.bitquery.io/CPMM-pools-created_1)
 
-#### Get Latest Price of a Token in USD
+#### Get LP Latest liqudity on Solana
 
-▶️ [Get Latest Price of a Token](https://ide.bitquery.io/Pumpfun-token-latest-price-USD)
+Get LP Latest liqudity on Solana. Uses the `DEXPools` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Get LP Latest liqudity on Solana](https://ide.bitquery.io/Get-LP-Latest-liqudity-on-Solana)
+
+#### Get all the liquidity pools info for a particular token
+
+Get all the liquidity pools info for a particular token. Uses the `DEXPools` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get all the liquidity pools info for a particular token](https://ide.bitquery.io/get-all-the-liquidity-pools-info-for-a-particular-token_1)
+
+#### Liquidity change in recent month
+
+Liquidity change in recent month. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Liquidity change in recent month](https://ide.bitquery.io/liquidity-change-in-recent-month)
+
+#### Liquidity lock using instructions balance update
+
+Liquidity lock using instructions balance update. Uses the `InstructionBalanceUpdates` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Liquidity lock using instructions balance update](https://ide.bitquery.io/Liquidity-lock-using-instructions-balance-update)
+
+### Events & Calls
+
+#### Not Anchor Error Solana Logs
+
+Not Anchor Error Solana Logs. Uses the `Instructions` cube.
+
+▶️ [Not Anchor Error Solana Logs](https://ide.bitquery.io/Not-Anchor-Error-Solana-Logs)
+
+#### Solana Zeta Market logs
+
+Solana Zeta Market logs. Uses the `Instructions` cube.
+
+▶️ [Solana Zeta Market logs](https://ide.bitquery.io/Solana-Zeta-Market-logs)
+
+### Pump.fun
+
+#### Top 10 pump fun tokens by Marketcap change in last 5mins
+
+This query returns the top 10 pump fun tokens by Marketcap change in last 5mins. You can increase the limit to get more tokens.
+
+▶️ [Top 10 pump fun tokens by Marketcap change in last 5mins](https://ide.bitquery.io/Top-10-pump-fun-tokens-by-Marketcap-change-in-last-5mins_1)
+
+#### Top PumpFun Tokens by Marketcap
+
+This query returns the top 10 PumpFun tokens based on market cap. You can increase the limit to get more tokens.
+
+▶️ [Top PumpFun Tokens by Marketcap](https://ide.bitquery.io/top-tokens-by-mktcap-on-pump-fun-in-last-15-min)
 
 #### Get Bonding Curve Progress of a Token on Pump Fun
 
 Returns Bonding Curve Percentage of a Token on the Pump Fun.
-▶️ [Bonding Curve Percentage of a Token on Pump Fun](https://ide.bitquery.io/get-the-bonding-curve-progress-percentage_1)
 
-#### Track Pump Fun token migrations to PumpSwap (subscription)
+▶️ [Get Bonding Curve Progress of a Token on Pump Fun](https://ide.bitquery.io/get-the-bonding-curve-progress-percentage_1)
 
-Realtime stream of PumpSwap **`create_pool`** migrations (Pump.fun → PumpSwap). Filters: successful transactions, instruction depth 1, program **`pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA`**, non-placeholder mint in arguments.
+#### ATH Market Cap of Pump Fun Tokens in a Specific Timeframe
 
-▶️ [Pump Fun migration stream](https://ide.bitquery.io/pumpfun-migration-stream_4#)
+ATH Market Cap of Pump Fun Tokens in a Specific Timeframe. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
 
-#### Latest Pump Fun token migrations to PumpSwap (query)
+▶️ [ATH Market Cap of Pump Fun Tokens in a Specific Timeframe](https://ide.bitquery.io/ATH-Market-Cap-of-Pump-Fun-Tokens-in-a-Specific-Timeframe)
 
-Latest migrations with the same filters as the subscription; **`limit: 20`**, ordered by **`Block_Slot`** descending.
+#### All tokens traded on Pump.fun in the last 1 hour
 
-▶️ [Pump Fun migration query](https://ide.bitquery.io/pumpfun-migration-query#)
+All tokens traded on Pump.fun in the last 1 hour. Uses the `Pairs` cube.
 
-#### Top PumpFun Tokens by Marketcap
+▶️ [All tokens traded on Pump.fun in the last 1 hour](https://ide.bitquery.io/all-tokens-traded-on-Pumpfun-in-the-last-1-hour_1)
 
-This query returns the top 10 PumpFun tokens based on market cap. You can increase the limit to get more tokens.  
-▶️ [Top Tokens by Marketcap](https://ide.bitquery.io/top-tokens-by-mktcap-on-pump-fun-in-last-15-min)
+#### How do I get tokens that reached a specific market cap on Pump.fun?
 
-#### Top 10 pump fun tokens by Price change in last 5mins
+How do I get tokens that reached a specific market cap on Pump.fun?. Uses the `Pairs` cube.
 
-This query returns the top 10 pump fun tokens by Price change in last 5mins. You can increase the limit to get more tokens.  
-▶️ [Top 10 pump fun tokens by Price change in last 5mins](https://ide.bitquery.io/Top-10-pump-fun-tokens-by-Price-change-in-last-5mins_2)
+▶️ [How do I get tokens that reached a specific market cap on Pump.fun?](https://ide.bitquery.io/How-do-I-get-tokens-that-reached-a-specific-market-cap-on-Pumpfun)
 
-#### Top 10 pump fun tokens by Marketcap change in last 5mins
+### Meteora
 
-This query returns the top 10 pump fun tokens by Marketcap change in last 5mins. You can increase the limit to get more tokens.  
-▶️ [Top 10 pump fun tokens by Marketcap change in last 5mins](https://ide.bitquery.io/Top-10-pump-fun-tokens-by-Marketcap-change-in-last-5mins_1)
+#### Get the Top Traders of a specific Token on Meteora DAMM v2 DEX
 
-#### Historical PumpFun Migrated Token on Raydium and Pumpswap.
+Get the Top Traders of a specific Token on Meteora DAMM v2 DEX. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-▶️ [Historical PumpFun Migrated Tokens](https://ide.bitquery.io/all-pumpfun-migrated-token-query_4)
+▶️ [Get the Top Traders of a specific Token on Meteora DAMM v2 DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DAMM-v2-DEX_1)
 
-### Raydium Launchpad APIs
+#### Get the Top Traders of a specific Token on Meteora DLMM DEX
 
-#### Get Bonding Curve Progress of a Raydium Launchpad Token
+Get the Top Traders of a specific Token on Meteora DLMM DEX. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-Returns Bonding Curve Percentage of a Raydium Launchpad Token.
-▶️ [Bonding Curve Percentage of a Raydium Launchpad Token](https://ide.bitquery.io/bonding-curve-progress-percentage-of-a-letsbonkfun-token)
+▶️ [Get the Top Traders of a specific Token on Meteora DLMM DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DLMM-DEX)
 
-#### Track Raydium Launchpad tokens above 95% Bonding Curve Progress in realtime
+#### Get the Top Traders of a specific Token on Meteora DYN DEX
 
-Returns Raydium Launchpad tokens which have more than 95% bonding curve progress.
-▶️ [Raydium Launchpad Tokens above 95% Bonding Curve Progress](https://ide.bitquery.io/LetsBonkfun-Tokens-between-95-and-100-bonding-curve-progress_2)
+Get the Top Traders of a specific Token on Meteora DYN DEX. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get the Top Traders of a specific Token on Meteora DYN DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DYN-DEX)
+
+#### Meteora DAMM v2 OHLC API
+
+Meteora DAMM v2 OHLC API. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Meteora DAMM v2 OHLC API](https://ide.bitquery.io/Meteora-DAMM-v2-OHLC-API)
+
+#### Meteora DLMM OHLC API
+
+Meteora DLMM OHLC API. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Meteora DLMM OHLC API](https://ide.bitquery.io/Meteora-DLMM-OHLC-API)
+
+#### Meteora DYN OHLC API
+
+Meteora DYN OHLC API. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Meteora DYN OHLC API](https://ide.bitquery.io/Meteora-DYN-OHLC-API)
+
+### Raydium
 
 #### Top 100 About to Graduate Raydium Launchpad Tokens
 
 Returns top 100 About to Graduate Raydium Launchpadn Tokens.
+
 ▶️ [Top 100 About to Graduate Raydium Launchpad Tokens](https://ide.bitquery.io/Top-100-graduating-raydium-launchlab-tokens-in-last-5-minutes)
 
-#### Graduated Tokens
+#### Historical PumpFun Migrated Token on Raydium and Pumpswap.
 
-This query gives you tokens which are graduated from Raydium Launchpad to Raydium.
-▶️ [Graduated Tokens from Launchpad](https://ide.bitquery.io/Track-Token-Migrations-to-Raydium-DEX-and-Raydium-CPMM-in-realtime)
+Historical PumpFun Migrated Token on Raydium and Pumpswap. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
 
-### LetsBonk.fun APIs
+▶️ [Historical PumpFun Migrated Token on Raydium and Pumpswap.](https://ide.bitquery.io/all-pumpfun-migrated-token-query_4)
 
-#### Get Bonding Curve Progress of a LetsBonk.fun Token
+#### Get Bonding Curve Progress of a Raydium Launchpad Token
 
-Returns Bonding Curve Percentage of a LetsBonk.fun Token.
-▶️ [Bonding Curve Percentage of a LetsBonk.fun Token](https://ide.bitquery.io/bonding-curve-progress-percentage-of-a-letsbonkfun-token)
+Returns Bonding Curve Percentage of a Raydium Launchpad Token.
 
-#### Track LetsBonk.fun tokens above 95% Bonding Curve Progress in realtime
+▶️ [Get Bonding Curve Progress of a Raydium Launchpad Token](https://ide.bitquery.io/bonding-curve-progress-percentage-of-a-letsbonkfun-token)
 
-Returns LetsBonk.fun tokens which have more than 95% bonding curve progress.
-▶️ [LetsBonk.fun Tokens above 95% Bonding Curve Progress](https://ide.bitquery.io/LetsBonkfun-Tokens-between-95-and-100-bonding-curve-progress_2)
+#### Latest Price of a Token on Raydium Launchpad
 
-#### Top 100 About to Graduate LetsBonk.fun Tokens
+This query returns the latest price of a token on the Raydium launchpad.
 
-Returns top 100 About to Graduate LetsBonk.fun Tokens.
-▶️ [Top 100 About to Graduate LetsBonk.fun Tokens](https://ide.bitquery.io/Top-100-graduating-raydium-launchlab-tokens-in-last-5-minutes)
+▶️ [Latest Price of a Token on Raydium Launchpad](https://ide.bitquery.io/Latest-Price-of-a-Token-on-Launchpad)
 
-## Base
+#### Latest Trades for a specific currency on Raydium
 
-### Balance APIs
+This query returns the latest trades for a token on Raydium. You can set the limit here also.
 
-#### Get latest token balance of a wallet
+▶️ [Latest Trades for a specific currency on Raydium](https://ide.bitquery.io/Trades-for-a-token-on-Raydium-on-Solana)
 
-Get latest token balance of a wallet.
-▶️ [Get latest token balance of a wallet](https://ide.bitquery.io/Get-Latest-Token-Balance-for-an-Address_4)
+#### DecreaseLiquidityV2 latest raydium clmm
 
-#### Get All Token Balances for an Address
+DecreaseLiquidityV2 latest raydium clmm. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
 
-Retrieve all token balances held by a specific address. This query returns balances for all tokens the address holds.
-▶️ [Get All Token Balances for an Address](https://ide.bitquery.io/Get-All-Token-Balances-for-an-Address_4)
+▶️ [DecreaseLiquidityV2 latest raydium clmm](https://ide.bitquery.io/decreaseLiquidityV2-latest-raydium-clmm_1)
 
-#### Latest Liquidity of Base Pool
+### LetsBonk.fun
 
-Get the latest liquidity of an Base DEX pool (e.g., Uniswap v3 pool).  
-▶️ [Latest Liquidity of Base Pool](https://ide.bitquery.io/latest-liquidity-of-a-Base-pool_2)
+#### Latest Price of a LetsBonk.fun Token on Launchpad
 
-### Real Time Transfers
+Latest Price of a LetsBonk.fun Token on Launchpad. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-#### Get token transfers by wallet
+▶️ [Latest Price of a LetsBonk.fun Token on Launchpad](https://ide.bitquery.io/Latest-Price-of-a-LetsBonkfun-Token-on-Launchpad)
 
-Get token transactions ordered by block number in descending order.  
-▶️ [Get token transfers by wallet](https://ide.bitquery.io/Get-token-transfers-by-wallet-base_1)
+#### Latest Trades of a letsbonk.fun token on Launchpad
 
-### Historical Transfers
+Latest Trades of a letsbonk.fun token on Launchpad. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-#### Get Historical ERC20 token transfers by wallet
+▶️ [Latest Trades of a letsbonk.fun token on Launchpad](https://ide.bitquery.io/Latest-Trades-of-a-letsbonkfun-token-on-Launchpad)
 
-Get ERC20 token transfers for an address in a given historical time window
-▶️ [Get Historical ERC20 token transfers by wallet](https://ide.bitquery.io/Get-historical-ERC20-token-transfers-by-wallet-base_2)
+#### Liquidity for a Letsbonk.fun token pair
 
-### Real Time Transactions
+Liquidity for a Letsbonk.fun token pair. Uses the `DEXPools` cube. Replace the address in the `where` clause to use it.
 
-#### Get transactions by wallet
+▶️ [Liquidity for a Letsbonk.fun token pair](https://ide.bitquery.io/liquidity-for-a-Letsbonkfun-token-pair_2)
 
-Get transactions ordered by block number in descending order.  
-▶️ [Get transactions by wallet](https://ide.bitquery.io/Get-transactions-by-wallet_8)
+#### Ohlc for letsbonk.fun token
 
-### Historical Transactions
+Ohlc for letsbonk.fun token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-#### Get historical transactions by wallet in a given period
+▶️ [Ohlc for letsbonk.fun token](https://ide.bitquery.io/ohlc-for-letsbonkfun-token)
 
-Get historical transactions for a given period of time ordered by block number in descending order.  
-▶️ [Get historical transactions by wallet](https://ide.bitquery.io/Get-historical-transactions-by-wallet-base_1)
+#### Pool address for letsbonk.fun token
 
-### Trades
+Pool address for letsbonk.fun token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-#### Base DEX Trades
+▶️ [Pool address for letsbonk.fun token](https://ide.bitquery.io/pool-address-for-letsbonkfun-token_1)
 
-This query returns the latest trades on the Base network from a trader perspective and returns useful metrics such as marketcap and pool ranking.  
-▶️ [Base DEX Trades](https://ide.bitquery.io/base-dextrades_3)
+#### Top buyers of a letsbonk.fun token on launchpad
 
-#### Base Dex Trade By Tokens
+Top buyers of a letsbonk.fun token on launchpad. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-This query returns the latest trades on the Base network. This is useful when looking for trades of a token.  
-▶️ [DexTrade By Tokens](https://ide.bitquery.io/base-dextrades-for-a-token)
+▶️ [Top buyers of a letsbonk.fun token on launchpad](https://ide.bitquery.io/top-buyers-of-a-letsbonkfun-token-on-launchpad)
 
-#### Get Trades by a Trader
-
-Get all trades by a particular trader.  
-▶️ [Get Swaps by Wallet Address](https://ide.bitquery.io/base-dextrades-by-a-trader)
-
-### Events & Calls
-
-#### Get Latest Events
-
-▶️ [Get Latest Events](https://ide.bitquery.io/Recents-Events-and-Logs-on-Base)
-
-#### Get Latest Calls
-
-▶️ [Get Latest Calls](https://ide.bitquery.io/Recent-Calls-on-base_1)
-
-### OHLC & Price Data
-
-#### Get OHLCV by Pair Address
-
-Get the OHLCV candle stick by using pair address.  
-▶️ [Get OHLCV by Pair Address](https://ide.bitquery.io/OHLC--base)
-
-#### Get Multiple Token Prices
-
-Returns an array of token prices denominated in the blockchain's native token and USD for a given token contract address.  
-▶️ [Get Multiple Token Prices](https://ide.bitquery.io/Price-of-multiple-tokens-in-realtime_1)
-
-#### Get ATH Price of a token
-
-Retrieves the all-time high (ATH) price in USD for a specified token contract.
-▶️ [Get ATH Price of a token](https://ide.bitquery.io/ATH-of-base-token)
-
-#### Get Price Change 5min, 1h, 6h and 24h of a specific token
-
-This query gets you Price Change 5min, 1h, 6h and 24h of a specific token on the Base network.
-▶️ [Get Price Change 5min, 1h, 6h and 24h of a specific token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_6)
-
-#### Top 10 Base Tokens by Price Change in last 1h
-
-This query gets you top 10 Base Tokens by Price Change in last 1h.
-▶️ [Top 10 Base Tokens by Price Change in last 1h](https://ide.bitquery.io/Top-10-base-tokens-by-price-change-in-last-1-hr_1)
-
-#### Uniswap v3 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders
-
-1-second OHLC and volume stream for tokens traded on Uniswap v3 (Base). Great for bot trading strategies.
-▶️ [Uniswap v3 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders](https://ide.bitquery.io/Uniswap-v3-DEX-tokens-1-second-price-stream-with-OHLC_1)
-
-### MarketCap APIs
-
-Trading API **`Tokens`** query for the latest **market cap**, **FDV**, **supply**, **price**, and **volume** for one Base token. Use **`base:`** + **lowercase** contract in **`Token.Id`**. Full examples: **[Base Token Market Cap API](/docs/blockchain/Base/base-token-marketcap-api)**.
-
-#### Latest market cap for a specific Base token (Trading API)
-
-▶️ [Specific Base Token Latest Market Cap](https://ide.bitquery.io/specific-base-token-latest-marketcap)
-
-### Token Analytics
-
-#### Get Token Total Supply and Market Cap
-
-Retrieve the total supply and market capitalization of a specific token. This query provides on-chain market cap data.
-▶️ [Get Token Total Supply and Market Cap](https://ide.bitquery.io/Get-Token-Total-Supply-and-Market-Cap_5)
-
-#### Token Holder Count on a Specific Date
-
-This API returns the total number of holders for a specific token on a given date.
-▶️ [Token Holder Count on a Specific Date](https://ide.bitquery.io/token-holders-count-base)
-
-#### Real-Time Holders of Multiple Tokens
-
-This API leverages the balanceUpdate endpoint to deliver real-time holder data for multiple tokens.
-▶️ [Real-Time Holders of Multiple Tokens](https://ide.bitquery.io/Top-10-holders-of-multiple-tokens-on-Base_2)
-
-#### Token Holders of Multiple Tokens on a speicifc date
-
-This API provides a list of top holders along with relevant statistics for a given token liston a specific date using Holders API.
-▶️ [Real-Time Holders of Multiple Tokens](https://ide.bitquery.io/Top-10-holders-of-multiple-tokens-on-Base-at-a-specific-time-holder-api)
-
-#### Token Holders and Stats on a Specific Date - TokenHolders API
-
-This API provides a list of all holders along with relevant statistics for a given token on a specific date.
-▶️ [Token Holders and Stats on a Specific Date](https://ide.bitquery.io/tokens-holders-of-a-token-base)
-
-### Slippage APIs
-
-#### Latest Slippage for a Specific Pool
-
-This query retrieves the latest slippage data for a specific DEX pool on Base. Use this to check current liquidity depth and price impact for a particular token pair.
-
-▶️ [Latest Slippage for a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_7)
-
-### Liquidity APIs
-
-#### Latest Liquidity Changes of a Specific Pool
-
-This query retrieves the latest liquidity events for a specific DEX pool on Base. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
-
-▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_4#)
-
-## Robinhood Chain
-
-### Trades
-
-#### Latest DEX Trades on Robinhood Chain
-
-Latest DEX trades on Robinhood Chain (chain id 4663) via the Trading API, with price and USD amounts.
-▶️ [Latest DEX Trades on Robinhood Chain](https://ide.bitquery.io/Robinhood-Trades)
-
-### Uniswap v4
-
-#### Uniswap v4 Pools on Robinhood Chain
-
-New Uniswap v4 pools: decoded Initialize events on the PoolManager with currencies, fee tier, tick spacing and hooks.
-▶️ [Uniswap v4 Pools on Robinhood Chain](https://ide.bitquery.io/uniswap-v4-pools-on-robinhood-chain)
-
-## BSC (Binance Smart Chain)
-
-### Balance APIs
-
-#### Get latest BNB balance of an wallet
-
-Get latest BNB balance of an wallet.
-▶️ [Get latest BNB balance of a wallet](https://ide.bitquery.io/Latest-native-balance-of-an-address-bsc)
-
-#### Get latest liquidity of an EVM Pool
-
-Get latest liquidity of an EVM Pool.
-▶️ [Get latest liquidity of an EVM Pool](https://ide.bitquery.io/latest-liquidity-of-a-EVM-pool)
-
-#### Get Native & Token Balances by Wallet
-
-Get token balances for a specific wallet address.  
-▶️ [Get Native & Token Balances by Wallet](https://ide.bitquery.io/balance-of-a-wallet_1)
-
-#### Get Token Balance by Wallet
-
-Get token balances for a specific wallet address.  
-▶️ [Get Token Balance by Wallet](https://ide.bitquery.io/Get-ERC20-Token-Balance-by-Wallet)
-
-#### Get wallet net worth
-
-Get the net worth of a wallet in USD.  
-▶️ [Get wallet net worth](https://ide.bitquery.io/balance-of-a-wallet-in-USD_2)
-
-### Token Supply
-
-#### Get Total Supply and Marketcap of an BSC token
-
-Get Total Supply and Marketcap of an BSC token.
-▶️ [Get Total Supply and Marketcap of an BSC token](https://ide.bitquery.io/latest-liquidity-of-a-EVM-pool)
-
-### MarketCap APIs
-
-Trading API **`Tokens`** query for the latest **market cap**, **FDV**, **supply**, **price**, and **volume** for one BSC token. Use **`bsc:`** + **lowercase** contract in **`Token.Id`**. Full examples: **[BSC Token Market Cap API](/docs/blockchain/BSC/bsc-token-marketcap-api)**.
-
-#### Latest market cap for a specific BSC token (Trading API)
-
-▶️ [Specific BSC Token Latest Market Cap](https://ide.bitquery.io/specific-bsc-token-latest-marketcap_1)
-
-### Real Time Transfers
-
-#### Get token transfers by wallet
-
-Get token transactions ordered by block number in descending order.  
-▶️ [Get token transfers by wallet](https://ide.bitquery.io/Get-ERC20-token-transfers-by-wallet-bsc)
-
-### Historical Transfers
-
-#### Get Historical ERC20 token transfers by wallet
-
-Get ERC20 token transfers for an address in a given historical time window
-▶️ [Get Historical ERC20 token transfers by wallet](https://ide.bitquery.io/Get-historical-ERC20-token-transfers-by-wallet-bsc)
-
-### Real Time Transactions
-
-#### Get transactions by wallet
-
-Get transactions ordered by block number in descending order.  
-▶️ [Get transactions by wallet](https://ide.bitquery.io/Get-transactions-by-wallet_6)
-
-### Historical Transactions
-
-#### Get historical transactions by wallet in a given period
-
-Get historical transactions for a given period of time ordered by block number in descending order.  
-▶️ [Get historical transactions by wallet](https://ide.bitquery.io/Get-historical-transactions-by-wallet-bsc)
+## BSC
 
 ### Trades
 
 #### BSC DEX Trades
 
-This query returns the latest trades on the BSC network from a trader perspective and returns useful metrics such as marketcap and pool ranking.  
+This query returns the latest trades on the BSC network from a trader perspective and returns useful metrics such as marketcap and pool ranking.
+
 ▶️ [BSC DEX Trades](https://ide.bitquery.io/BSC-dextrades_9)
 
 #### BSC Dex Trade By Tokens
 
-This query returns the latest trades on the BSC network. This is useful when looking for trades of a token.  
-▶️ [DexTrade By Tokens](https://ide.bitquery.io/BSC-dextrades-for-a-token)
+This query returns the latest trades on the BSC network. This is useful when looking for trades of a token.
+
+▶️ [BSC Dex Trade By Tokens](https://ide.bitquery.io/BSC-dextrades-for-a-token)
+
+#### Top Gainers on BSC
+
+Get Top Gainers for the BSC network.
+
+▶️ [Top Gainers on BSC](https://ide.bitquery.io/bsc-top-gainers)
 
 #### Get Trades by a Trader
 
-Get all trades by a particular trader.  
-▶️ [Get Swaps by Wallet Address](https://ide.bitquery.io/BSC-dextrades-by-a-trader)
+Get all trades by a particular trader.
 
-#### Trades on Pancakeswap
+▶️ [Get Trades by a Trader](https://ide.bitquery.io/BSC-dextrades-by-a-trader)
 
-Get the latest trades on Pancakeswap.  
-▶️[User Trades](https://ide.bitquery.io/BSC-dextrades-for-pancakeswap)
+#### All dexs info on bsc
 
-### OHLC & Price Data
+All dexs info on bsc.
 
-#### Get Multiple Token Prices
+▶️ [All dexs info on bsc](https://ide.bitquery.io/all-dexs-info-on-bsc)
 
-Returns an array of token prices denominated in the blockchain's native token and USD for a given token contract address.  
-▶️ [Get Multiple Token Prices](https://ide.bitquery.io/Price-of-multiple-tokens-in-realtime)
+#### First 500 buyers of a specific BSC chain token
 
-#### Get OHLCV by Pair Address
+First 500 buyers of a specific BSC chain token. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
 
-Get the OHLCV candle stick by using pair address.  
-▶️ [Get OHLCV by Pair Address](https://ide.bitquery.io/OHLC0_8)
+▶️ [First 500 buyers of a specific BSC chain token](https://ide.bitquery.io/first-500-buyers-of-a-specific-BSC-chain-token_2)
 
-#### OHLC for a BEP-20 Token
+#### Get all dex markets for a token
 
-Get OHLC statistics for a BEP-20 token on BSC network.  
-▶️[OHLC of a Token](https://ide.bitquery.io/OHLC-for-a-token-on-bsc_1)
+Get all dex markets for a token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-#### Get ATH Price of a token
+▶️ [Get all dex markets for a token](https://ide.bitquery.io/get-all-dex-markets-for-a-token)
 
-Retrieves the all-time high (ATH) price in USD for a specified token contract.
-▶️ [Get ATH Price of a token](https://ide.bitquery.io/ATH-of-bsc-token_2)
+#### Get all the DEXs on BSC network
+
+Get all the DEXs on BSC network.
+
+▶️ [Get all the DEXs on BSC network](https://ide.bitquery.io/Get-all-the-DEXs-on-BSC-network)
+
+#### Latest Flap.sh trades for a specific token
+
+Latest Flap.sh trades for a specific token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Latest Flap.sh trades for a specific token](https://ide.bitquery.io/Latest-Flapsh-trades-for-a-specific-token)
+
+#### Latest Flap.sh trades using DEXTrades API
+
+Latest Flap.sh trades using DEXTrades API. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Latest Flap.sh trades using DEXTrades API](https://ide.bitquery.io/Latest-Flapsh-trades-using-DEXTrades-API)
+
+### Settlements
+
+#### Gra fun redeem transactions
+
+Gra fun redeem transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Gra fun redeem transactions](https://ide.bitquery.io/Gra-fun-redeem-transactions)
+
+### Transfers
+
+#### Get Historical ERC20 token transfers by wallet
+
+Get ERC20 token transfers for an address in a given historical time window
+
+▶️ [Get Historical ERC20 token transfers by wallet](https://ide.bitquery.io/Get-historical-ERC20-token-transfers-by-wallet-bsc)
+
+#### Get token transfers by wallet
+
+Get token transactions ordered by block number in descending order.
+
+▶️ [Get token transfers by wallet](https://ide.bitquery.io/Get-ERC20-token-transfers-by-wallet-bsc)
+
+#### Check if an address interacted with predict.fun ever
+
+Check if an address interacted with predict.fun ever. Uses the `Transfers` cube.
+
+▶️ [Check if an address interacted with predict.fun ever](https://ide.bitquery.io/check-if-an-address-interacted-with-predictfun-ever)
+
+#### Check who created this meme rush token
+
+Check who created this meme rush token. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Check who created this meme rush token](https://ide.bitquery.io/check-who-created-this-meme-rush-token)
+
+#### Check who created this token
+
+Check who created this token. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Check who created this token](https://ide.bitquery.io/check-who-created-this-token)
+
+#### First transfers of a token
+
+First transfers of a token. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [First transfers of a token](https://ide.bitquery.io/first-transfers-of-a-token_5)
+
+#### Meme rush tokens created by specific dev
+
+Meme rush tokens created by specific dev. Uses the `Transfers` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Meme rush tokens created by specific dev](https://ide.bitquery.io/meme-rush-tokens-created-by-specific-dev)
+
+#### New Flap.sh Tokens Created Using Transfers API
+
+New Flap.sh Tokens Created Using Transfers API. Uses the `Transfers` cube.
+
+▶️ [New Flap.sh Tokens Created Using Transfers API](https://ide.bitquery.io/New-Flapsh-Tokens-Created-Using-Transfers-API)
+
+#### Sender OR Receiver Transfer Example BSC
+
+Sender OR Receiver Transfer Example BSC. Uses the `Transfers` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Sender OR Receiver Transfer Example BSC](https://ide.bitquery.io/Sender-OR-Receiver-Transfer-Example-BSC)
+
+#### Token created by specific dev
+
+Token created by specific dev. Uses the `Transfers` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Token created by specific dev](https://ide.bitquery.io/token-created-by-specific-dev)
+
+### Balances & Holders
+
+#### Get latest BNB balance of an wallet
+
+Get latest BNB balance of an wallet.
+
+▶️ [Get latest BNB balance of an wallet](https://ide.bitquery.io/Latest-native-balance-of-an-address-bsc)
+
+#### Average Tip in terms of avg gas Fee bsc
+
+Average Tip in terms of avg gas Fee bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Average Tip in terms of avg gas Fee bsc](https://ide.bitquery.io/Average-Tip-in-terms-of-avg-gas-Fee-bsc)
+
+#### Latest balance of an address for a specific token bsc
+
+Latest balance of an address for a specific token bsc. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Latest balance of an address for a specific token bsc](https://ide.bitquery.io/Latest-balance-of-an-address-for-a-specific-token-bsc)
+
+#### Top 10 holders percentage
+
+Top 10 holders percentage. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top 10 holders percentage](https://ide.bitquery.io/top-10-holders-percentage)
+
+#### Track recent ephemeral contract patterns bsc
+
+Track recent ephemeral contract patterns bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Track recent ephemeral contract patterns bsc](https://ide.bitquery.io/Track-recent-ephemeral-contract-patterns-bsc)
+
+#### Balance Updates for multiple addresses transfer in last 24 hours bsc
+
+Balance Updates for multiple addresses transfer in last 24 hours bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Balance Updates for multiple addresses transfer in last 24 hours bsc](https://ide.bitquery.io/Balance-Updates-for-multiple-addresses-transfer-in-last-24-hours-bsc)
+
+#### Balance Updates for transfer in last 24 hours bsc
+
+Balance Updates for transfer in last 24 hours bsc. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Balance Updates for transfer in last 24 hours bsc](https://ide.bitquery.io/Balance-Updates-for-transfer-in-last-24-hours-bsc)
+
+#### Balance update after transfer received bsc
+
+Balance update after transfer received bsc. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Balance update after transfer received bsc](https://ide.bitquery.io/Balance-update-after-transfer-received-bsc)
+
+#### Balance update after transfer received from multiple addresses bsc
+
+Balance update after transfer received from multiple addresses bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Balance update after transfer received from multiple addresses bsc](https://ide.bitquery.io/Balance-update-after-transfer-received-from-multiple-addresses-bsc)
+
+#### Balance update after transfer sent bsc
+
+Balance update after transfer sent bsc. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Balance update after transfer sent bsc](https://ide.bitquery.io/Balance-update-after-transfer-sent-bsc)
+
+### Price & OHLC
 
 #### BEP-20 Token Price
 
-Get the latest price of a BEP-20 token on BSC network.  
-▶️[Token Price](https://ide.bitquery.io/realtime-usd-price-of-a-token)
+Get the latest price of a BEP-20 token on BSC network.
 
-#### Price of a Token on PancakeSwap
-
-Get the latest price of a token traded on Pancakeswap.  
-▶️[Token Price on Pancakeswap](https://ide.bitquery.io/BSC-PancakeSwap-v3-Price-for-a-token)
-
-#### OHLC of a Token on PancakeSwap
-
-Get the OHLC stats of a token traded on Pancakeswap.  
-▶️[Token OHLC](https://ide.bitquery.io/OHLC-of-a-Token-on-pancake_swap_v3)
+▶️ [BEP-20 Token Price](https://ide.bitquery.io/realtime-usd-price-of-a-token)
 
 #### Get Price Change 5min, 1h, 6h and 24h of a specific BSC token
 
 This query gets you Price Change 5min, 1h, 6h and 24h of a specific token on the BSC network.
-▶️ [Get Price Change 5min, 1h, 6h and 24h of a specific token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_3)
+
+▶️ [Get Price Change 5min, 1h, 6h and 24h of a specific BSC token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_3)
+
+#### OHLC for a BEP-20 Token
+
+Get OHLC statistics for a BEP-20 token on BSC network.
+
+▶️ [OHLC for a BEP-20 Token](https://ide.bitquery.io/OHLC-for-a-token-on-bsc_1)
 
 #### Top 10 BSC Tokens by Price Change in last 1h
 
 This query gets you top 10 BSC Tokens by Price Change in last 1h.
+
 ▶️ [Top 10 BSC Tokens by Price Change in last 1h](https://ide.bitquery.io/Top-10-bsc-tokens-by-price-change-in-last-1-hr)
 
-#### Top Gainers on BSC
+#### BSC OHLC API For Token Pair
 
-Get Top Gainers for the BSC network.  
-▶️[Top Gainers](https://ide.bitquery.io/bsc-top-gainers)
+BSC OHLC API For Token Pair. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-#### FourMeme 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders
+▶️ [BSC OHLC API For Token Pair](https://ide.bitquery.io/BSC-OHLC-API-For-Token-Pair)
 
-Track token activity (OHLC, price, volume) every 1 second on FourMeme DEX (BSC).
-▶️ [FourMeme 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders](https://ide.bitquery.io/FourMeme-DEX-tokens-1-second-price-stream-with-OHLC)
+#### Meme rush token ATH price
 
-### Token Analytics
+Meme rush token ATH price. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Meme rush token ATH price](https://ide.bitquery.io/meme-rush-token-ATH-price)
+
+#### Latest price of a token on bsc
+
+Latest price of a token on bsc. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Latest price of a token on bsc](https://ide.bitquery.io/Latest-price-of-a-token-on-bsc)
+
+#### OHLCV data for specific Flap.sh token against BNB
+
+OHLCV data for specific Flap.sh token against BNB. Uses the `Pairs` cube.
+
+▶️ [OHLCV data for specific Flap.sh token against BNB](https://ide.bitquery.io/OHLCV-data-for-specific-Flapsh-token-against-BNB)
+
+#### OHLCV data for specific Flap.sh token in USD
+
+OHLCV data for specific Flap.sh token in USD. Uses the `Tokens` cube.
+
+▶️ [OHLCV data for specific Flap.sh token in USD](https://ide.bitquery.io/OHLCV-data-for-specific-Flapsh-token-in-USD)
+
+#### Percentage price change for a meme rush token
+
+Percentage price change for a meme rush token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Percentage price change for a meme rush token](https://ide.bitquery.io/Percentage-price-change-for-a-meme-rush-token)
+
+### Supply & Market Cap
 
 #### Get Total Supply and Marketcap of an ERC20 token
 
 Get Total Supply and Marketcap of an ERC20 token.
+
 ▶️ [Get Total Supply and Marketcap of an ERC20 token](https://ide.bitquery.io/Total-Supply-and-onchain-Marketcap-of-a-specific-token-bsc_1)
 
-#### BSC Token Holders
+#### Top Tokens by Market Cap on bsc
 
-This query returns the top `50` holders of a given BEP-20 token.  
-▶️[BSC Token Holders](https://ide.bitquery.io/Top-10-holders-of-a-token-on-BSC)
+Top Tokens by Market Cap on bsc. Uses the `Tokens` cube.
 
-#### Trading Pairs on a BSC DEX
+▶️ [Top Tokens by Market Cap on bsc](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-bsc)
 
-Get all trading pairs present on a BSC network DEX.  
-▶️[Trading Pairs](https://ide.bitquery.io/trading-pairs-on-BNB-by-USD-volume)
+#### Total Supply and onchain Marketcap of a specific token bsc
 
-### Slippage APIs
+Total Supply and onchain Marketcap of a specific token bsc. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Total Supply and onchain Marketcap of a specific token bsc](https://ide.bitquery.io/Total-Supply-and-onchain-Marketcap-of-a-specific-token-bsc)
+
+### Liquidity & Pools
 
 #### Latest Slippage for a Specific Pool
 
@@ -1078,110 +1388,1525 @@ This query retrieves the latest slippage data for a specific DEX pool on BSC. Us
 
 ▶️ [Latest Slippage for a Specific Pool](https://ide.bitquery.io/Latest-slippage-of-a-pool-on-Pancakeswap)
 
-### Liquidity APIs
-
 #### Latest Liquidity Changes of a Specific Pool
 
-This query retrieves the latest liquidity events for a specific DEX pool on BSC. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
+Latest Liquidity Changes of a Specific Pool. Uses the `DEXPoolEvents` cube.
 
-▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_2#)
+▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_2)
 
-### Four Meme APIs
+### Transactions
 
-#### Stream Real-time MarketCap of FourMeme Tokens
+#### Get transactions by wallet
 
-Real-time market cap stream with OHLC for FourMeme tokens at 1-second intervals. Market cap is calculated from price using fixed 1 billion supply.
-▶️[Real-time Mcap](https://ide.bitquery.io/Real-Time-Marektcap-and-price-for-Four-meme-tokens)
+Get transactions ordered by block number in descending order.
 
-#### Trade Metrics of a Four Meme Token
+▶️ [Get transactions by wallet](https://ide.bitquery.io/Get-transactions-by-wallet_6)
 
-This query returns the traded volume and number of trades for a particular Four Meme token in different time frames, namely 24 hours, 1 hour and 5 minutes.  
-▶️[Token Trade Metrics](https://ide.bitquery.io/volume-and-trades-for-a-token-in-different-time-frames_1)
+#### Gra fun buy transactions
 
-#### Get Newly Created Tokens on Four Meme
+Gra fun buy transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
 
-This query retrieves newly created tokens on Four Meme by listening to the `TokenCreate` event. The response provides token information including creator address, token contract address, name, symbol, total supply, and launch details.
-▶️[Get Newly Created Tokens](https://ide.bitquery.io/track-Four-meme-token-creation-using-events)
+▶️ [Gra fun buy transactions](https://ide.bitquery.io/Gra-fun-buy-transactions)
 
-#### Track Four Meme Token migrations to PancakeSwap
+#### Gra fun sell transactions
 
-This query tracks four meme token migrations to Pancakeswap in realtime by monitoring transactions sent to the Four Meme factory address and filtering for `PairCreated` and `PoolCreated` events. These events are emitted when a token graduates from Four Meme and migrates to Pancakeswap.
-▶️[Track Four meme migrations](https://ide.bitquery.io/four-meme-migration-to-pancakeswap)
+Gra fun sell transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Gra fun sell transactions](https://ide.bitquery.io/Gra-fun-sell-transactions)
+
+### Events & Calls
+
+#### Latest Calls on BSC network
+
+Latest Calls on BSC network. Uses the `Calls` cube.
+
+▶️ [Latest Calls on BSC network](https://ide.bitquery.io/Latest-Calls-on-BSC-network)
+
+#### Latest flap.sh token created using events data
+
+Latest flap.sh token created using events data. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest flap.sh token created using events data](https://ide.bitquery.io/Latest-flapsh-token-created-using-events-data_1)
+
+### Blocks & Validators
+
+#### Aggregate Self-Destruct Statistics bsc
+
+Aggregate Self-Destruct Statistics bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Aggregate Self-Destruct Statistics bsc](https://ide.bitquery.io/Aggregate-Self-Destruct-Statistics-bsc)
+
+#### Self-Destruct Balance Decrease API bsc
+
+Self-Destruct Balance Decrease API bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Self-Destruct Balance Decrease API bsc](https://ide.bitquery.io/Self-Destruct-Balance-Decrease-API-bsc)
+
+#### Self-Destruct Balance Increase API bsc
+
+Self-Destruct Balance Increase API bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Self-Destruct Balance Increase API bsc](https://ide.bitquery.io/Self-Destruct-Balance-Increase-API-bsc)
+
+#### Top validators by total tips in last 24 hrs bsc
+
+Top validators by total tips in last 24 hrs bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Top validators by total tips in last 24 hrs bsc](https://ide.bitquery.io/top-validators-by-total-tips-in-last-24-hrs-bsc)
+
+#### Historical Miner Balance Data bsc
+
+Historical Miner Balance Data bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Historical Miner Balance Data bsc](https://ide.bitquery.io/Historical-Miner-Balance-Data-bsc)
+
+#### Total tips received by a validator in last 24 hrs bsc
+
+Total tips received by a validator in last 24 hrs bsc. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Total tips received by a validator in last 24 hrs bsc](https://ide.bitquery.io/total-tips-received-by-a-validator-in-last-24-hrs-bsc)
+
+### PancakeSwap
+
+#### OHLC of a Token on PancakeSwap
+
+Get the OHLC stats of a token traded on Pancakeswap.
+
+▶️ [OHLC of a Token on PancakeSwap](https://ide.bitquery.io/OHLC-of-a-Token-on-pancake_swap_v3)
+
+#### Price of a Token on PancakeSwap
+
+Get the latest price of a token traded on Pancakeswap.
+
+▶️ [Price of a Token on PancakeSwap](https://ide.bitquery.io/BSC-PancakeSwap-v3-Price-for-a-token)
+
+#### Trades on Pancakeswap
+
+Get the latest trades on Pancakeswap.
+
+▶️ [Trades on Pancakeswap](https://ide.bitquery.io/BSC-dextrades-for-pancakeswap)
+
+#### All pools of a token on pancake swap
+
+All pools of a token on pancake swap. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [All pools of a token on pancake swap](https://ide.bitquery.io/All-pools-of-a-token-on-pancake-swap_2)
+
+#### Bsc pancakeswap ohlc using trading api
+
+Bsc pancakeswap ohlc using trading api. Uses the `Pairs` cube.
+
+▶️ [Bsc pancakeswap ohlc using trading api](https://ide.bitquery.io/bsc-pancakeswap-ohlc-using-trading-api)
+
+#### Get Latest Price of a token on PancakeSwap Infinity
+
+Get Latest Price of a token on PancakeSwap Infinity. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get Latest Price of a token on PancakeSwap Infinity](https://ide.bitquery.io/Get-Latest-Price-of-a-token-on-PancakeSwap-Infinity_1)
+
+### Four Meme
 
 #### Get Dev and Age of Four Meme Token
 
 Below query retrieves the Dev address and time when a Four Meme Token was created.
-▶️[Get Dev and Age of Four Meme Token](https://ide.bitquery.io/get-dev-and-age-of-a-four-meme-token)
+
+▶️ [Get Dev and Age of Four Meme Token](https://ide.bitquery.io/get-dev-and-age-of-a-four-meme-token)
+
+#### Get Newly Created Tokens on Four Meme
+
+This query retrieves newly created tokens on Four Meme by listening to the `TokenCreate` event. The response provides token information including creator address, token contract address, name, symbol, total supply, and launch details.
+
+▶️ [Get Newly Created Tokens on Four Meme](https://ide.bitquery.io/track-Four-meme-token-creation-using-events)
+
+#### Liquidity Addition for Four Meme Token
+
+Get the liquidity addition events for a specific token on the Four Meme Exchange.
+
+▶️ [Liquidity Addition for Four Meme Token](https://ide.bitquery.io/Liquidity-Added-to-specific-tokens-on-Four-meme)
+
+#### Four meme - token ATH price
+
+Four meme - token ATH price. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Four meme - token ATH price](https://ide.bitquery.io/four-meme---token-ATH-price)
+
+#### Get first buys of an address list of a specific token
+
+Get first buys of an address list of a specific token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Get first buys of an address list of a specific token](https://ide.bitquery.io/get-first-buys-of-an-address-list-of-a-specific-token_2)
+
+#### If meme rush token migrated from four meme or not
+
+If meme rush token migrated from four meme or not. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [If meme rush token migrated from four meme or not](https://ide.bitquery.io/if-meme-rush-token-migrated-from-four-meme-or-not)
+
+### Uniswap
+
+#### Trading Pairs on a BSC DEX
+
+Get all trading pairs present on a BSC network DEX.
+
+▶️ [Trading Pairs on a BSC DEX](https://ide.bitquery.io/trading-pairs-on-BNB-by-USD-volume)
+
+#### Get metadata
+
+Get metadata. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get metadata](https://ide.bitquery.io/get-metadata_1)
+
+#### Latest Trades for a currency pair on bsc
+
+Latest Trades for a currency pair on bsc. Uses the `DEXTrades` cube.
+
+▶️ [Latest Trades for a currency pair on bsc](https://ide.bitquery.io/Latest-Trades-for-a-currency-pair-on-bsc)
+
+#### OHLC on BSC Uniswap v3
+
+OHLC on BSC Uniswap v3. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [OHLC on BSC Uniswap v3](https://ide.bitquery.io/OHLC-on-BSC-Uniswap-v3)
+
+#### Top bought tokens on bsc uniswap v3
+
+Top bought tokens on bsc uniswap v3. Uses the `DEXTradeByTokens` cube.
+
+▶️ [Top bought tokens on bsc uniswap v3](https://ide.bitquery.io/top-bought-tokens-on-bsc-uniswap-v3)
+
+#### Top buyers of a currency on uniswap v4 bsc
+
+Top buyers of a currency on uniswap v4 bsc. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top buyers of a currency on uniswap v4 bsc](https://ide.bitquery.io/top-buyers-of-a-currency-on-uniswap-v4-bsc)
+
+## Base
+
+### Trades
+
+#### Base DEX Trades
+
+This query returns the latest trades on the Base network from a trader perspective and returns useful metrics such as marketcap and pool ranking.
+
+▶️ [Base DEX Trades](https://ide.bitquery.io/base-dextrades_3)
+
+#### Base Dex Trade By Tokens
+
+This query returns the latest trades on the Base network. This is useful when looking for trades of a token.
+
+▶️ [Base Dex Trade By Tokens](https://ide.bitquery.io/base-dextrades-for-a-token)
+
+#### Get Trades by a Trader
+
+Get all trades by a particular trader.
+
+▶️ [Get Trades by a Trader](https://ide.bitquery.io/base-dextrades-by-a-trader)
+
+#### First 500 buyers of a specific base token
+
+First 500 buyers of a specific base token. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [First 500 buyers of a specific base token](https://ide.bitquery.io/first-500-buyers-of-a-specific-base-token)
+
+#### Latest Trades of a Token on Zora Base
+
+Latest Trades of a Token on Zora Base. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Latest Trades of a Token on Zora Base](https://ide.bitquery.io/Latest-Trades-of-a-Token-on-Zora-Base)
+
+#### Latest Zora Trades on Base
+
+Latest Zora Trades on Base. Uses the `DEXTrades` cube.
+
+▶️ [Latest Zora Trades on Base](https://ide.bitquery.io/Latest-Zora-Trades-on-Base)
+
+#### Most Traded Tokens on Aerodome Last Month
+
+Most Traded Tokens on Aerodome Last Month. Uses the `DEXTradeByTokens` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Most Traded Tokens on Aerodome Last Month](https://ide.bitquery.io/Most-Traded-Tokens-on-Aerodome-Last-Month)
+
+#### Top Traders by PnL of a specific base pool
+
+Top Traders by PnL of a specific base pool. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Top Traders by PnL of a specific base pool](https://ide.bitquery.io/Top-Traders-by-PnL-of-a-specific-base-pool_1)
+
+#### Ape store token trades
+
+Ape store token trades. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Ape store token trades](https://ide.bitquery.io/ape-store-token-trades)
+
+### Transfers
+
+#### Get Historical ERC20 token transfers by wallet
+
+Get ERC20 token transfers for an address in a given historical time window
+
+▶️ [Get Historical ERC20 token transfers by wallet](https://ide.bitquery.io/Get-historical-ERC20-token-transfers-by-wallet-base_2)
+
+#### Get token transfers by wallet
+
+Get token transactions ordered by block number in descending order.
+
+▶️ [Get token transfers by wallet](https://ide.bitquery.io/Get-token-transfers-by-wallet-base_1)
+
+#### Newly created zora tokens
+
+Newly created zora tokens. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Newly created zora tokens](https://ide.bitquery.io/Newly-created-zora-tokens)
+
+#### Tx from to base address
+
+Tx from to base address. Uses the `Transfers` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Tx from to base address](https://ide.bitquery.io/tx-from-to-base-address)
+
+### Balances & Holders
+
+#### Real-Time Holders of Multiple Tokens
+
+This API leverages the balanceUpdate endpoint to deliver real-time holder data for multiple tokens.
+
+▶️ [Real-Time Holders of Multiple Tokens](https://ide.bitquery.io/Top-10-holders-of-multiple-tokens-on-Base_2)
+
+#### Token Holder Count on a Specific Date
+
+This API returns the total number of holders for a specific token on a given date.
+
+▶️ [Token Holder Count on a Specific Date](https://ide.bitquery.io/token-holders-count-base)
+
+#### Token Holders and Stats on a Specific Date - TokenHolders API
+
+This API provides a list of all holders along with relevant statistics for a given token on a specific date.
+
+▶️ [Token Holders and Stats on a Specific Date - TokenHolders API](https://ide.bitquery.io/tokens-holders-of-a-token-base)
+
+#### Token Holders of Multiple Tokens on a speicifc date
+
+This API provides a list of top holders along with relevant statistics for a given token liston a specific date using Holders API.
+
+▶️ [Token Holders of Multiple Tokens on a speicifc date](https://ide.bitquery.io/Top-10-holders-of-multiple-tokens-on-Base-at-a-specific-time-holder-api)
+
+#### Get All Token Balances for an Address
+
+Retrieve all token balances held by a specific address. This query returns balances for all tokens the address holds.
+
+▶️ [Get All Token Balances for an Address](https://ide.bitquery.io/Get-All-Token-Balances-for-an-Address_4)
+
+#### Get latest token balance of a wallet
+
+Get latest token balance of a wallet.
+
+▶️ [Get latest token balance of a wallet](https://ide.bitquery.io/Get-Latest-Token-Balance-for-an-Address_4)
+
+#### Base balances address
+
+Base balances address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Base balances address](https://ide.bitquery.io/base-balances-address)
+
+#### Base native balances address
+
+Base native balances address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Base native balances address](https://ide.bitquery.io/base-native-balances-address)
+
+#### Latest balance of an address for a specific token base
+
+Latest balance of an address for a specific token base. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Latest balance of an address for a specific token base](https://ide.bitquery.io/Latest-balance-of-an-address-for-a-specific-token-base)
+
+#### Token holder snapshot base
+
+Token holder snapshot base. Uses the `Holders` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Token holder snapshot base](https://ide.bitquery.io/token-holder-snapshot-base)
+
+### Price & OHLC
+
+#### Get ATH Price of a token
+
+Retrieves the all-time high (ATH) price in USD for a specified token contract.
+
+▶️ [Get ATH Price of a token](https://ide.bitquery.io/ATH-of-base-token)
+
+#### Get Multiple Token Prices
+
+Returns an array of token prices denominated in the blockchain's native token and USD for a given token contract address.
+
+▶️ [Get Multiple Token Prices](https://ide.bitquery.io/Price-of-multiple-tokens-in-realtime_1)
+
+#### Get OHLCV by Pair Address
+
+Get the OHLCV candle stick by using pair address.
+
+▶️ [Get OHLCV by Pair Address](https://ide.bitquery.io/OHLC--base)
+
+#### Get Price Change 5min, 1h, 6h and 24h of a specific token
+
+This query gets you Price Change 5min, 1h, 6h and 24h of a specific token on the Base network.
+
+▶️ [Get Price Change 5min, 1h, 6h and 24h of a specific token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_6)
+
+#### Top 10 Base Tokens by Price Change in last 1h
+
+This query gets you top 10 Base Tokens by Price Change in last 1h.
+
+▶️ [Top 10 Base Tokens by Price Change in last 1h](https://ide.bitquery.io/Top-10-base-tokens-by-price-change-in-last-1-hr_1)
+
+#### OHLC-of-AERO-Coin
+
+OHLC-of-AERO-Coin. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [OHLC-of-AERO-Coin](https://ide.bitquery.io/OHLC-of-AERO-Coin_1)
+
+#### Price change 5min, 1hr, 6hr, 24h precentage of a specific token
+
+Price change 5min, 1hr, 6hr, 24h precentage of a specific token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Price change 5min, 1hr, 6hr, 24h precentage of a specific token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-24h-precentage-of-a-specific-token)
+
+#### Top 10 base tokens by price change in last 1 hr
+
+Top 10 base tokens by price change in last 1 hr. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Top 10 base tokens by price change in last 1 hr](https://ide.bitquery.io/Top-10-base-tokens-by-price-change-in-last-1-hr)
+
+### Supply & Market Cap
+
+#### Get Token Total Supply and Market Cap
+
+Retrieve the total supply and market capitalization of a specific token. This query provides on-chain market cap data.
+
+▶️ [Get Token Total Supply and Market Cap](https://ide.bitquery.io/Get-Token-Total-Supply-and-Market-Cap_5)
+
+#### Top Tokens by Market Cap on Base
+
+Top Tokens by Market Cap on Base. Uses the `Tokens` cube.
+
+▶️ [Top Tokens by Market Cap on Base](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-Base)
+
+#### Total supply of a AERO on Base
+
+Total supply of a AERO on Base. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Total supply of a AERO on Base](https://ide.bitquery.io/Total-supply-of-a-AERO-on-Base)
+
+#### Bankr token latest marketcap OHLC
+
+Bankr token latest marketcap OHLC. Uses the `Tokens` cube.
+
+▶️ [Bankr token latest marketcap OHLC](https://ide.bitquery.io/Bankr-token-latest-marketcap-OHLC)
+
+#### Total Supply and onchain Marketcap of a specific token base
+
+Total Supply and onchain Marketcap of a specific token base. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Total Supply and onchain Marketcap of a specific token base](https://ide.bitquery.io/Total-Supply-and-onchain-Marketcap-of-a-specific-token-base)
+
+### Liquidity & Pools
+
+#### Latest Liquidity of Base Pool
+
+Get the latest liquidity of an Base DEX pool (e.g., Uniswap v3 pool).
+
+▶️ [Latest Liquidity of Base Pool](https://ide.bitquery.io/latest-liquidity-of-a-Base-pool_2)
+
+#### Latest Slippage for a Specific Pool
+
+This query retrieves the latest slippage data for a specific DEX pool on Base. Use this to check current liquidity depth and price impact for a particular token pair.
+
+▶️ [Latest Slippage for a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_7)
+
+#### Latest Liquidity Changes of a Specific Pool
+
+Latest Liquidity Changes of a Specific Pool. Uses the `DEXPoolEvents` cube.
+
+▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_4)
+
+#### Latest Liquidity Pools on Aerodome
+
+Latest Liquidity Pools on Aerodome. Uses the `Events` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Latest Liquidity Pools on Aerodome](https://ide.bitquery.io/Latest-Liquidity-Pools-on-Aerodome)
+
+#### Top liquidity pools of cbBTC
+
+Top liquidity pools of cbBTC. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top liquidity pools of cbBTC](https://ide.bitquery.io/top-liquidity-pools-of-cbBTC)
+
+#### Latest liquidity of a base pool
+
+Latest liquidity of a base pool. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest liquidity of a base pool](https://ide.bitquery.io/latest-liquidity-of-a-base-pool)
+
+### Transactions
+
+#### Get transactions by wallet
+
+Get transactions ordered by block number in descending order.
+
+▶️ [Get transactions by wallet](https://ide.bitquery.io/Get-transactions-by-wallet_8)
+
+#### Latest gauge vaults claimRewards transactions
+
+Latest gauge vaults claimRewards transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest gauge vaults claimRewards transactions](https://ide.bitquery.io/latest-gauge-vaults-claimRewards-transactions)
+
+#### Latest gauge vaults deposits transactions
+
+Latest gauge vaults deposits transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest gauge vaults deposits transactions](https://ide.bitquery.io/latest-gauge-vaults-deposits-transactions)
+
+#### Latest gauge vaults withdraw transactions
+
+Latest gauge vaults withdraw transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest gauge vaults withdraw transactions](https://ide.bitquery.io/latest-gauge-vaults-withdraw-transactions_1)
+
+### Events & Calls
+
+#### Get Latest Calls
+
+Get Latest Calls. Uses the `Calls` cube.
+
+▶️ [Get Latest Calls](https://ide.bitquery.io/Recent-Calls-on-base_1)
+
+#### Get Latest Events
+
+Get Latest Events. Uses the `Events` cube.
+
+▶️ [Get Latest Events](https://ide.bitquery.io/Recents-Events-and-Logs-on-Base)
+
+#### Latest Bankr launches Doppler Airlock Base
+
+Latest Bankr launches Doppler Airlock Base. Uses the `Events` cube.
+
+▶️ [Latest Bankr launches Doppler Airlock Base](https://ide.bitquery.io/Latest-Bankr-launches-Doppler-Airlock-Base)
+
+#### All bankers tokens created by a deployer
+
+All bankers tokens created by a deployer. Uses the `Events` cube. Change the token address in the `where` clause to use it.
+
+▶️ [All bankers tokens created by a deployer](https://ide.bitquery.io/All-bankers-tokens-created-by-a-deployer)
+
+#### Ape store buys from a wallet
+
+Ape store buys from a wallet. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Ape store buys from a wallet](https://ide.bitquery.io/ape-store-buys-from-a-wallet)
+
+#### Ape store token event
+
+Ape store token event. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Ape store token event](https://ide.bitquery.io/ape-store-token-event_1)
+
+#### Ape-store-buys
+
+Ape-store-buys. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Ape-store-buys](https://ide.bitquery.io/ape-store-buys_1)
+
+#### Base jump token event
+
+Base jump token event. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Base jump token event](https://ide.bitquery.io/base-jump-token-event)
+
+#### Base-jump-buys
+
+Base-jump-buys. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Base-jump-buys](https://ide.bitquery.io/base-jump-buys)
+
+#### Latest Coin on Base Coin
+
+Latest Coin on Base Coin. Uses the `Calls` cube.
+
+▶️ [Latest Coin on Base Coin](https://ide.bitquery.io/Latest-Coin-on-Base-Coin_3)
+
+### Blocks & Validators
+
+#### Aggregate Self Destruct Statistics base
+
+Aggregate Self Destruct Statistics base. Uses the `TransactionBalances` cube.
+
+▶️ [Aggregate Self Destruct Statistics base](https://ide.bitquery.io/Aggregate-Self-Destruct-Statistics-base)
+
+#### Self Destruct Balance Decrease API base
+
+Self Destruct Balance Decrease API base. Uses the `TransactionBalances` cube.
+
+▶️ [Self Destruct Balance Decrease API base](https://ide.bitquery.io/Self-Destruct-Balance-Decrease-API-base)
+
+#### Self Destruct Balance Increase API base
+
+Self Destruct Balance Increase API base. Uses the `TransactionBalances` cube.
+
+▶️ [Self Destruct Balance Increase API base](https://ide.bitquery.io/Self-Destruct-Balance-Increase-API-base)
+
+### Uniswap
+
+#### Uniswap Trades Stream
+
+This subscription returns the real-time trades happening on Uniswap. You can modify the stream to get real-time trades for a particular token, a particular token pair and even a particular trader.
+
+▶️ [Uniswap Trades Stream](https://ide.bitquery.io/Realtime-Uniswap-v1-Uniswap-v2-Uniswap-V3-Trades_1)
+
+#### Get metadata for base uniswap token
+
+Get metadata for base uniswap token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get metadata for base uniswap token](https://ide.bitquery.io/get-metadata-for-base-uniswap-token)
+
+#### Latest slippage of a pool on Uniswap v3
+
+Latest slippage of a pool on Uniswap v3. Change the token address in the `where` clause to use it.
+
+▶️ [Latest slippage of a pool on Uniswap v3](https://ide.bitquery.io/Latest-slippage-of-a-pool-on-Uniswap-v3)
+
+#### OHLC on BASE Uniswap v3
+
+OHLC on BASE Uniswap v3. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [OHLC on BASE Uniswap v3](https://ide.bitquery.io/OHLC-on-BASE-Uniswap-v3)
+
+#### Top bought tokens on uniswap v3
+
+Top bought tokens on uniswap v3. Uses the `DEXTradeByTokens` cube.
+
+▶️ [Top bought tokens on uniswap v3](https://ide.bitquery.io/top-bought-tokens-on-uniswap-v3)
+
+#### Top sold tokens on uniswap v3
+
+Top sold tokens on uniswap v3. Uses the `DEXTradeByTokens` cube.
+
+▶️ [Top sold tokens on uniswap v3](https://ide.bitquery.io/top-sold-tokens-on-uniswap-v3)
+
+### PancakeSwap
+
+#### Get Latest Price of a token on PancakeSwap Infinity
+
+Get Latest Price of a token on PancakeSwap Infinity. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get Latest Price of a token on PancakeSwap Infinity](https://ide.bitquery.io/Get-Latest-Price-of-a-token-on-PancakeSwap-Infinity)
+
+#### Pancakeswap infinity trades
+
+Pancakeswap infinity trades. Uses the `DEXTrades` cube.
+
+▶️ [Pancakeswap infinity trades](https://ide.bitquery.io/pancakeswap-infinity-trades)
+
+#### Top bought tokens on pancakeswap_infinity
+
+Top bought tokens on pancakeswap_infinity. Uses the `DEXTradeByTokens` cube.
+
+▶️ [Top bought tokens on pancakeswap_infinity](https://ide.bitquery.io/top-bought-tokens-on-pancakeswap_infinity)
+
+#### Top sold tokens on pancake infinty
+
+Top sold tokens on pancake infinty. Uses the `DEXTradeByTokens` cube.
+
+▶️ [Top sold tokens on pancake infinty](https://ide.bitquery.io/top-sold-tokens-on-pancake-infinty)
+
+#### Get metadata for base pancakeswap infnity token
+
+Get metadata for base pancakeswap infnity token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get metadata for base pancakeswap infnity token](https://ide.bitquery.io/get-metadata-for-base-pancakeswap-infnity-token)
+
+#### OHLC on BASE pancakeswap infinity
+
+OHLC on BASE pancakeswap infinity. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [OHLC on BASE pancakeswap infinity](https://ide.bitquery.io/OHLC-on-BASE-pancakeswap-infinity)
+
+### Aerodrome
+
+#### Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge claimRewards Transactions
+
+Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge claimRewards Transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge claimRewards Transactions](https://ide.bitquery.io/latest-Aerodrome-Finance-CL100-WETHVVV-Pool-Gauge-claimRewards-Transactions)
+
+#### Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge deposits
+
+Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge deposits. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge deposits](https://ide.bitquery.io/latest-Aerodrome-Finance-CL100-WETHVVV-Pool-Gauge-deposits)
+
+#### Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge withdraw transactions
+
+Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge withdraw transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest Aerodrome Finance: CL100-WETH/VVV Pool Gauge withdraw transactions](https://ide.bitquery.io/latest-Aerodrome-Finance-CL100-WETHVVV-Pool-Gauge-withdraw-transactions_1)
+
+## Arbitrum
+
+### Trades
+
+#### Pair last trades
+
+Pair last trades. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Pair last trades](https://ide.bitquery.io/Pair-last-trades_2)
+
+#### Swap Events Arbitrum
+
+Swap Events Arbitrum. Uses the `Events` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Swap Events Arbitrum](https://ide.bitquery.io/Swap-Events-Arbitrum)
+
+#### Top Sold Tokens on Arbitrum
+
+Top Sold Tokens on Arbitrum. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
+
+▶️ [Top Sold Tokens on Arbitrum](https://ide.bitquery.io/Top-Sold-Tokens-on-Arbitrum)
+
+#### Top bought tokens on Arbitrum
+
+Top bought tokens on Arbitrum. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
+
+▶️ [Top bought tokens on Arbitrum](https://ide.bitquery.io/top-bought-tokens-on-Arbitrum)
+
+#### Top traders for a token on Arbitrum
+
+Top traders for a token on Arbitrum. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top traders for a token on Arbitrum](https://ide.bitquery.io/top-traders-for-a-token-on-Arbitrum_3)
+
+#### Trending token pairs on Arbitrum
+
+Trending token pairs on Arbitrum. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Trending token pairs on Arbitrum](https://ide.bitquery.io/trending-token-pairs-on-Arbitrum)
+
+### Balances & Holders
+
+#### Arbitrum Balance of an Address
+
+Arbitrum Balance of an Address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Arbitrum Balance of an Address](https://ide.bitquery.io/Arbitrum-Balance-of-an-Address)
+
+#### Arbitrum balances by date
+
+Arbitrum balances by date. Uses the `Balances` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Arbitrum balances by date](https://ide.bitquery.io/arbitrum-balances-by-date)
+
+#### Arbitrum balances history
+
+Arbitrum balances history. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Arbitrum balances history](https://ide.bitquery.io/arbitrum-balances-history)
+
+#### Arbitrum balances specific token
+
+Arbitrum balances specific token. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Arbitrum balances specific token](https://ide.bitquery.io/arbitrum-balances-specific-token)
+
+#### Arbitrum native balances address
+
+Arbitrum native balances address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Arbitrum native balances address](https://ide.bitquery.io/arbitrum-native-balances-address)
+
+#### Token holder snapshot arbitrum
+
+Token holder snapshot arbitrum. Uses the `Holders` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Token holder snapshot arbitrum](https://ide.bitquery.io/token-holder-snapshot-arbitrum)
+
+### Price & OHLC
+
+#### Ohlc for a pair on Arbitrum
+
+Ohlc for a pair on Arbitrum. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Ohlc for a pair on Arbitrum](https://ide.bitquery.io/ohlc-for-a-pair-on-Arbitrum_1)
+
+#### Price change 5min, 1hr, 6hr, 24hr precentage of a specific token
+
+Price change 5min, 1hr, 6hr, 24hr precentage of a specific token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Price change 5min, 1hr, 6hr, 24hr precentage of a specific token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-24hr-precentage-of-a-specific-token_1)
+
+#### Top 10 arb tokens by price change in last 1 hr
+
+Top 10 arb tokens by price change in last 1 hr. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Top 10 arb tokens by price change in last 1 hr](https://ide.bitquery.io/Top-10-arb-tokens-by-price-change-in-last-1-hr)
+
+### Supply & Market Cap
+
+#### Top Tokens by Market Cap on Arbitrum
+
+Top Tokens by Market Cap on Arbitrum. Uses the `Tokens` cube.
+
+▶️ [Top Tokens by Market Cap on Arbitrum](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-Arbitrum)
+
+### Liquidity & Pools
+
+#### Latest liquidity changes of a specific pool
+
+Latest liquidity changes of a specific pool. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Latest liquidity changes of a specific pool](https://ide.bitquery.io/latest-liquidity-changes-of-a-specific-pool)
+
+### Transactions
+
+#### Latest Transactions
+
+Latest Transactions. Uses the `Transactions` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Latest Transactions](https://ide.bitquery.io/Latest-Transactions_3)
+
+#### Transaction Call Trace Arbitrum
+
+Transaction Call Trace Arbitrum. Uses the `Calls` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Transaction Call Trace Arbitrum](https://ide.bitquery.io/Transaction-Call-Trace-Arbitrum)
+
+### Events & Calls
+
+#### Latest GMX Events
+
+Latest GMX Events. Uses the `Events` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Latest GMX Events](https://ide.bitquery.io/latest-GMX-Events)
+
+#### Latest vGLP Withdraw Events
+
+Latest vGLP Withdraw Events. Uses the `Events` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Latest vGLP Withdraw Events](https://ide.bitquery.io/latest-vGLP-Withdraw-Events)
+
+#### Latest deposits on Across Bridge
+
+Latest deposits on Across Bridge. Uses the `Events` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Latest deposits on Across Bridge](https://ide.bitquery.io/Latest-deposits-on-Across-Bridge)
+
+#### Latest vGLP Deposit Events
+
+Latest vGLP Deposit Events. Uses the `Events` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Latest vGLP Deposit Events](https://ide.bitquery.io/latest-vGLP-Deposit-Events)
+
+### Blocks & Validators
+
+#### Latest Arbitrum blocks
+
+Latest Arbitrum blocks. Uses the `Blocks` cube.
+
+▶️ [Latest Arbitrum blocks](https://ide.bitquery.io/Latest-Arbitrum-blocks)
+
+### Uniswap
+
+#### Get virtual pool address for a token on uniswap v4 arbitrum
+
+Get virtual pool address for a token on uniswap v4 arbitrum. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get virtual pool address for a token on uniswap v4 arbitrum](https://ide.bitquery.io/get-virtual-pool-address-for-a-token-on-uniswap-v4-arbitrum)
+
+#### Latest Trades for a currency pair on arbitrum
+
+Latest Trades for a currency pair on arbitrum. Uses the `DEXTrades` cube.
+
+▶️ [Latest Trades for a currency pair on arbitrum](https://ide.bitquery.io/Latest-Trades-for-a-currency-pair-on-arbitrum)
+
+#### Top buyers of a currency on uniswap v4 arbitrum
+
+Top buyers of a currency on uniswap v4 arbitrum. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top buyers of a currency on uniswap v4 arbitrum](https://ide.bitquery.io/top-buyers-of-a-currency-on-uniswap-v4-arbitrum)
+
+#### Top sellers of a token on uniswap v4 arbitrum
+
+Top sellers of a token on uniswap v4 arbitrum. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top sellers of a token on uniswap v4 arbitrum](https://ide.bitquery.io/top-sellers-of-a-token-on-uniswap-v4-arbitrum)
+
+#### Trade stats for a token pair on uniswap v4 arbitrum
+
+Trade stats for a token pair on uniswap v4 arbitrum. Uses the `DEXTradeByTokens` cube.
+
+▶️ [Trade stats for a token pair on uniswap v4 arbitrum](https://ide.bitquery.io/trade-stats-for-a-token-pair-on-uniswap-v4-arbitrum)
+
+## Optimism
+
+### Trades
+
+#### Top tokens on optimism
+
+Top tokens on optimism. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
+
+▶️ [Top tokens on optimism](https://ide.bitquery.io/top-tokens-on-optimism)
+
+#### Top traders for wld usdc pair
+
+Top traders for wld usdc pair. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top traders for wld usdc pair](https://ide.bitquery.io/top-traders-for-wld-usdc-pair)
+
+#### Top traders on optimism
+
+Top traders on optimism. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
+
+▶️ [Top traders on optimism](https://ide.bitquery.io/top-traders-on-optimism)
+
+### Balances & Holders
+
+#### Optimism Balance of an Address
+
+Optimism Balance of an Address. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Optimism Balance of an Address](https://ide.bitquery.io/Optimism-Balance-of-an-Address)
+
+#### Optimism balances by date
+
+Optimism balances by date. Uses the `Balances` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Optimism balances by date](https://ide.bitquery.io/optimism-balances-by-date)
+
+#### Optimism balances history address
+
+Optimism balances history address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Optimism balances history address](https://ide.bitquery.io/optimism-balances-history-address)
+
+#### Optimism balances specific token
+
+Optimism balances specific token. Uses the `Balances` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Optimism balances specific token](https://ide.bitquery.io/optimism-balances-specific-token)
+
+#### Optimism native balances address
+
+Optimism native balances address. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Optimism native balances address](https://ide.bitquery.io/optimism-native-balances-address)
+
+#### Token holder snapshot optimism
+
+Token holder snapshot optimism. Uses the `Holders` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Token holder snapshot optimism](https://ide.bitquery.io/token-holder-snapshot-optimism)
+
+### Uniswap
+
+#### Latest Trades for a currency pair on optimism
+
+Latest Trades for a currency pair on optimism. Uses the `DEXTrades` cube.
+
+▶️ [Latest Trades for a currency pair on optimism](https://ide.bitquery.io/Latest-Trades-for-a-currency-pair-on-optimism)
+
+#### Top buyers of a currency on uniswap v4 optimism
+
+Top buyers of a currency on uniswap v4 optimism. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top buyers of a currency on uniswap v4 optimism](https://ide.bitquery.io/top-buyers-of-a-currency-on-uniswap-v4-optimism)
+
+#### Top sellers of a token on uniswap v4 pool optimism
+
+Top sellers of a token on uniswap v4 pool optimism. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top sellers of a token on uniswap v4 pool optimism](https://ide.bitquery.io/top-sellers-of-a-token-on-uniswap-v4-pool-optimism)
+
+#### Trade stats for a token pair on uniswap v4 optimism
+
+Trade stats for a token pair on uniswap v4 optimism. Uses the `DEXTradeByTokens` cube.
+
+▶️ [Trade stats for a token pair on uniswap v4 optimism](https://ide.bitquery.io/trade-stats-for-a-token-pair-on-uniswap-v4-optimism)
+
+## Polygon
+
+### Trades
+
+#### Top Traders by PnL of a specific polygon pool
+
+Top Traders by PnL of a specific polygon pool. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Top Traders by PnL of a specific polygon pool](https://ide.bitquery.io/Top-Traders-by-PnL-of-a-specific-polygon-pool)
+
+#### Top traders of a token on matic
+
+Top traders of a token on matic. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Top traders of a token on matic](https://ide.bitquery.io/top-traders-of-a-token-on-matic_1)
+
+### Transfers
+
+#### Check if an address interacted with polymarket ever
+
+Check if an address interacted with polymarket ever. Uses the `Transfers` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Check if an address interacted with polymarket ever](https://ide.bitquery.io/check-if-an-address-interacted-with-polymarket-ever)
+
+### Balances & Holders
+
+#### Balance of an address
+
+Returns all token balances for a wallet on Polygon using `EVM.Balances` with `network: matic` and `dataset: combined`. See [Polygon Address Balance API](/docs/blockchain/Matic/matic-balance-api/#balance-of-an-address).
+
+▶️ [Balance of an address](https://ide.bitquery.io/matic-balances-address_1)
+
+#### Matic historical balances address
+
+Returns all token balances for a wallet on Polygon using `EVM.Balances` with `network: matic` and `dataset: combined` until a particular period. For this example we will find the Balnce of the address one month ago.
+
+▶️ [Matic historical balances address](https://ide.bitquery.io/matic-historical-balances-address_1)
+
+#### Matic balances address
+
+Matic balances address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Matic balances address](https://ide.bitquery.io/matic-balances-address)
+
+#### Matic balances history
+
+Matic balances history. Uses the `Balances` cube.
+
+▶️ [Matic balances history](https://ide.bitquery.io/matic-balances-history)
+
+#### Matic balances specific token
+
+Matic balances specific token. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Matic balances specific token](https://ide.bitquery.io/matic-balances-specific-token)
+
+#### Matic native balances address
+
+Matic native balances address. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Matic native balances address](https://ide.bitquery.io/matic-native-balances-address)
+
+#### Matic wallet balance token at date
+
+Matic wallet balance token at date. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Matic wallet balance token at date](https://ide.bitquery.io/matic-wallet-balance-token-at-date)
+
+#### Token holder snapshot matic
+
+Token holder snapshot matic. Uses the `Holders` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Token holder snapshot matic](https://ide.bitquery.io/token-holder-snapshot-matic)
+
+### Supply & Market Cap
+
+#### Top Tokens by Market Cap on Polygon
+
+Top Tokens by Market Cap on Polygon. Uses the `Tokens` cube.
+
+▶️ [Top Tokens by Market Cap on Polygon](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-Polygon_1)
+
+### Liquidity & Pools
+
+#### Latest Liquidity Changes of a Specific Pool
+
+Latest Liquidity Changes of a Specific Pool. Uses the `DEXPoolEvents` cube.
+
+▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_6)
+
+### Uniswap
+
+#### Get virtual pool address for a token on uniswap v4 matic
+
+Get virtual pool address for a token on uniswap v4 matic. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get virtual pool address for a token on uniswap v4 matic](https://ide.bitquery.io/get-virtual-pool-address-for-a-token-on-uniswap-v4-matic)
+
+#### OHLCV on MATIC uniswap v3
+
+OHLCV on MATIC uniswap v3. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [OHLCV on MATIC uniswap v3](https://ide.bitquery.io/OHLCV-on-MATIC-uniswap-v3)
+
+#### Top bought tokens on matic uniswap v3
+
+Top bought tokens on matic uniswap v3. Uses the `DEXTradeByTokens` cube.
+
+▶️ [Top bought tokens on matic uniswap v3](https://ide.bitquery.io/top-bought-tokens-on-matic-uniswap-v3_4)
+
+#### Top sold tokens on matic uniswap v3
+
+Top sold tokens on matic uniswap v3. Uses the `DEXTradeByTokens` cube.
+
+▶️ [Top sold tokens on matic uniswap v3](https://ide.bitquery.io/top-sold-tokens-on-matic-uniswap-v3)
+
+#### Top traders of a token on uniswapv3 matic
+
+Top traders of a token on uniswapv3 matic. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top traders of a token on uniswapv3 matic](https://ide.bitquery.io/top-traders-of-a-token-on-uniswapv3-matic)
+
+#### Trade volume matic uniswapv3
+
+Trade volume matic uniswapv3. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Trade volume matic uniswapv3](https://ide.bitquery.io/trade_volume_matic_uniswapv3)
 
 ## TRON
 
-### Real Time Balance APIs
-
-#### Current Balance of a Wallet
-
-This query returns the current balance of a wallet for all currencies on the TRON network.  
-▶️ [TRON Balance of a Wallet](https://ide.bitquery.io/Tron-Wallet-Balance)
-
-### Historical Tron Balance APIs
-
-#### Historical Balance of a Wallet for a Currency
-
-This query returns the current balance of a wallet for all currencies on the TRON network.  
-▶️ [TRON Balance for a Currency](https://ide.bitquery.io/Historical-Tron-Wallet-Balance-for-a-currency)
-
-### Real Time Transfers
-
-#### Latest TRON Transfers
-
-This query returns the most recent transfers on the TRON network and includes details such as token amount transferred, sender, receiver, and token info.  
-▶️ [TRON Transfers](https://ide.bitquery.io/Tron-transfer_10_1)
-
-### Historical Transfers
-
-#### Historical TRON Transfers for a Wallet
-
-This query returns the historical transfers for a wallet in a given time window on the TRON network and includes details such as token amount transferred, sender, receiver, and token info.  
-▶️ [TRON Transfers](https://ide.bitquery.io/Historical-Tron-transfers-for-a-wallet)
-
-### Real Time Trades
-
-#### Tron DEX Trades
-
-This query returns the latest trades on the TRON network from a trader perspective.  
-▶️ [TRON DEX Trades](https://ide.bitquery.io/Tron-Trades)
-
-#### Tron Dex Trade By Tokens
-
-This query returns the latest token trades on the TRON network.  
-▶️ [DexTrade By Tokens](https://ide.bitquery.io/Tron-trades-for-a-token)
-
-### Historical Trades
-
-#### Historical Tron Token Trades within 30 Days
-
-This query returns the historical trades on the TRON network for a token with the time window of past 30 days.  
-▶️ [Historical TRON Token Trades](https://ide.bitquery.io/Historical-Tron-trades-for-a-token-within-30-days)
+### Trades
 
 #### Historical Tron Token Trades beyond 30 Days
 
-This query returns the historical token trades on the TRON network for time window beyond 30 days.  
-▶️ [Historical Token Trades beyond 30 Days](https://ide.bitquery.io/Historical-tron-token-trades-beyond-30-days)
+This query returns the historical token trades on the TRON network for time window beyond 30 days.
+
+▶️ [Historical Tron Token Trades beyond 30 Days](https://ide.bitquery.io/Historical-tron-token-trades-beyond-30-days)
+
+#### Historical Tron Token Trades within 30 Days
+
+This query returns the historical trades on the TRON network for a token with the time window of past 30 days.
+
+▶️ [Historical Tron Token Trades within 30 Days](https://ide.bitquery.io/Historical-Tron-trades-for-a-token-within-30-days)
+
+#### Tron DEX Trades
+
+This query returns the latest trades on the TRON network from a trader perspective.
+
+▶️ [Tron DEX Trades](https://ide.bitquery.io/Tron-Trades)
+
+#### Tron Dex Trade By Tokens
+
+This query returns the latest token trades on the TRON network.
+
+▶️ [Tron Dex Trade By Tokens](https://ide.bitquery.io/Tron-trades-for-a-token)
+
+#### All dexs info
+
+All dexs info.
+
+▶️ [All dexs info](https://ide.bitquery.io/all-dexs-info)
+
+#### DEX Markets for a token
+
+DEX Markets for a token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [DEX Markets for a token](https://ide.bitquery.io/DEX-Markets-for-a-token_1)
+
+#### First 100 buyers tron token
+
+First 100 buyers tron token. Uses the `DEXTradeByTokens` cube.
+
+▶️ [First 100 buyers tron token](https://ide.bitquery.io/first-100-buyers-tron-token)
+
+#### Peg health tron
+
+Peg health tron. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Peg health tron](https://ide.bitquery.io/peg-health-tron)
+
+#### Sunmpump launchtoDEX
+
+Sunmpump launchtoDEX. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Sunmpump launchtoDEX](https://ide.bitquery.io/sunmpump-launchtoDEX_1)
+
+#### Sunswap v2 latest Trades
+
+Sunswap v2 latest Trades. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Sunswap v2 latest Trades](https://ide.bitquery.io/sunswap-v2-latest-Trades)
+
+### Transfers
+
+#### Historical TRON Transfers for a Wallet
+
+This query returns the historical transfers for a wallet in a given time window on the TRON network and includes details such as token amount transferred, sender, receiver, and token info.
+
+▶️ [Historical TRON Transfers for a Wallet](https://ide.bitquery.io/Historical-Tron-transfers-for-a-wallet)
+
+#### Latest TRON Transfers
+
+This query returns the most recent transfers on the TRON network and includes details such as token amount transferred, sender, receiver, and token info.
+
+▶️ [Latest TRON Transfers](https://ide.bitquery.io/Tron-transfer_10_1)
+
+#### Daily transfer volume tron
+
+Daily transfer volume tron. Uses the `Transfers` cube. Adjust the date range in the `where` clause.
+
+▶️ [Daily transfer volume tron](https://ide.bitquery.io/daily-transfer-volume-tron)
+
+#### Top transfers of a token
+
+Top transfers of a token. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top transfers of a token](https://ide.bitquery.io/top-transfers-of-a-token_2)
+
+#### Tron total txn fees paid by the Account
+
+Tron total txn fees paid by the Account. Uses the `Transfers` cube.
+
+▶️ [Tron total txn fees paid by the Account](https://ide.bitquery.io/Tron-total-txn-fees-paid-by-the-Account)
+
+#### Transfers of a wallet API
+
+Transfers of a wallet API. Uses the `Transfers` cube.
+
+▶️ [Transfers of a wallet API](https://ide.bitquery.io/Transfers-of-a-wallet-API)
+
+#### Tron Transaction fees paid by Account aggregated by currency
+
+Tron Transaction fees paid by Account aggregated by currency. Uses the `Transfers` cube.
+
+▶️ [Tron Transaction fees paid by Account aggregated by currency](https://ide.bitquery.io/Tron-Transaction-fees-paid-by-Account-aggregated-by-currency)
+
+#### Tron wallet transfers with transaction fees paid
+
+Tron wallet transfers with transaction fees paid. Uses the `Transfers` cube.
+
+▶️ [Tron wallet transfers with transaction fees paid](https://ide.bitquery.io/tron-wallet-transfers-with-transaction-fees-paid)
+
+### Balances & Holders
+
+#### Historical Balance of a Wallet for a Currency
+
+This query returns the current balance of a wallet for all currencies on the TRON network.
+
+▶️ [Historical Balance of a Wallet for a Currency](https://ide.bitquery.io/Historical-Tron-Wallet-Balance-for-a-currency)
+
+#### Top token holders of a token
+
+Top token holders of a token. Uses the `Holders` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Top token holders of a token](https://ide.bitquery.io/top-token-holders-of-a-token)
+
+#### Tron Balances for Native currency
+
+Tron Balances for Native currency. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Tron Balances for Native currency](https://ide.bitquery.io/Tron-Balances-for-Native-currency)
+
+#### Tron USDT Balance At Date (Balances Cube)
+
+Tron USDT Balance At Date (Balances Cube). Uses the `Balances` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Tron USDT Balance At Date (Balances Cube)](https://ide.bitquery.io/tron-usdt-balance-at-date)
+
+#### Tron balances by date
+
+Tron balances by date. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Tron balances by date](https://ide.bitquery.io/tron-balances-by-date)
+
+#### Tron token balance
+
+Tron token balance. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Tron token balance](https://ide.bitquery.io/tron-token-balance)
+
+#### TronWalletPortfolio Tron
+
+TronWalletPortfolio Tron. Uses the `Balances` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [TronWalletPortfolio Tron](https://ide.bitquery.io/TronWalletPortfolio-Tron)
+
+#### SunPump Bonding Curve TRX Balance
+
+SunPump Bonding Curve TRX Balance. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [SunPump Bonding Curve TRX Balance](https://ide.bitquery.io/SunPump-Bonding-Curve-TRX-Balance)
+
+#### SunPump Historical Bonding Curve TRX Balance
+
+SunPump Historical Bonding Curve TRX Balance. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [SunPump Historical Bonding Curve TRX Balance](https://ide.bitquery.io/SunPump-Historical-Bonding-Curve-TRX-Balance)
+
+### Liquidity & Pools
+
+#### Sun Pump Virtual Liquidity Pools
+
+Sun Pump Virtual Liquidity Pools. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Sun Pump Virtual Liquidity Pools](https://ide.bitquery.io/Sun-Pump-Virtual-Liquidity-Pools_1)
+
+### Events & Calls
+
+#### Latest created Sunpump tokens
+
+Latest created Sunpump tokens. Uses the `Events` cube.
+
+▶️ [Latest created Sunpump tokens](https://ide.bitquery.io/latest-created-Sunpump-tokens)
+
+#### Latest tokens created on Sunpump
+
+Latest tokens created on Sunpump. Uses the `Events` cube.
+
+▶️ [Latest tokens created on Sunpump](https://ide.bitquery.io/Latest-tokens-created-on-Sunpump_2)
+
+#### TokenPurchased on Sunpump
+
+TokenPurchased on Sunpump. Uses the `Events` cube.
+
+▶️ [TokenPurchased on Sunpump](https://ide.bitquery.io/TokenPurchased-on-Sunpump)
+
+## Robinhood Chain
+
+### Trades
+
+#### Largest Trades on Robinhood Chain (24h, USD)
+
+Largest Trades on Robinhood Chain (24h, USD). Uses the `Trades` cube.
+
+▶️ [Largest Trades on Robinhood Chain (24h, USD)](https://ide.bitquery.io/largest-swaps-robinhood-chain)
+
+#### Pools trade Crowd Launch bids
+
+Pools trade Crowd Launch bids. Uses the `Events` cube.
+
+▶️ [Pools trade Crowd Launch bids](https://ide.bitquery.io/Pools-trade-Crowd-Launch-bids)
+
+#### Pools trade Latest launches
+
+Pools trade Latest launches. Uses the `Events` cube.
+
+▶️ [Pools trade Latest launches](https://ide.bitquery.io/Pools-trade-Latest-launches)
+
+#### Pools trade Latest trades for a token
+
+Pools trade Latest trades for a token. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Pools trade Latest trades for a token](https://ide.bitquery.io/Pools-trade-Latest-trades-for-a-token)
+
+#### Pools trade Launches per day
+
+Pools trade Launches per day. Uses the `Events` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Pools trade Launches per day](https://ide.bitquery.io/Pools-trade-Launches-per-day)
+
+#### Pools trade Most active token creators
+
+Pools trade Most active token creators. Uses the `Events` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Pools trade Most active token creators](https://ide.bitquery.io/Pools-trade-Most-active-token-creators)
+
+#### Pools trade PoolKey from TokenLaunched
+
+Pools trade PoolKey from TokenLaunched. Uses the `Events` cube.
+
+▶️ [Pools trade PoolKey from TokenLaunched](https://ide.bitquery.io/Pools-trade-PoolKey-from-TokenLaunched)
+
+#### Pools trade Token description and image
+
+Pools trade Token description and image. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Pools trade Token description and image](https://ide.bitquery.io/Pools-trade-Token-description-and-image)
+
+#### Pools trade TokenDistributed decoded event
+
+Pools trade TokenDistributed decoded event. Uses the `Events` cube.
+
+▶️ [Pools trade TokenDistributed decoded event](https://ide.bitquery.io/Pools-trade-raw-event-by-topic0)
+
+#### Pools trade Top tokens by volume
+
+Pools trade Top tokens by volume. Uses the `Tokens` cube. Adjust the date range in the `where` clause.
+
+▶️ [Pools trade Top tokens by volume](https://ide.bitquery.io/Pools-trade-Top-tokens-by-volume)
+
+### Transfers
+
+#### Ape.store Newly created tokens
+
+Ape.store Newly created tokens. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Ape.store Newly created tokens](https://ide.bitquery.io/Apestore-Newly-created-tokens)
+
+#### Bags.fm Newly created tokens
+
+Bags.fm Newly created tokens. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Bags.fm Newly created tokens](https://ide.bitquery.io/Bagsfm-Newly-created-tokens)
+
+#### Bankr Bot Newly created tokens
+
+Bankr Bot Newly created tokens. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Bankr Bot Newly created tokens](https://ide.bitquery.io/Bankr-Bot-Newly-created-tokens)
+
+#### Flap.sh Newly created tokens using transfer data
+
+Flap.sh Newly created tokens using transfer data. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Flap.sh Newly created tokens using transfer data](https://ide.bitquery.io/Flapsh-Newly-created-tokens-using-transfer-data)
+
+#### Klik Finance Newly created tokens using transfers
+
+Klik Finance Newly created tokens using transfers. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Klik Finance Newly created tokens using transfers](https://ide.bitquery.io/Klik-Finance-Newly-created-tokens-using-transfers)
+
+#### Robinhood Chain API - Latest Token Transfers
+
+Robinhood Chain API - Latest Token Transfers. Uses the `Transfers` cube.
+
+▶️ [Robinhood Chain API - Latest Token Transfers](https://ide.bitquery.io/latest-transfers-on-robinhood)
+
+#### Robinhood Chain Token Lookup by Contract Address
+
+Robinhood Chain Token Lookup by Contract Address. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Robinhood Chain Token Lookup by Contract Address](https://ide.bitquery.io/Pools-trade-Token-name-symbol-decimals)
+
+#### Token Lookup by Contract Address - Robinhood Chain
+
+Token Lookup by Contract Address - Robinhood Chain. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Token Lookup by Contract Address - Robinhood Chain](https://ide.bitquery.io/token-lookup-by-address-robinhood-chain)
+
+#### Transfers for a token on robinhood
+
+Transfers for a token on robinhood. Uses the `Transfers` cube.
+
+▶️ [Transfers for a token on robinhood](https://ide.bitquery.io/Transfers-for-a-token-on-robinhood)
+
+#### Transfers for a wallet on Robinhood
+
+Transfers for a wallet on Robinhood. Uses the `Transfers` cube.
+
+▶️ [Transfers for a wallet on Robinhood](https://ide.bitquery.io/transfers-for-a-wallet-on-Robinhood)
+
+### Balances & Holders
+
+#### Pools trade Per-transaction balance changes
+
+Pools trade Per-transaction balance changes. Uses the `TransactionBalances` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Pools trade Per-transaction balance changes](https://ide.bitquery.io/Pools-trade-Per-transaction-balance-changes)
+
+#### Wallet Token Balances on Robinhood Chain
+
+Wallet Token Balances on Robinhood Chain. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Wallet Token Balances on Robinhood Chain](https://ide.bitquery.io/wallet-token-balances-robinhood-chain)
+
+### Price & OHLC
+
+#### Latest price of a token
+
+Latest price of a token. Uses the `Tokens` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest price of a token](https://ide.bitquery.io/latest-price-of-a-token_10)
+
+#### Latest price of a token on a pool
+
+Latest price of a token on a pool. Uses the `Pairs` cube.
+
+▶️ [Latest price of a token on a pool](https://ide.bitquery.io/latest-price-of-a-token-on-a-pool)
+
+#### Pools trade OHLCV price candles
+
+Pools trade OHLCV price candles. Uses the `Tokens` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Pools trade OHLCV price candles](https://ide.bitquery.io/Pools-trade-OHLCV-price-candles)
+
+### Supply & Market Cap
+
+#### Pools trade Token holders and supply
+
+Pools trade Token holders and supply. Uses the `Holders` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Pools trade Token holders and supply](https://ide.bitquery.io/Pools-trade-Token-holders-and-supply)
+
+### Liquidity & Pools
+
+#### Pools trade Per-swap slippage
+
+Pools trade Per-swap slippage.
+
+▶️ [Pools trade Per-swap slippage](https://ide.bitquery.io/Pools-trade-Per-swap-slippage)
+
+#### Pools trade Pool creation Initialize
+
+Pools trade Pool creation Initialize. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Pools trade Pool creation Initialize](https://ide.bitquery.io/Pools-trade-Pool-creation-Initialize)
+
+### Transactions
+
+#### Daily Active Wallets on Robinhood Chain
+
+Daily Active Wallets on Robinhood Chain. Uses the `Transactions` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Daily Active Wallets on Robinhood Chain](https://ide.bitquery.io/robinhood-chain-active-wallets)
+
+#### Robinhood Chain Daily Transaction Count
+
+Robinhood Chain Daily Transaction Count. Uses the `Transactions` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Robinhood Chain Daily Transaction Count](https://ide.bitquery.io/robinhood-chain-daily-transactions)
+
+#### Robinhood Chain Gas Usage and Gas Price
+
+Robinhood Chain Gas Usage and Gas Price. Uses the `Transactions` cube.
+
+▶️ [Robinhood Chain Gas Usage and Gas Price](https://ide.bitquery.io/robinhood-chain-gas-fees)
+
+### Events & Calls
+
+#### All events from Flap.sh
+
+All events from Flap.sh. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [All events from Flap.sh](https://ide.bitquery.io/All-events-from-Flapsh)
+
+#### Flap.sh Newly created tokens using logs TokenCreated
+
+Flap.sh Newly created tokens using logs TokenCreated. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Flap.sh Newly created tokens using logs TokenCreated](https://ide.bitquery.io/Flapsh-Newly-created-tokens-using-logs-TokenCreated)
+
+#### New Contracts Deployed on Robinhood Chain
+
+New Contracts Deployed on Robinhood Chain. Uses the `Calls` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [New Contracts Deployed on Robinhood Chain](https://ide.bitquery.io/new-contracts-deployed-robinhood-chain)
+
+### Blocks & Validators
+
+#### Robinhood Chain Blocks per Day and Block Time
+
+Robinhood Chain Blocks per Day and Block Time. Uses the `Blocks` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Robinhood Chain Blocks per Day and Block Time](https://ide.bitquery.io/robinhood-chain-block-time)
+
+### Uniswap
+
+#### Uniswap v4 Pools on Robinhood Chain
+
+New Uniswap v4 pools: decoded Initialize events on the PoolManager with currencies, fee tier, tick spacing and hooks.
+
+▶️ [Uniswap v4 Pools on Robinhood Chain](https://ide.bitquery.io/uniswap-v4-pools-on-robinhood-chain)
+
+#### Uniswap v4 Hooks in Use on Robinhood Chain
+
+Uniswap v4 Hooks in Use on Robinhood Chain. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Uniswap v4 Hooks in Use on Robinhood Chain](https://ide.bitquery.io/uniswap-v4-hooks-robinhood-chain)
+
+#### Uniswap v4 Pool Liquidity on Robinhood Chain (pools.trade)
+
+Uniswap v4 Pool Liquidity on Robinhood Chain (pools.trade). Uses the `DEXPoolEvents` cube.
+
+▶️ [Uniswap v4 Pool Liquidity on Robinhood Chain (pools.trade)](https://ide.bitquery.io/Pools-trade-Live-pool-liquidity)
 
 ## Bitcoin
-
-### Balance APIs
-
-#### Bitcoin Balance API
-
-Retrieve the total incoming and outgoing transactions for a specific Bitcoin wallet. The balance is calculated as: Balance = Total Output - Total Input. You can also specify a date to get the historical balance.
-
-▶️ [Bitcoin Balance API](https://ide.bitquery.io/Bitcoin-balance-using-input-outputs)
-
-#### Bitcoin Balance for multiple addresses
-
-This query calculates the combined balance of multiple Bitcoin wallet addresses by summing their total inflows and outflows: Balance = Total Output - Total Input. You can also set a date to get balances as of a specific point in time.
-
-▶️ [Bitcoin Balance for multiple addresses](https://ide.bitquery.io/BTC-balance-api-for-multiple-addresses)
 
 ### Transfers
 
@@ -1191,13 +2916,45 @@ This API returns all incoming and outgoing transactions for a specific Bitcoin w
 
 ▶️ [Inflows and Outflows of a wallet](https://ide.bitquery.io/Inflows-and-Outflow-of-a-bitcoin-wallet)
 
-### Price Data
+### Balances & Holders
 
-#### Latest Bitcoin Price
+#### Bitcoin Balance for multiple addresses
 
-You can stream Bitcoin price at 1-second interval using the [Crypto Price APIs](/docs/trading/crypto-price-api/introduction/).
+This query calculates the combined balance of multiple Bitcoin wallet addresses by summing their total inflows and outflows: Balance = Total Output - Total Input. You can also set a date to get balances as of a specific point in time.
 
-▶️ [Bitcoin Price Stream](https://ide.bitquery.io/Stream-Bitcoin-Price-Across-Chains)
+▶️ [Bitcoin Balance for multiple addresses](https://ide.bitquery.io/BTC-balance-api-for-multiple-addresses)
+
+#### BTC balance api for multiple addresses
+
+BTC balance api for multiple addresses.
+
+▶️ [BTC balance api for multiple addresses](https://ide.bitquery.io/BTC-balance-API-for-multiple-addresses)
+
+#### Bitcoin balance
+
+Bitcoin balance.
+
+▶️ [Bitcoin balance](https://ide.bitquery.io/Bitcoin-balance_5)
+
+#### Bitcoin balance at a given height
+
+Bitcoin balance at a given height. Replace the address in the `where` clause to use it.
+
+▶️ [Bitcoin balance at a given height](https://ide.bitquery.io/bitcoin-balance-at-a-given-height)
+
+#### Bitcoin balance on a given block height
+
+Bitcoin balance on a given block height. Replace the address in the `where` clause to use it.
+
+▶️ [Bitcoin balance on a given block height](https://ide.bitquery.io/bitcoin-balance-on-a-given-block-height)
+
+### Price & OHLC
+
+#### Btc price in 2016
+
+Btc price in 2016.
+
+▶️ [Btc price in 2016](https://ide.bitquery.io/btc-price-in-2016)
 
 ### Transactions
 
@@ -1207,56 +2964,83 @@ This API provides comprehensive details of a specific Bitcoin transaction in a s
 
 ▶️ [Details of Bitcoin Transaction](https://ide.bitquery.io/Details-of-Bitcoin-Transaction)
 
+### Blocks & Validators
+
+#### Bitcoin miners rewards
+
+Bitcoin miners rewards. Adjust the date range in the `where` clause.
+
+▶️ [Bitcoin miners rewards](https://ide.bitquery.io/bitcoin-miners-rewards)
+
+#### Get miners activity in a specific timeframe
+
+Get miners activity in a specific timeframe. Adjust the date range in the `where` clause.
+
+▶️ [Get miners activity in a specific timeframe](https://ide.bitquery.io/get-miners-activity-in-a-specific-timeframe)
+
+#### Get miners first activity
+
+Get miners first activity.
+
+▶️ [Get miners first activity](https://ide.bitquery.io/get-miners-first-activity)
+
 ## Cardano
 
-### Balance APIs
-
-#### Cardano Balance
-
-This query returns the current balance of a user on Cardano network.  
-▶️ [Cardano Balance](https://ide.bitquery.io/cardano-address-balance_1)
-
-### Transfers
-
-#### Cardano Transfers
-
-This query returns the latest transfers on Cardano network.
-▶️ [Cardano Transfers](https://ide.bitquery.io/Cardano-Transfers_1)
-
-#### Cardano User Transfers
-
-This query returns the latest transfers for a useron Cardano network.  
-▶️ [Cardano User Transfers](https://ide.bitquery.io/cardano-transfers-of-a-wallet)
-
-### OHLC & Price Data
+### Trades
 
 #### Cardano Price
 
-This query returns the latest price of Cardano on Cardano Network.  
+This query returns the latest price of Cardano on Cardano Network.
+
 ▶️ [Cardano Price](https://ide.bitquery.io/latest-cardano-price)
-
-## Ripple
-
-### Balance APIs
-
-#### Ripple Historical Balance
-
-This query returns all historical balance of an address on Ripple network.  
-▶️ [Ripple Balance](https://ide.bitquery.io/historical-balances-of-a-ripple-address)
 
 ### Transfers
 
-#### Ripple Historical Transfers
+#### Cardano User Transfers
 
-This query returns all the historical transfers done by a specific address on the Ripple network.  
-▶️ [Ripple Transfers](https://ide.bitquery.io/All-historical-transfers-of-an-individual-address)
+This query returns the latest transfers for a useron Cardano network.
+
+▶️ [Cardano User Transfers](https://ide.bitquery.io/cardano-transfers-of-a-wallet)
+
+### Balances & Holders
+
+#### Cardano Balance
+
+This query returns the current balance of a user on Cardano network.
+
+▶️ [Cardano Balance](https://ide.bitquery.io/cardano-address-balance_1)
+
+## Ripple
 
 ### Trades
 
 #### Ripple Token DEX Trades
 
-This query returns the latest trades of a currency on the Ripple network.  
+This query returns the latest trades of a currency on the Ripple network.
+
 ▶️ [Ripple Token DEX Trades](https://ide.bitquery.io/trades-for-CNY-on-ripple)
+
+#### Ripple Payments
+
+This query returns the latest payments on Ripple network.
+
+▶️ [Ripple Payments](https://ide.bitquery.io/Latest-payments-on-ripple-blockchain)
+
+### Transfers
+
+#### Ripple Historical Transfers
+
+This query returns all the historical transfers done by a specific address on the Ripple network.
+
+▶️ [Ripple Historical Transfers](https://ide.bitquery.io/All-historical-transfers-of-an-individual-address)
+
+### Balances & Holders
+
+#### Ripple Historical Balance
+
+This query returns all historical balance of an address on Ripple network.
+
+▶️ [Ripple Historical Balance](https://ide.bitquery.io/historical-balances-of-a-ripple-address)
 
 ### Transactions
 
@@ -1264,126 +3048,890 @@ This query returns the latest trades of a currency on the Ripple network.
 
 This query uses transaction hash and date range as filter to fetch tx details.
 
-▶️ [XRPL Transaction Details](https://ide.bitquery.io/xrpl-search-tx-details)
+▶️ [Transaction Details using Hash](https://ide.bitquery.io/xrpl-search-tx-details)
 
-#### Ripple Payments
+## Algorand
 
-This query returns the latest payments on Ripple network.  
-▶️ [Ripple Payments](https://ide.bitquery.io/Latest-payments-on-ripple-blockchain)
+### Transfers
 
-## Cosmos
+#### All the transfers of an asset on Algorand Mainnet in a specific timeframe
 
-### Balance APIs
+All the transfers of an asset on Algorand Mainnet in a specific timeframe. Adjust the date range in the `where` clause.
 
-#### Cosmos address balance and staking reward details
+▶️ [All the transfers of an asset on Algorand Mainnet in a specific timeframe](https://ide.bitquery.io/All-the-transfers-of-an-asset-on-Algorand-Mainnet-in-a-specific-timeframe)
 
-This query provides balance and staking reward information for the Cosmos blockchain.
-▶️ [Cosmos address balance and staking reward details](https://ide.bitquery.io/Cosmos-balance-staking-rewards-of-an-address)
+#### Traansfers where a currency is sent from or sent to a particular address
 
-## NFT APIs
+Traansfers where a currency is sent from or sent to a particular address. Adjust the date range in the `where` clause.
 
-#### Get NFTs a specific wallet holds
+▶️ [Traansfers where a currency is sent from or sent to a particular address](https://ide.bitquery.io/traansfers-where-a-currency-is-sent-from-or-sent-to-a-particular-address)
 
-Get NFTs owned by a given address.
-▶️ [Get NFTs by wallet](https://ide.bitquery.io/Get-NFTs-by-wallet_1)
+### Price & OHLC
 
-#### Get NFTs a contract holds
+#### Get Count of Smart Contract Calls in Latest Block
 
-Get NFTs for a given contract address, including metadata for all NFTs (where available).
-▶️ [Get NFTs by contract](https://ide.bitquery.io/Get-NFTs-by-wallet_1)
+Get Count of Smart Contract Calls in Latest Block.
 
-#### Get NFT metadata
+▶️ [Get Count of Smart Contract Calls in Latest Block](https://ide.bitquery.io/Get-Count-of-Smart-Contract-Calls-in-Latest-Block_1)
 
-Get NFT data, including metadata (where available), for the given NFT contract address.
-▶️ [Get NFT metadata](https://ide.bitquery.io/Get-NFT-metadata)
+### Transactions
 
-#### Get Metadata for Multiple NFT Contracts
+#### All Transactions on Algorand
 
-Get the metadata for a given list of contract addresses.
-▶️ [Get Metadata for Multiple NFT Contracts](https://ide.bitquery.io/Get-Metadata-for-Multiple-NFT-Contracts_1)
+All Transactions on Algorand. Adjust the date range in the `where` clause.
+
+▶️ [All Transactions on Algorand](https://ide.bitquery.io/All-Transactions-on-Algorand)
+
+#### Daily Transaction Count for last 10 days
+
+Daily Transaction Count for last 10 days.
+
+▶️ [Daily Transaction Count for last 10 days](https://ide.bitquery.io/Daily-Transaction-Count-for-last-10-days)
+
+#### Daily Unique Txn Senders on algorand
+
+Daily Unique Txn Senders on algorand.
+
+▶️ [Daily Unique Txn Senders on algorand](https://ide.bitquery.io/Daily-Unique-Txn-Senders-on-algorand)
+
+## Trading API
+
+### Trades
+
+#### Average fee per trade, Total fees, total volume, trades count per DEX program
+
+Average fee per trade, Total fees, total volume, trades count per DEX program. Uses the `Trades` cube.
+
+▶️ [Average fee per trade, Total fees, total volume, trades count per DEX program](https://ide.bitquery.io/Average-fee-per-trade-Total-fees-total-volume-trades-count-per-DEX-program)
+
+#### Last 10 WSOL USDC Token pair trades
+
+Last 10 WSOL USDC Token pair trades. Uses the `Trades` cube.
+
+▶️ [Last 10 WSOL USDC Token pair trades](https://ide.bitquery.io/Last-10-WSOL-USDC-Token-pair-trades)
+
+#### Most active market pools by trades
+
+Most active market pools by trades. Uses the `Trades` cube.
+
+▶️ [Most active market pools by trades](https://ide.bitquery.io/Most-active-market-pools-by-trades)
+
+#### Most active traders by trade count
+
+Most active traders by trade count. Uses the `Trades` cube.
+
+▶️ [Most active traders by trade count](https://ide.bitquery.io/Most-active-traders-by-trade-count)
+
+#### Most traded token in last 1 hour on solana and it's average trade amount and total volume
+
+Most traded token in last 1 hour on solana and it's average trade amount and total volume. Uses the `Trades` cube.
+
+▶️ [Most traded token in last 1 hour on solana and it's average trade amount and total volume](https://ide.bitquery.io/Most-traded-token-in-last-1-hour-on-solana-and-its-average-trade-amount-and-total-volume)
+
+#### Net flow (buys - sells) per token symbol
+
+Net flow (buys - sells) per token symbol. Uses the `Trades` cube.
+
+▶️ [Net flow (buys - sells) per token symbol](https://ide.bitquery.io/Net-flow-buys---sells-per-token-symbol_2)
+
+#### Tokens with highest trade frequency
+
+Tokens with highest trade frequency. Uses the `Trades` cube.
+
+▶️ [Tokens with highest trade frequency](https://ide.bitquery.io/Tokens-with-highest-trade-frequency)
+
+#### Tokens with most unique buyers
+
+Tokens with most unique buyers. Uses the `Trades` cube.
+
+▶️ [Tokens with most unique buyers](https://ide.bitquery.io/Tokens-with-most-unique-buyers)
+
+#### Top Traders on Solana
+
+Top Traders on Solana. Uses the `Trades` cube.
+
+▶️ [Top Traders on Solana](https://ide.bitquery.io/Top-Traders-on-Solana_2)
+
+#### Total SOL fees, Total Volume, Total count trades
+
+Total SOL fees, Total Volume, Total count trades. Uses the `Trades` cube.
+
+▶️ [Total SOL fees, Total Volume, Total count trades](https://ide.bitquery.io/Total-SOL-fees-Total-Volume-Total-count-trades)
+
+### Price & OHLC
+
+#### Historical Bitcoin OHLC data for the last 7 days
+
+Historical Bitcoin OHLC data for the last 7 days. Uses the `Currencies` cube.
+
+▶️ [Historical Bitcoin OHLC data for the last 7 days](https://ide.bitquery.io/historical-Bitcoin-OHLC-data-for-the-last-7-days)
+
+#### OHLC of a currency on multiple blockchains
+
+OHLC of a currency on multiple blockchains. Uses the `Currencies` cube.
+
+▶️ [OHLC of a currency on multiple blockchains](https://ide.bitquery.io/OHLC-of-a-currency-on-multiple-blockchains)
+
+### Supply & Market Cap
+
+#### Marketcap of pump token
+
+Marketcap of pump token. Uses the `Tokens` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Marketcap of pump token](https://ide.bitquery.io/marketcap-of-pump-token)
+
+#### Tokens ranked by market cap
+
+Tokens ranked by market cap. Uses the `Trades` cube.
+
+▶️ [Tokens ranked by market cap](https://ide.bitquery.io/Tokens-ranked-by-market-cap_1)
+
+## Stablecoins
+
+### Trades
+
+#### Solana USDT trades query
+
+Solana USDT trades query. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Solana USDT trades query](https://ide.bitquery.io/solana-USDT-trades-query)
+
+### Transfers
+
+#### Latest Tron USDT Transfers
+
+Latest Tron USDT Transfers. Uses the `Transfers` cube.
+
+▶️ [Latest Tron USDT Transfers](https://ide.bitquery.io/Latest-Tron-USDT-Transfers)
+
+#### Latest USDT/USDC Transfer api on base
+
+Latest USDT/USDC Transfer api on base. Uses the `Transfers` cube.
+
+▶️ [Latest USDT/USDC Transfer api on base](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-api-on-base)
+
+#### Latest USDT/USDC Transfer api on ethereum
+
+Latest USDT/USDC Transfer api on ethereum. Uses the `Transfers` cube.
+
+▶️ [Latest USDT/USDC Transfer api on ethereum](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-api-on-ethereum)
+
+#### Stablecoin Transfers from/to an address
+
+Stablecoin Transfers from/to an address. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Stablecoin Transfers from/to an address](https://ide.bitquery.io/stablecoin-Transfers-fromto-an-address)
+
+#### Stablecoin recieved and sent by an address
+
+Stablecoin recieved and sent by an address. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Stablecoin recieved and sent by an address](https://ide.bitquery.io/Stablecoin-recieved-and-sent-by-an-address)
+
+#### USDT Stablecoin reserves on Ethereum
+
+USDT Stablecoin reserves on Ethereum. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [USDT Stablecoin reserves on Ethereum](https://ide.bitquery.io/USDT-Stablecoin-reserves-on-Ethereum)
+
+#### USDT and USDC token Transfers api on solana
+
+USDT and USDC token Transfers api on solana. Uses the `Transfers` cube.
+
+▶️ [USDT and USDC token Transfers api on solana](https://ide.bitquery.io/USDT-and-USDC-token-Transfers-api-on-solana)
+
+#### USDT token Transfers api on solana
+
+USDT token Transfers api on solana. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+
+▶️ [USDT token Transfers api on solana](https://ide.bitquery.io/USDT-token-Transfers-api-on-solana)
+
+### Price & OHLC
+
+#### 5 minute price change stablecoin API
+
+5 minute price change stablecoin API. Uses the `Tokens` cube.
+
+▶️ [5 minute price change stablecoin API](https://ide.bitquery.io/5-minute-price-change-stablecoin-API)
+
+#### Stablecoin price query of USDT
+
+Stablecoin price query of USDT. Uses the `Tokens` cube.
+
+▶️ [Stablecoin price query of USDT](https://ide.bitquery.io/stablecoin-price-query-of-USDT_1)
+
+#### Usdt latest price arbitrage
+
+Usdt latest price arbitrage. Uses the `Tokens` cube.
+
+▶️ [Usdt latest price arbitrage](https://ide.bitquery.io/usdt-latest-price-arbitrage)
+
+### Supply & Market Cap
+
+#### USDC Stablecoin reserves on Solana
+
+USDC Stablecoin reserves on Solana. Uses the `TokenSupplyUpdates` cube. Change the token address in the `where` clause to use it.
+
+▶️ [USDC Stablecoin reserves on Solana](https://ide.bitquery.io/USDC-Stablecoin-reserves-on-Solana)
+
+#### USDT Stablecoin reserves on Solana query
+
+USDT Stablecoin reserves on Solana query. Uses the `TokenSupplyUpdates` cube. Change the token address in the `where` clause to use it.
+
+▶️ [USDT Stablecoin reserves on Solana query](https://ide.bitquery.io/USDT-Stablecoin-reserves-on-Solana--query)
+
+## Perpetuals
+
+### Trades
+
+#### Hyperliquid BTC Perp Trades
+
+Hyperliquid BTC Perp Trades. Uses the `Trades` cube.
+
+▶️ [Hyperliquid BTC Perp Trades](https://ide.bitquery.io/hyperliquid-btc-perp-trades)
+
+#### Hyperliquid Latest Trades (Perps + Spot + HIP-3)
+
+Hyperliquid Latest Trades (Perps + Spot + HIP-3). Uses the `Trades` cube.
+
+▶️ [Hyperliquid Latest Trades (Perps + Spot + HIP-3)](https://ide.bitquery.io/hyperliquid-latest-trades)
+
+#### Hyperliquid Trader Leverage Updates
+
+Hyperliquid Trader Leverage Updates.
+
+▶️ [Hyperliquid Trader Leverage Updates](https://ide.bitquery.io/hyperliquid-leverage-updates)
+
+#### Phoenix Perps Fills by Trader Wallet - Solana
+
+Phoenix Perps Fills by Trader Wallet - Solana.
+
+▶️ [Phoenix Perps Fills by Trader Wallet - Solana](https://ide.bitquery.io/sol_perps_filled_orders_by_signer)
+
+#### Trader Realized PnL on Solana Perps
+
+Trader Realized PnL on Solana Perps.
+
+▶️ [Trader Realized PnL on Solana Perps](https://ide.bitquery.io/solana-perps-trader-pnl)
+
+#### Whale Trades on Solana Perps (Phoenix)
+
+Whale Trades on Solana Perps (Phoenix).
+
+▶️ [Whale Trades on Solana Perps (Phoenix)](https://ide.bitquery.io/solana-perps-whale-trades)
+
+### Price & OHLC
+
+#### Hyperliquid BTC OHLCV Candles (1 minute)
+
+Hyperliquid BTC OHLCV Candles (1 minute).
+
+▶️ [Hyperliquid BTC OHLCV Candles (1 minute)](https://ide.bitquery.io/hyperliquid-btc-ohlcv-candles)
+
+#### Hyperliquid Mark Prices (All Markets)
+
+Hyperliquid Mark Prices (All Markets).
+
+▶️ [Hyperliquid Mark Prices (All Markets)](https://ide.bitquery.io/hyperliquid-mark-prices)
+
+#### Solana Perps OHLC Candles from Mark Price
+
+Solana Perps OHLC Candles from Mark Price.
+
+▶️ [Solana Perps OHLC Candles from Mark Price](https://ide.bitquery.io/solana-perps-ohlc-candles)
+
+## NFTs
+
+### Trades
+
+#### Get NFT trades for a specific NFT contract on specific marketplace
+
+Get trades of NFTs for a given contract and marketplace.
+
+▶️ [Get NFT trades for a specific NFT contract on specific marketplace](https://ide.bitquery.io/Get-NFT-trades-by-contract)
+
+#### Get NFT trades for a specific NFT contract and token ID
+
+Get trades of NFTs for a given contract and token ID.
+
+▶️ [Get NFT trades for a specific NFT contract and token ID](https://ide.bitquery.io/Get-NFT-trades-by-token)
+
+#### Get NFT trades by wallet
+
+Get trades of NFTs for a given wallet.
+
+▶️ [Get NFT trades by wallet](https://ide.bitquery.io/Get-trades-of-NFTs-for-a-given-wallet)
+
+#### Latest NFT Trades
+
+This query gets the latest 10 NFT trades on Ethereum mainnet. You can increase the limit to whatever you like, up to 25,000. Currently, it only retrieves data from the real-time database. To include historical data, use `dataset: combined`.
+
+▶️ [Latest NFT Trades](https://ide.bitquery.io/Latest-NFT-trades-on-ETH)
+
+#### Top Traded NFTs in a Period
+
+This query gets the top 10 traded NFTs based on the number of trades within a specified date range. You can change the filters such as the date range and limit.
+
+▶️ [Top Traded NFTs in a Period](https://ide.bitquery.io/Top-traded-NFT-tokens-in-a-month)
+
+#### Latests OpenSea Trades
+
+Latests OpenSea Trades.
+
+▶️ [Latests OpenSea Trades](https://ide.bitquery.io/Latests-OpenSea-Trades)
+
+#### Latest NFT trades on Ethereum network
+
+Latest NFT trades on Ethereum network.
+
+▶️ [Latest NFT trades on Ethereum network](https://ide.bitquery.io/latest-NFT-trades-on-Ethereum-network)
+
+#### Pairs of blur token new dataset
+
+Pairs of blur token new dataset.
+
+▶️ [Pairs of blur token new dataset](https://ide.bitquery.io/pairs-of-blur-token-new-dataset_1)
+
+#### New Uniswap v3 liquidity positions
+
+Position NFTs as they are minted — who is adding liquidity to v3 pools, and to which pair.
+
+▶️ [New Uniswap v3 liquidity positions](https://ide.bitquery.io/recent-uniswap-position-NFTs-mint_1)
+
+#### NFT currencies on Solana by DEX'es
+
+NFT currencies on Solana by DEX'es.
+
+▶️ [NFT currencies on Solana by DEX'es](https://ide.bitquery.io/NFT-currencies-on-Solana-by-DEXes_1)
+
+### Transfers
 
 #### Get NFT transfers by wallet
 
 Get transfers of NFTs given the wallet.
+
 ▶️ [Get NFT transfers by wallet](https://ide.bitquery.io/latest-nft-transfers-by-a-user)
 
-#### Get NFT owners by contract
+#### All transfers of an NFT
 
-Get owners of NFTs for a given contract.
-▶️ [Get NFT owners by contract](https://ide.bitquery.io/top-token-holders-of-Moonwalker-NFT)
+All transfers of an NFT.
 
-#### Get NFT owners by token ID
+▶️ [All transfers of an NFT](https://ide.bitquery.io/All-transfers-of-an-NFT)
 
-Get owners of a specific NFT given the contract address and token ID.
-▶️ [Get NFT owners by token ID](https://ide.bitquery.io/Who-owns-specific-NFT)
+#### NFT Token Transfers By Date
+
+NFT Token Transfers By Date.
+
+▶️ [NFT Token Transfers By Date](https://ide.bitquery.io/NFT-Token-Transfers-By-Date)
+
+#### Top transfered NFT tokens in network
+
+Top transfered NFT tokens in network.
+
+▶️ [Top transfered NFT tokens in network](https://ide.bitquery.io/Top-transfered-NFT-tokens-in-network)
+
+#### Array_intersect example for NFT
+
+Array_intersect example for NFT.
+
+▶️ [Array_intersect example for NFT](https://ide.bitquery.io/array_intersect-example-for-NFT)
+
+#### Get all transfers of a specific nft
+
+Get all transfers of a specific nft.
+
+▶️ [Get all transfers of a specific nft](https://ide.bitquery.io/get-all-transfers-of-a-specific-nft)
+
+### Balances & Holders
 
 #### Get Latest NFT Balance for an Address
 
 Get the latest NFT balance for a specific address and NFT collection. This query returns the current NFT count and ownership information.
+
 ▶️ [Get Latest NFT Balance for an Address](https://ide.bitquery.io/Get-Latest-NFT-Balance-for-an-Address)
 
 #### Get All NFT Collections for an Address
 
 Retrieve all NFT collections held by a specific address. This query returns balances for all NFT collections the address owns.
+
 ▶️ [Get All NFT Collections for an Address](https://ide.bitquery.io/Get-All-NFT-Collections-for-an-Address_1)
 
 #### Get NFT Owner for Specific Token ID
 
 Check the current owner of a specific NFT token ID. This query returns ownership information for a particular token.
+
 ▶️ [Get NFT Owner for Specific Token ID](https://ide.bitquery.io/Get-NFT-Owner-for-Specific-Token-ID)
 
-#### Get NFT trades for a specific NFT contract on specific marketplace
+#### Get NFT Balances for Multiple Addresses
 
-Get trades of NFTs for a given contract and marketplace.
-▶️ [Get NFT trades by contract](https://ide.bitquery.io/Get-NFT-trades-by-contract)
+Get NFT Balances for Multiple Addresses.
 
-#### Get NFT trades for a specific NFT contract and token ID
+▶️ [Get NFT Balances for Multiple Addresses](https://ide.bitquery.io/Get-NFT-Balances-for-Multiple-Addresses_1)
 
-Get trades of NFTs for a given contract and token ID.
-▶️ [Get NFT trades by token](https://ide.bitquery.io/Get-NFT-trades-by-token)
+#### Get NFT Ownership History
 
-#### Get NFT trades by wallet
+Get NFT Ownership History.
 
-Get trades of NFTs for a given wallet.
-▶️ [Get NFT trades by wallet](https://ide.bitquery.io/Get-trades-of-NFTs-for-a-given-wallet)
+▶️ [Get NFT Ownership History](https://ide.bitquery.io/Get-NFT-Ownership-History_2)
 
-#### Get all NFTs in a collection
+### Price & OHLC
 
-Get all NFTs in a collection.
-▶️ [Get all NFTs in a collection](https://ide.bitquery.io/Get-all-NFTs-for-a-collection)
+#### Smart contract calls to an nft contract
 
-#### Latest NFT Trades
+Smart contract calls to an nft contract.
 
-This query gets the latest 10 NFT trades on Ethereum mainnet. You can increase the limit to whatever you like, up to 25,000. Currently, it only retrieves data from the real-time database. To include historical data, use `dataset: combined`.  
-▶️ [Latest NFT Trades](https://ide.bitquery.io/Latest-NFT-trades-on-ETH)
+▶️ [Smart contract calls to an nft contract](https://ide.bitquery.io/Smart-contract-calls-to-an-nft-contract)
 
-#### Top Traded NFTs in a Period
+### Events & Calls
 
-This query gets the top 10 traded NFTs based on the number of trades within a specified date range. You can change the filters such as the date range and limit.  
-▶️ [Top Traded NFTs](https://ide.bitquery.io/Top-traded-NFT-tokens-in-a-month)
+#### All refinance loans for specific NFT collection
 
-## x402 APIs
+All refinance loans for specific NFT collection.
 
-### Base
+▶️ [All refinance loans for specific NFT collection](https://ide.bitquery.io/All-refinance-loans-for-specificNFT-collection)
 
-#### Get Latest Payments to x402 Server
+#### Auction on blur marketplace
 
-Retrieves the most recent payments made to a specific x402 server on Base network.
-▶️ [Latest Payment to x402 Server](https://ide.bitquery.io/Latest-payment-to-specific-x402-server)
+Auction on blur marketplace.
 
-#### Payment Analytics for x402 Server
+▶️ [Auction on blur marketplace](https://ide.bitquery.io/Auction-on-blur-marketplace)
 
-Comprehensive payment analytics including total volume, unique users, transaction counts, and time-based breakdowns for a specific x402 server.
-▶️ [Payment Analytics for x402 Server](https://ide.bitquery.io/Payment-analytics-related-specific-x402-server)
+#### Creator_of_an_NFT
 
-### Solana
+Creator_of_an_NFT.
 
-#### Get Latest Payments to x402 Server on Solana
+▶️ [Creator_of_an_NFT](https://ide.bitquery.io/Creator_of_an_NFT)
 
-Retrieves the most recent payments made to a specific x402 server on Solana network.
-▶️ [Latest Payment to x402 Server on Solana](https://ide.bitquery.io/Latest-Payment-to-specific-x402-server-taking-solana-payments)
+#### Latest Cancelled offers on Blur NFT marketplace
+
+Latest Cancelled offers on Blur NFT marketplace.
+
+▶️ [Latest Cancelled offers on Blur NFT marketplace](https://ide.bitquery.io/Latest-Cancelled-offers-on-Blur-NFT-marketplace)
+
+#### Latest Loans for a specific borrower on Blur marketplace
+
+Latest Loans for a specific borrower on Blur marketplace.
+
+▶️ [Latest Loans for a specific borrower on Blur marketplace](https://ide.bitquery.io/Latest-Loans-for-a-specificborrower-on-Blur-marketplace)
+
+#### Latest Seized NFTs on Blur marketplace
+
+Latest Seized NFTs on Blur marketplace.
+
+▶️ [Latest Seized NFTs on Blur marketplace](https://ide.bitquery.io/Latest-Seized-NFTs-on-Blur-marketplace)
+
+#### Latest loans for specific NFT token
+
+Latest loans for specific NFT token.
+
+▶️ [Latest loans for specific NFT token](https://ide.bitquery.io/Latest-loans-for-specific-NFTtoken)
+
+#### Loan history for specific NFT ID
+
+Loan history for specific NFT ID.
+
+▶️ [Loan history for specific NFT ID](https://ide.bitquery.io/Loan-history-for-specific-NFTID)
+
+#### Loan repayment of blur marketplace
+
+Loan repayment of blur marketplace.
+
+▶️ [Loan repayment of blur marketplace](https://ide.bitquery.io/Loan-repayment-of-blur-marketplace)
+
+#### Loans above a specific amount on the Blur NFT marketplace
+
+Loans above a specific amount on the Blur NFT marketplace.
+
+▶️ [Loans above a specific amount on the Blur NFT marketplace](https://ide.bitquery.io/Loans-above-a-specific-amount-on-the-Blur-NFT-marketplace)
+
+#### Locked NFT bought on Blur marketplace
+
+Locked NFT bought on Blur marketplace.
+
+▶️ [Locked NFT bought on Blur marketplace](https://ide.bitquery.io/Locked-NFT-bought-on-Blur-marketplace)
+
+## Polymarket
+
+### Trades
+
+#### Latest Trades
+
+Fetch the most recent prediction market trades with full details, ordered by block time.
+
+▶️ [Latest Trades](https://ide.bitquery.io/latest-prediction-market-trades_8)
+
+#### Total Volume and Yes/No Volume for a Market
+
+Aggregate USD volume for a market over a time window: total volume plus volume per outcome (e.g. Yes/No). Pass the market's outcome token AssetIds in `$marketAssets`.
+
+▶️ [Total Volume and Yes/No Volume for a Market](https://ide.bitquery.io/total-volume-outcome-1-volume-outcome-2-volume-of-a-market_1)
+
+#### Trades for a Specific Trader
+
+Fetch all trades where the given address is either Buyer or Seller. Pass the trader address as the `$trader` variable.
+
+▶️ [Trades for a Specific Trader](https://ide.bitquery.io/Trades-for-a-specific-trader_1)
+
+#### How do I count trades for a specific Polymarket trader?
+
+How do I count trades for a specific Polymarket trader?. Replace the address in the `where` clause to use it.
+
+▶️ [How do I count trades for a specific Polymarket trader?](https://ide.bitquery.io/How-do-I-count-trades-for-a-specific-Polymarket-trader)
+
+#### How do I get top buyers and sellers on Polymarket by volume?
+
+How do I get top buyers and sellers on Polymarket by volume?.
+
+▶️ [How do I get top buyers and sellers on Polymarket by volume?](https://ide.bitquery.io/How-do-I-get-top-buyers-and-sellers-on-Polymarket-by-volume)
+
+#### Latest prediction market trades
+
+Latest prediction market trades.
+
+▶️ [Latest prediction market trades](https://ide.bitquery.io/latest-prediction-market-trades)
+
+#### Prediction_trades
+
+Prediction_trades.
+
+▶️ [Prediction_trades](https://ide.bitquery.io/prediction_trades)
+
+#### Top 100 markets by volumein last24 hrs
+
+Top 100 markets by volumein last24 hrs.
+
+▶️ [Top 100 markets by volumein last24 hrs](https://ide.bitquery.io/top-100-markets-by-volumein-last24-hrs_1)
+
+#### Top AI markets by volume Polymarket
+
+Top AI markets by volume Polymarket.
+
+▶️ [Top AI markets by volume Polymarket](https://ide.bitquery.io/Top-AI-markets-by-volume-Polymarket)
+
+#### Top Buyers/Sellers of Bitcoin up down market
+
+Top Buyers/Sellers of Bitcoin up down market.
+
+▶️ [Top Buyers/Sellers of Bitcoin up down market](https://ide.bitquery.io/Top-BuyersSellers-of-Bitcoin-up-down-market)
+
+### Markets
+
+#### Created vs Resolved Count (Last 24 Hours)
+
+Count how many Created and Resolved events occurred in the last 24 hours.
+
+▶️ [Created vs Resolved Count (Last 24 Hours)](https://ide.bitquery.io/last-24-hr-resolution-and-ceated-count_1)
+
+#### Latest Creations + Resolutions
+
+Fetch the most recent creation and resolution events with full details, ordered by block time.
+
+▶️ [Latest Creations + Resolutions](https://ide.bitquery.io/latest-Prediction-managements-resolutions-creations_1)
+
+#### Latest Market Creations
+
+Fetch the most recent Created events (new markets). All possible outcomes per market are in Prediction.Condition.Outcomes.
+
+▶️ [Latest Market Creations](https://ide.bitquery.io/latest-polymarket-creations_1)
+
+#### Latest Market Resolutions
+
+Query that returns the 10 most recent Resolved events. Winning outcome is in Prediction.Outcome; Prediction.OutcomeToken holds the asset ID and contract details.
+
+▶️ [Latest Market Resolutions](https://ide.bitquery.io/latest-polymarket-resolutions_2)
+
+#### Latest Prediction managements (resolutions, creations)
+
+Latest Prediction managements (resolutions, creations).
+
+▶️ [Latest Prediction managements (resolutions, creations)](https://ide.bitquery.io/latest-Prediction-managements-resolutions-creations)
+
+#### Latest polymarket creations
+
+Latest polymarket creations.
+
+▶️ [Latest polymarket creations](https://ide.bitquery.io/latest-polymarket-creations)
+
+#### Latest polymarket resolutions
+
+Latest polymarket resolutions.
+
+▶️ [Latest polymarket resolutions](https://ide.bitquery.io/latest-polymarket-resolutions_1)
+
+#### Latest resolved crudeoil markets
+
+Latest resolved crudeoil markets.
+
+▶️ [Latest resolved crudeoil markets](https://ide.bitquery.io/latest-resolved-crudeoil-markets)
+
+#### Latest resolved sports markets
+
+Latest resolved sports markets.
+
+▶️ [Latest resolved sports markets](https://ide.bitquery.io/Latest-resolved-sports-markets)
+
+#### Query latest created resolved prediction markets for Bitcoin
+
+Query latest created resolved prediction markets for Bitcoin.
+
+▶️ [Query latest created resolved prediction markets for Bitcoin](https://ide.bitquery.io/Query-latest-created-resolved-prediction-markets-for-Bitcoin)
+
+### Settlements
+
+#### Latest Settlements
+
+Fetch the most recent settlements with full details, ordered by block time.
+
+▶️ [Latest Settlements](https://ide.bitquery.io/latest-prediction-market-settlements_3)
+
+#### Latest Whale Settlements
+
+Find the most recent high-value redemptions (e.g. amount ≥ 10,000 in outcome token units). Useful for tracking large payouts and whale activity.
+
+▶️ [Latest Whale Settlements](https://ide.bitquery.io/latest-whale-settlements-on-prediction-market_3)
+
+#### Redemption / Merge / Split Count (Last 1 Hour)
+
+Count how many settlement events occurred in the last hour, grouped by event signature (Split, Merge, Redemption).
+
+▶️ [Redemption / Merge / Split Count (Last 1 Hour)](https://ide.bitquery.io/redemptions-merge-split-count-in-last-1-hour_1)
+
+#### Top 10 Market Questions by Redeemed Amount (Last 1 Hour)
+
+Aggregate redemptions by market question and sort by total redeemed amount. See which markets had the most payout activity recently.
+
+▶️ [Top 10 Market Questions by Redeemed Amount (Last 1 Hour)](https://ide.bitquery.io/top-10-market-questions-in-last-1-hour_3)
+
+#### Top 10 Redeemers (Last 1 Hour)
+
+Rank addresses by total amount redeemed in the last hour across all markets. Useful for leaderboards and whale tracking.
+
+▶️ [Top 10 Redeemers (Last 1 Hour)](https://ide.bitquery.io/top-10-redeemers_1)
+
+#### Top 10 Winners of a Specific Market Question
+
+Rank holders by total redeemed amount for one market (filter by question title).
+
+▶️ [Top 10 Winners of a Specific Market Question](https://ide.bitquery.io/top-10-winners-of-a-market-question_2)
+
+#### Latest prediction market settlements
+
+Latest prediction market settlements.
+
+▶️ [Latest prediction market settlements](https://ide.bitquery.io/latest-prediction-market-settlements_2)
+
+#### Latest whale settlements on prediction market
+
+Latest whale settlements on prediction market.
+
+▶️ [Latest whale settlements on prediction market](https://ide.bitquery.io/latest-whale-settlements-on-prediction-market_2)
+
+#### Redemptions, merge, split count in last 1 hour
+
+Redemptions, merge, split count in last 1 hour.
+
+▶️ [Redemptions, merge, split count in last 1 hour](https://ide.bitquery.io/redemptions-merge-split-count-in-last-1-hour)
+
+#### Top 10 redeemers
+
+Top 10 redeemers.
+
+▶️ [Top 10 redeemers](https://ide.bitquery.io/top-10-redeemers)
+
+### Transfers
+
+#### Freshwallet check for polymarket
+
+Freshwallet check for polymarket. Uses the `Transfers` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Freshwallet check for polymarket](https://ide.bitquery.io/freshwallet-check-for-polymarket)
+
+#### FundingSource for poylmarket
+
+FundingSource for poylmarket. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [FundingSource for poylmarket](https://ide.bitquery.io/FundingSource-for-poylmarket)
+
+#### SiblingWallets for polymarket
+
+SiblingWallets for polymarket. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [SiblingWallets for polymarket](https://ide.bitquery.io/SiblingWallets-for-polymarket)
+
+### Balances & Holders
+
+#### Polymarket TVL
+
+Polymarket TVL. Uses the `TransactionBalances` cube.
+
+▶️ [Polymarket TVL](https://ide.bitquery.io/Polymarket-TVL)
+
+### Price & OHLC
+
+#### Current Price per Outcome (Latest Trade)
+
+Get the latest trade price for each outcome in a market. Uses `limitBy` for one row per outcome, with Price and PriceInUSD at the most recent block time.
+
+▶️ [Current Price per Outcome (Latest Trade)](https://ide.bitquery.io/Current-price-inside-the-market-for-all-options-based-on-latest-trade_1)
+
+#### Current price inside the market for all options based on latest trade
+
+Current price inside the market for all options based on latest trade.
+
+▶️ [Current price inside the market for all options based on latest trade](https://ide.bitquery.io/Current-price-inside-the-market-for-all-options-based-on-latest-trade)
+
+#### Latest price of outcomes of a crude oil market
+
+Latest price of outcomes of a crude oil market.
+
+▶️ [Latest price of outcomes of a crude oil market](https://ide.bitquery.io/latest-price-of-outcomes-of-a-crude-oil-market)
+
+#### OHLC of a outcome of a gold market
+
+OHLC of a outcome of a gold market.
+
+▶️ [OHLC of a outcome of a gold market](https://ide.bitquery.io/OHLC-of-a-outcome-of-a-gold-market)
+
+#### Polymarket AI odds movement OHLC
+
+Polymarket AI odds movement OHLC.
+
+▶️ [Polymarket AI odds movement OHLC](https://ide.bitquery.io/Polymarket-AI-odds-movement-OHLC)
+
+#### Polymarket sports odds movement OHLC
+
+Polymarket sports odds movement OHLC.
+
+▶️ [Polymarket sports odds movement OHLC](https://ide.bitquery.io/Polymarket-sports-odds-movement-OHLC)
+
+### Liquidity & Pools
+
+#### Top cricket Markets by Liquidity
+
+Top cricket Markets by Liquidity.
+
+▶️ [Top cricket Markets by Liquidity](https://ide.bitquery.io/Top-cricket-Markets-by-Liquidity)
+
+#### Top FIFA World Cup Markets by Liquidity
+
+Top FIFA World Cup Markets by Liquidity.
+
+▶️ [Top FIFA World Cup Markets by Liquidity](https://ide.bitquery.io/Top-FIFA-World-Cup-Markets-by-Liquidity)
+
+## Futures DEXs
+
+### Trades
+
+#### All events of AsterDEX
+
+All events of AsterDEX. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [All events of AsterDEX](https://ide.bitquery.io/All-events-of-AsterDEX)
+
+#### AsterDEX - All latest Liquidations
+
+AsterDEX - All latest Liquidations. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [AsterDEX - All latest Liquidations](https://ide.bitquery.io/AsterDEX---All-latest-Liquidations)
+
+#### AsterDEX - OpenMarketTrade
+
+AsterDEX - OpenMarketTrade. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [AsterDEX - OpenMarketTrade](https://ide.bitquery.io/AsterDEX---OpenMarketTrade)
+
+#### Trader's specific event
+
+Trader's specific event. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Trader's specific event](https://ide.bitquery.io/Traders-specific-event)
+
+#### Traders data - 0x01554d63537d3c62715826a268d4eab645d64b92
+
+Traders data - 0x01554d63537d3c62715826a268d4eab645d64b92. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Traders data - 0x01554d63537d3c62715826a268d4eab645d64b92](https://ide.bitquery.io/Copy-of-Traders-data---0x01554d63537d3c62715826a268d4eab645d64b92)
+
+#### Traders data - 0x2b7363708984aa25a90450cfca7bedaf6804115c
+
+Traders data - 0x2b7363708984aa25a90450cfca7bedaf6804115c. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Traders data - 0x2b7363708984aa25a90450cfca7bedaf6804115c](https://ide.bitquery.io/Traders-data---0x2b7363708984aa25a90450cfca7bedaf6804115c)
+
+## x402
+
+### Trades
 
 #### Payment Analytics for x402 Server on Solana
 
 Comprehensive payment analytics for a specific x402 server on Solana including total volume, unique users, and transaction counts.
+
 ▶️ [Payment Analytics for x402 Server on Solana](https://ide.bitquery.io/Payment-analytics-related-specific-x402-server-on-Solana)
+
+### Transfers
+
+#### Get Latest Payments to x402 Server
+
+Retrieves the most recent payments made to a specific x402 server on Base network.
+
+▶️ [Get Latest Payments to x402 Server](https://ide.bitquery.io/Latest-payment-to-specific-x402-server)
+
+#### Get Latest Payments to x402 Server on Solana
+
+Retrieves the most recent payments made to a specific x402 server on Solana network.
+
+▶️ [Get Latest Payments to x402 Server on Solana](https://ide.bitquery.io/Latest-Payment-to-specific-x402-server-taking-solana-payments)
+
+#### Payment Analytics for x402 Server
+
+Comprehensive payment analytics including total volume, unique users, transaction counts, and time-based breakdowns for a specific x402 server.
+
+▶️ [Payment Analytics for x402 Server](https://ide.bitquery.io/Payment-analytics-related-specific-x402-server)
+
+## Cross-Chain
+
+### Trades
+
+#### Volume of Multiple Tokens Across Different Chains
+
+Get volume and price change data for multiple tokens trading on different chains (Solana, Ethereum, BSC, Tron) in a single query. Returns volume for 1h, 4h, and 24h periods, plus price change percentages. > **Note:** For EVM chains (Ethereum, BSC, etc.) in the Trading API, use **all lowercase…
+
+▶️ [Volume of Multiple Tokens Across Different Chains](https://ide.bitquery.io/volume-of-a-token_2)
+
+### Price & OHLC
+
+#### Latest Price of Any Token
+
+This query gives you bitcoin currency 1-sec OHLC across different blockchains. You can adjust duration in `Duration: {eq: 1}` filter.
+
+▶️ [Latest Price of Any Token](https://ide.bitquery.io/Latest-bitcoin-price-on-across-chains_5)
+
+#### OHLC of a currency on multiple blockchains
+
+This query retrieves the OHLC (Open, High, Low, Close) prices of a currency(in this eg Bitcoin; it will include all sorts of currencies whose underlying asset is Bitcoin like cbBTC, WBTC, etc) across all supported blockchains, aggregated into a given time interval (e.g., 60 seconds in this example).
+
+▶️ [OHLC of a currency on multiple blockchains](https://ide.bitquery.io/OHLC-of-a-currency-on-multiple-blockchains_2)
+
+#### SMA and Volume Data (for past 28, 14 and 7 Days Time)
+
+Use this API to get SMA and volume over the past 28 days, with 14 days, and 7 days breakdowns. Note that the oldest possible data it could return is 30 days ago.
+
+▶️ [SMA and Volume Data (for past 28, 14 and 7 Days Time)](https://ide.bitquery.io/multiple-tokens-volume-and-SMA)
+
+#### Historical OHLC of a Token Pair Across Chains
+
+This query fetches historical OHLC (Open, High, Low, Close) price data for a token pair across different blockchains for as long back as 30 days. For **native tokens**, you only need to specify their ID (e.g., `bid:eth` for ETH).
+
+▶️ [Historical OHLC of a Token Pair Across Chains](https://ide.bitquery.io/Historical-Token-OHLC-Multi-Chains_1)
+
+#### Historical Price and Volume Data for a Token Pair beyond 30 days
+
+Use this API to get historical price and volume for a specific token pair address on a specific network for the time window beyond the 30 days.
+
+▶️ [Historical Price and Volume Data for a Token Pair beyond 30 days](https://ide.bitquery.io/historical-price-and-historical-volume)
+
+#### All time High Trade Price for a Token
+
+Retrieves the all-time high (ATH) price in USD for a specified token contract. All time high price could lie beyond the 30 days window provided by Trading API, hence we use these network specific APIs to get the ATH for a token. While this provides the option to go beyond the 30 days time…
+
+▶️ [All time High Trade Price for a Token](https://ide.bitquery.io/ATH-of-eth-token_1)

--- a/docs/start/starter-queries.md
+++ b/docs/start/starter-queries.md
@@ -25,13 +25,14 @@ Every query below is saved in the [Bitquery IDE](https://ide.bitquery.io) and wa
 - [Polygon](#polygon)
 - [TRON](#tron)
 - [Robinhood Chain](#robinhood-chain)
+- [Avalanche](#avalanche)
+- [Celo](#celo)
 - [Bitcoin](#bitcoin)
 - [Litecoin](#litecoin)
 - [Bitcoin Cash](#bitcoin-cash)
 - [Dogecoin](#dogecoin)
 - [Dash](#dash)
 - [Zcash](#zcash)
-- [Bitcoin SV](#bitcoin-sv)
 - [Cardano](#cardano)
 - [Ripple](#ripple)
 - [Algorand](#algorand)
@@ -68,7 +69,7 @@ Every buy and sell made by one address. Replace the wallet in `Transaction: {Fro
 
 #### Address is Buyer or Seller V2
 
-Returns gives you trades where the specified address is either as a buyer or a seller. This is achieved by utilizing the `any` filter, which acts as an OR condition to encompass both buyer and seller roles in the results. You can find the query [here
+Returns trades where the specified address is either as a buyer or a seller. This is achieved by utilizing the `any` filter, which acts as an OR condition to encompass both buyer and seller roles in the results.
 
 ▶️ [Address is Buyer or Seller V2](https://ide.bitquery.io/Address-is-Buyer-or-Seller-V2)
 
@@ -80,7 +81,7 @@ Get a comprehensive list of all events emitted by the Fluid DEX Vault Factory co
 
 #### Buys, Sells, BuyVolume, SellVolume, Makers, TotalTradedVolume, PriceinUSD for a eth pair
 
-The query will fetch you the buys, sells, buy volume, sell volume and also the number of makers for a particular token just like how DEXScreener shows in its UI.
+Will fetch the buys, sells, buy volume, sell volume and also the number of makers for a particular token just like how DEXScreener shows in its UI.
 
 ▶️ [Buys, Sells, BuyVolume, SellVolume, Makers, TotalTradedVolume, PriceinUSD for a eth pair](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-a-eth-pair)
 
@@ -92,13 +93,13 @@ Coin ticker api. Uses the `DEXTradeByTokens` cube. Change the token address in t
 
 #### Dex info
 
-Returns will fetch you a specific DEX stats for the selected network. You can test the query [here
+Will fetch a specific DEX stats for the selected network.
 
 ▶️ [Dex info](https://ide.bitquery.io/dex-info)
 
 #### Dex markets
 
-Returns will fetch you all the DEXs info for the selected network. You can test the query [here
+Will fetch all the DEXs info for the selected network.
 
 ▶️ [Dex markets](https://ide.bitquery.io/dex-markets)
 
@@ -130,7 +131,7 @@ Find addresses that have interacted with multiple addresses from a given list. T
 
 #### Binance:hot wallet transfers with transaction fees
 
-Track wallet token transfers and get the fees paid for each by the address. `SenderFee` and `SenderFeeInUSD` fields in query are the transaction fees in ETH and transaction fees in USD respectively. You can test the query [here
+Track wallet token transfers and get the fees paid for each by the address. `SenderFee` and `SenderFeeInUSD` fields in query are the transaction fees in ETH and transaction fees in USD respectively.
 
 ▶️ [Binance:hot wallet transfers with transaction fees](https://ide.bitquery.io/binancehot-wallet-transfers-with-transaction-fees)
 
@@ -166,7 +167,7 @@ Both sides of an address's transfer history in one result, using an OR filter. N
 
 #### Total txn fees paid by binance hot wallet in a day
 
-Get the total fees (in Eth and USD) paid by a specific EVM account across all transfers. `SenderFee` and `SenderFeeInUSD` fields in query are the transaction fees in ETH and transaction fees in USD respectively. You can test the query [here
+Get the total fees (in Eth and USD) paid by a specific EVM account across all transfers. `SenderFee` and `SenderFeeInUSD` fields in query are the transaction fees in ETH and transaction fees in USD respectively.
 
 ▶️ [Total txn fees paid by binance hot wallet in a day](https://ide.bitquery.io/total-txn-fees-paid-by-binance-hot-wallet-in-a-day)
 
@@ -204,7 +205,7 @@ This API provides a list of top holders along with relevant statistics for a giv
 
 #### Average Tip in terms of avg gas Fee
 
-Compares average user tip to average total gas fee per block across the last 10 blocks. Test the query [here
+Compares average user tip to average total gas fee per block across the last 10 blocks.
 
 ▶️ [Average Tip in terms of avg gas Fee](https://ide.bitquery.io/Average-Tip-in-terms-of-avg-gas-Fee_4)
 
@@ -272,7 +273,7 @@ Use this API to get historical price and volume for a specific token pair addres
 
 #### Ohlc of a token pair 1 hour interval
 
-Returns fetches the Open, High, Low, and Close (OHLC) price data (USD-quoted) for a given token pair across DEXs, using a specified quote token and time interval (in seconds).
+Fetches the Open, High, Low, and Close (OHLC) price data (USD-quoted) for a given token pair across DEXs, using a specified quote token and time interval (in seconds).
 
 ▶️ [Ohlc of a token pair 1 hour interval](https://ide.bitquery.io/ohlc-of-a-token-pair-1-hour-interval)
 
@@ -290,7 +291,7 @@ Price change 5min, 1hr, 6hr precentage of a specific token. Uses the `DEXTradeBy
 
 #### Price of a token in realtime
 
-Returns will give you the latest Price of a specified token using DEXTrades API. Here we have calculated the price of a token in USD and also against the sell currency. Here is the [saved query link
+Will give the latest Price of a specified token using DEXTrades API. Here we have calculated the price of a token in USD and also against the sell currency. Here is the.
 
 ▶️ [Price of a token in realtime](https://ide.bitquery.io/Price-of-a-token-in-realtime)
 
@@ -310,7 +311,7 @@ Live supply for the two largest stablecoins; swap the addresses for any other to
 
 #### Get Token Total Supply and Market Cap
 
-Retrieve the total supply and market capitalization of a specific ERC-20 token. This query provides on-chain market cap data. Try the API [here
+Retrieve the total supply and market capitalization of a specific ERC-20 token. This query provides on-chain market cap data.
 
 ▶️ [Get Token Total Supply and Market Cap](https://ide.bitquery.io/Get-Token-Total-Supply-and-Market-Cap)
 
@@ -322,7 +323,7 @@ Get the current total supply for specific tokens like USDC and USDT on Ethereum 
 
 #### Pepe volume marketcap
 
-Returns provides the latest trade volume for the past one hour along with the latest market cap.
+Provides the latest trade volume for the past one hour along with the latest market cap.
 
 ▶️ [Pepe volume marketcap](https://ide.bitquery.io/pepe-volume-marketcap)
 
@@ -334,7 +335,7 @@ Ethereum tokens ranked by market capitalisation.
 
 #### Total Supply and onchain Marketcap of a specific token
 
-This API gives you latest Supply and Marketcap of a token on EVM (here as example we have taken BITGET Token `0x54D2252757e1672EEaD234D27B1270728fF90581` ). Try it out [here
+This API gives you latest Supply and Marketcap of a token on EVM (here as example we have taken BITGET Token `0x54D2252757e1672EEaD234D27B1270728fF90581` ). Try it out.
 
 ▶️ [Total Supply and onchain Marketcap of a specific token](https://ide.bitquery.io/Total-Supply-and-onchain-Marketcap-of-a-specific-token)
 
@@ -366,31 +367,31 @@ Every call to one function with its arguments decoded. Change the method name to
 
 #### BlackRock USD Institutional Digital Liquidity Fund Latest Issuance
 
-You can use the same as a `subscription` to monitor issuances in real-time. You can run the query [here
+You can use the same as a `subscription` to monitor issuances in real-time.
 
 ▶️ [BlackRock USD Institutional Digital Liquidity Fund Latest Issuance](https://ide.bitquery.io/BlackRock-USD-Institutional-Digital-Liquidity-Fund-Latest-Issuance)
 
 #### Liquidiy of all token pools
 
-Returns returns current liquidity across all pools where a token appears as either `CurrencyA` or `CurrencyB`. It is useful when you want a token-wide liquidity view across multiple pools and DEXes.
+Returns current liquidity across all pools where a token appears as either `CurrencyA` or `CurrencyB`. It is useful when you want a token-wide liquidity view across multiple pools and DEXes.
 
 ▶️ [Liquidiy of all token pools](https://ide.bitquery.io/liquidiy-of-all-token-pools_1)
 
 #### Top liquidity pools of atoken on ethereum
 
-Returns separates results by whether shiba inu is listed as the first token (`CurrencyA`) or the second token (`CurrencyB`) in the DEX pool, returning the 10 pools with the highest liquidity for each category.
+This query separates results by whether shiba inu is listed as the first token (`CurrencyA`) or the second token (`CurrencyB`) in the DEX pool, returning the 10 pools with the highest liquidity for each category.
 
 ▶️ [Top liquidity pools of atoken on ethereum](https://ide.bitquery.io/top-liquidity-pools-of-atoken-on-ethereum)
 
 #### Top liquidity pools on Ethereum
 
-You can run and modify this query in the [IDE example
+You can run and modify this query in the.
 
 ▶️ [Top liquidity pools on Ethereum](https://ide.bitquery.io/top-liquidity-pools-on-Ethereum)
 
 #### Latest Liquidity Changes of a Specific Pool
 
-Returns retrieves the latest liquidity events for a specific DEX pool on Ethereum. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
+Retrieves the latest liquidity events for a specific DEX pool on Ethereum. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
 
 ▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_5)
 
@@ -416,7 +417,7 @@ Converts transaction value to USD at the time it was mined.
 
 #### Debug traceTransaction
 
-To trace a transaction using the debug_traceTransaction we need the `transaction hash`. We are using [this
+To trace a transaction using the debug_traceTransaction we need the `transaction hash`. We are using.
 
 ▶️ [Debug traceTransaction](https://ide.bitquery.io/debug_traceTransaction)
 
@@ -460,13 +461,13 @@ Decoded event logs as they land. Filter by contract or by event name.
 
 #### All aave v3 events latest
 
-The query below shows latest 10 events emitted by the AAVE V3 contract. The `Log` field in the results will contain information about the event, including its signature, smart contract address, and transaction hash.
+Shows latest 10 events emitted by the AAVE V3 contract. The `Log` field in the results will contain information about the event, including its signature, smart contract address, and transaction hash.
 
 ▶️ [All aave v3 events latest](https://ide.bitquery.io/All-aave-v3-events-latest)
 
 #### ByteCode of A Token
 
-Returns will return the most recent transaction that created the token contract. The `Output` field of the Call object in the transaction contains the encoded bytecode of the contract.
+Will return the most recent transaction that created the token contract. The `Output` field of the Call object in the transaction contains the encoded bytecode of the contract.
 
 ▶️ [ByteCode of A Token](https://ide.bitquery.io/ByteCode-of-A-Token)
 
@@ -484,7 +485,7 @@ In this section, we will discuss how we can use Bitquery APIs as an alternative 
 
 #### ETH/BSC SC creates count over date
 
-Returns below, will return the number of new smart contracts created on the Ethereum and Binance Smart Chain networks since a particular date. It will also return the date of each day on which new smart contracts were created. You can find the query [here
+This query below, will return the number of new smart contracts created on the Ethereum and Binance Smart Chain networks since a particular date. It will also return the date of each day on which new smart contracts were created.
 
 ▶️ [ETH/BSC SC creates count over date](https://ide.bitquery.io/ETHBSC-SC-creates-count-over-date)
 
@@ -498,13 +499,13 @@ Now, just like the orignal eth_getLogs method, Bitquery APIs provides the option
 
 #### Get next available nonce
 
-Returns helps you determine the next available nonce for an Ethereum account by getting the latest transaction in the mempool (broadcasted transactions). The returned nonce is the highest nonce used by the account in the mempool.
+The following query helps you determine the next available nonce for an Ethereum account by getting the latest transaction in the mempool (broadcasted transactions). The returned nonce is the highest nonce used by the account in the mempool.
 
 ▶️ [Get next available nonce](https://ide.bitquery.io/get-next-available-nonce)
 
 #### Simulating Pending Transactions
 
-Returns retrieves information about in-flight transactions, helping you simulate the most recent state. It is a way to see if they will succeed without sending them on-chain.
+Retrieves information about in-flight transactions, helping you simulate the most recent state. It is a way to see if they will succeed without sending them on-chain.
 
 ▶️ [Simulating Pending Transactions](https://ide.bitquery.io/Simulating-Pending-Transactions_1)
 
@@ -512,37 +513,37 @@ Returns retrieves information about in-flight transactions, helping you simulate
 
 #### Aggregate Self-Destruct Statistics
 
-Calculate total ETH destroyed or received from self-destructs using aggregation functions: Try the API [here
+Calculate total ETH destroyed or received from self-destructs using aggregation functions.
 
 ▶️ [Aggregate Self-Destruct Statistics](https://ide.bitquery.io/Aggregate-Self-Destruct-Statistics)
 
 #### QuasarBuilder MEV Payout Transaction Balance
 
-Returns focuses on a block builder address and returns the most recent payouts, including the token metadata, pre/post balances, and USD valuations, so you can quickly see how large each MEV reward was.
+This query focuses on a block builder address and returns the most recent payouts, including the token metadata, pre/post balances, and USD valuations, so you can quickly see how large each MEV reward was.
 
 ▶️ [QuasarBuilder MEV Payout Transaction Balance](https://ide.bitquery.io/QuasarBuilder-MEV-Payout-Transaction-Balance)
 
 #### Self-Destruct Balance Decrease API
 
-Monitor contract balance decrease when contracts are self-destructing. [Run Query
+Monitor contract balance decrease when contracts are self-destructing.
 
 ▶️ [Self-Destruct Balance Decrease API](https://ide.bitquery.io/Self-Destruct-Balance-Decrease-API)
 
 #### Self-Destruct Balance Increase API
 
-Monitor contract balance increase when contracts are self-destructing. [Run query
+Monitor contract balance increase when contracts are self-destructing.
 
 ▶️ [Self-Destruct Balance Increase API](https://ide.bitquery.io/Self-Destruct-Balance-Increase-API)
 
 #### Top validators by total tips in last 24 hrs
 
-Ranks validators by cumulative priority fees (reason code 5) received in the last 24 hours. Test the query [here
+Ranks validators by cumulative priority fees (reason code 5) received in the last 24 hours.
 
 ▶️ [Top validators by total tips in last 24 hrs](https://ide.bitquery.io/top-validators-by-total-tips-in-last-24-hrs)
 
 #### Total tips received by a validator in last 24 hrs
 
-Returns the total priority fees (native and USD) earned by a specific validator over the last 24 hours. Test the query [here
+Returns the total priority fees (native and USD) earned by a specific validator over the last 24 hours.
 
 ▶️ [Total tips received by a validator in last 24 hrs](https://ide.bitquery.io/total-tips-received-by-a-validator-in-last-24-hrs)
 
@@ -588,7 +589,7 @@ This API endpoint provides latest liquidity event for every Uniswap V4 pool for 
 
 #### Latest Trades on PancakeSwap V3 ETH
 
-The PancakSwap DEX Data is also available for view as a dashboard at DEXRABBIT
+The PancakSwap DEX Data is also available for view as a dashboard at DEXRABBIT.
 
 ▶️ [Latest Trades on PancakeSwap V3 ETH](https://ide.bitquery.io/Latest-Trades-on-PancakeSwap-V3-ETH)
 
@@ -664,7 +665,7 @@ Get all trades related transactions (buy, sell) for a specific wallet address.
 
 #### Buys Sells BuyVolume SellVolume Makers TotalTradedVolume PriceinUSD for solana token pair
 
-Returns gives you the essential stats for a token such as buy volume, sell volume, total buys, total sells, makers, total trade volume, buyers, sellers (in last 5 min, 1 hour) of a specific token. You can run the query [here
+Returns the essential stats for a token such as buy volume, sell volume, total buys, total sells, makers, total trade volume, buyers, sellers (in last 5 min, 1 hour) of a specific token.
 
 ▶️ [Buys Sells BuyVolume SellVolume Makers TotalTradedVolume PriceinUSD for solana token pair](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-solana-token-pair00_2)
 
@@ -702,31 +703,31 @@ You can search tokens on Solana using names or symbols case insensitively also u
 
 #### Solana token transfers of Bags fm tokens
 
-Track all transfers of Bags FM tokens across wallets. This Bags FM token transfers endpoint provides complete transfer history. 🔗 [Try Query
+Track all transfers of Bags FM tokens across wallets. This Bags FM token transfers endpoint provides complete transfer history. 🔗.
 
 ▶️ [Solana token transfers of Bags fm tokens](https://ide.bitquery.io/Solana-token-transfers-of-Bags-fm-tokens)
 
 #### Total txn fees paid by the Account
 
-Get the total fees (in SOL and USD) paid by a specific Solana account across all transfers. You can test the query [here
+Get the total fees (in SOL and USD) paid by a specific Solana account across all transfers.
 
 ▶️ [Total txn fees paid by the Account](https://ide.bitquery.io/total-txn-fees-paid-by-the-Account)
 
 #### Transaction fees paid by Account aggregated by currency
 
-Get total fees paid by a Solana account for transferring each type of token. You can test the query [here
+Get total fees paid by a Solana account for transferring each type of token.
 
 ▶️ [Transaction fees paid by Account aggregated by currency](https://ide.bitquery.io/Transaction-fees-paid-by-Account-aggregated-by-currency)
 
 #### Transfers of a wallet
 
-Returns fetches you the recent 10 transfers of a specific wallet address `9nnLbotNTcUhvbrsA6Mdkx45Sm82G35zo28AqUvjExn8`. Try the query [here
+Fetches the recent 10 transfers of a specific wallet address `9nnLbotNTcUhvbrsA6Mdkx45Sm82G35zo28AqUvjExn8`.
 
 ▶️ [Transfers of a wallet](https://ide.bitquery.io/Transfers-of-a-wallet_1)
 
 #### Wallet transfers with transaction fees paid
 
-Track wallet token transfers and get the fees paid for each by the address. You can test the query [here
+Track wallet token transfers and get the fees paid for each by the address.
 
 ▶️ [Wallet transfers with transaction fees paid](https://ide.bitquery.io/wallet-transfers-with-transaction-fees-paid)
 
@@ -740,7 +741,7 @@ This query returns Solana balance update info for any balance update event, incl
 
 #### Balance updates
 
-The query below gives you balance update associated with a instruction invocation.
+Returns balance update associated with a instruction invocation.
 
 ▶️ [Balance updates](https://ide.bitquery.io/balance-updates)
 
@@ -752,7 +753,7 @@ The query below uses the InstructionBalanceUpdates API to fetch balance updates 
 
 #### Trades of wallets with balance Updates in that trades
 
-Returns will give you the trades of the wallets present in `addressList` along with the balance updates happened in those trades.. Try the query [here
+Below query will give you the trades of the wallets present in `addressList` along with the balance updates happened in those trades..
 
 ▶️ [Trades of wallets with balance Updates in that trades](https://ide.bitquery.io/Trades-of-wallets-with-balance-Updates-in-that-trades)
 
@@ -802,13 +803,13 @@ ATH of multiple tokens quantile Solana. Uses the `DEXTradeByTokens` cube. Needs 
 
 #### ATH with price delta Solana
 
-Fetches a Solana token’s ATH price, ATH date, and price change percentages over the past 24h, 7d, and 30d using Bitquery Solana APIs. Try the [query to get ATH price, ATH date, price change
+Fetches a Solana token’s ATH price, ATH date, and price change percentages over the past 24h, 7d, and 30d using Bitquery Solana APIs. Try the.
 
 ▶️ [ATH with price delta Solana](https://ide.bitquery.io/ATH-with-price-delta-Solana)
 
 #### AldrinAmm OHLC for specific pair
 
-If you want to get OHLC data for any specific currency pair on AldrinAmm, you can use this api. Only use [this API
+If you want to get OHLC data for any specific currency pair on AldrinAmm, you can use this api. Only use.
 
 ▶️ [AldrinAmm OHLC for specific pair](https://ide.bitquery.io/AldrinAmm-OHLC-for-specific-pair)
 
@@ -834,7 +835,7 @@ You can fetch Marketcap of a token using below query.
 
 #### Marketcap of tokens
 
-Returns returns the ATH (All-Time High) market cap, starting market cap, and related price metrics for multiple tokens. It calculates market cap using a 1 billion token supply and uses quantile to find the ATH price.
+Returns the ATH (All-Time High) market cap, starting market cap, and related price metrics for multiple tokens. It calculates market cap using a 1 billion token supply and uses quantile to find the ATH price.
 
 ▶️ [Marketcap of tokens](https://ide.bitquery.io/Marketcap-of-tokens)
 
@@ -846,25 +847,25 @@ See the Pairs cube for full field reference.
 
 #### Token burn example solana
 
-You can also track real-time token burn using the TokenSupplyUpdates API. Check out the [following example
+You can also track real-time token burn using the TokenSupplyUpdates API. Check out the.
 
 ▶️ [Token burn example solana](https://ide.bitquery.io/token-burn-example-solana)
 
 #### Token supply
 
-Returns will return the latest token supply of a specific token. We are getting here supply for this `6D7NaB2xsLd7cauWu1wKk6KBsJohJmP2qZH9GEfVi5Ui` token `PostBalance` will give you the current supply for this token. Check the query [here
+Will return the latest token supply of a specific token. We are getting here supply for this `6D7NaB2xsLd7cauWu1wKk6KBsJohJmP2qZH9GEfVi5Ui` token `PostBalance` will give you the current supply for this token.
 
 ▶️ [Token supply](https://ide.bitquery.io/token-supply_2)
 
 #### Tokens with market cap range
 
-Lets say we need to get the tokens whose marketcap has crossed the `1M USD` mark but is less than `2M USD` for various reasons like automated trading. We can get the token details that have crossed a particular marketcap using [this
+Lets say we need to get the tokens whose marketcap has crossed the `1M USD` mark but is less than `2M USD` for various reasons like automated trading. We can get the token details that have crossed a particular marketcap using.
 
 ▶️ [Tokens with market cap range](https://ide.bitquery.io/tokens-with-market-cap-range)
 
 #### Top 10 marketcap jump tokens in last 1hr
 
-Use below query to get top 10 marketcap jump tokens in last 1hr. Test the query [here
+Use below query to get top 10 marketcap jump tokens in last 1hr.
 
 ▶️ [Top 10 marketcap jump tokens in last 1hr](https://ide.bitquery.io/top-10-marketcap-jump-tokens-in-last-1hr)
 
@@ -876,7 +877,7 @@ Top Solana tokens based on market cap. Uses the `TokenSupplyUpdates` cube.
 
 #### Top Tokens by Market Cap on solana
 
-You can run this query [in the Bitquery IDE
+Ranks tokens on Solana by `Supply.MarketCap`, with 24h window, 1s interval, $1,000+ USD volume, `limitBy` per `Token_Id`, up to 50 rows. `Token.Network` is Solana.
 
 ▶️ [Top Tokens by Market Cap on solana](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-solana)
 
@@ -908,7 +909,7 @@ This query retrieves the latest changes to liquidity pools on Solana, including 
 
 #### All liquidity add instructions track on Solana
 
-Returns tracks liquidity addition events on Solana DEX pools by monitoring specific instructions.
+Tracks liquidity addition events on Solana DEX pools by monitoring specific instructions.
 
 ▶️ [All liquidity add instructions track on Solana](https://ide.bitquery.io/All-liquidity-add-instructions-track-on-Solana)
 
@@ -920,13 +921,13 @@ The mint addresses for the tokens being used in the pool are listed for example 
 
 #### Get LP Latest liqudity on Solana
 
-Returns gets you the liquidity/balance of the Quote Currency `WSOL` and Base Currency `SOLANADOG` for this particular pool address `BDQnwNhTWc3wK4hhsnsEaBBMj3sD4idGzvuidVqUw1vL`.
+Get LP Latest liqudity on Solana. Uses the `DEXPools` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [Get LP Latest liqudity on Solana](https://ide.bitquery.io/Get-LP-Latest-liqudity-on-Solana)
 
 #### Get all the liquidity pools info for a particular token
 
-Returns will give you the information on all the liquidity pools of a particular token `EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm`. You can find the query [here
+Will give the information on all the liquidity pools of a particular token `EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm`.
 
 ▶️ [Get all the liquidity pools info for a particular token](https://ide.bitquery.io/get-all-the-liquidity-pools-info-for-a-particular-token_1)
 
@@ -938,7 +939,7 @@ Liquidity change in recent month. Uses the `DEXTradeByTokens` cube. Needs the hi
 
 #### Liquidity lock using instructions balance update
 
-Using the below query, you can retrieve latest liquidity locks made using streamflow. Test the query [here
+Using the below query, you can retrieve latest liquidity locks made using streamflow.
 
 ▶️ [Liquidity lock using instructions balance update](https://ide.bitquery.io/Liquidity-lock-using-instructions-balance-update)
 
@@ -998,19 +999,19 @@ To find tokens on Pump.fun that have reached a specific market capitalization th
 
 #### Get the Top Traders of a specific Token on Meteora DAMM v2 DEX
 
-Returns gets the Top Traders of the specified Token on Meteora DAMM v2. This provides insights into the most active traders and their trading patterns.
+The below query gets the Top Traders of the specified Token on Meteora DAMM v2. This provides insights into the most active traders and their trading patterns.
 
 ▶️ [Get the Top Traders of a specific Token on Meteora DAMM v2 DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DAMM-v2-DEX_1)
 
 #### Get the Top Traders of a specific Token on Meteora DLMM DEX
 
-Returns gets the Top Traders of the specified Token on Meteora DLMM. This provides insights into the most active traders and their trading patterns.
+The below query gets the Top Traders of the specified Token on Meteora DLMM. This provides insights into the most active traders and their trading patterns.
 
 ▶️ [Get the Top Traders of a specific Token on Meteora DLMM DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DLMM-DEX)
 
 #### Get the Top Traders of a specific Token on Meteora DYN DEX
 
-Returns gets the Top Traders of the specified Token `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` on Meteora DYN.
+The below query gets the Top Traders of the specified Token `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` on Meteora DYN.
 
 ▶️ [Get the Top Traders of a specific Token on Meteora DYN DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DYN-DEX)
 
@@ -1028,7 +1029,7 @@ If you want to get OHLC (Open, High, Low, Close) data for any specific currency 
 
 #### Meteora DYN OHLC API
 
-If you want to get OHLC data for any specific currency pair on Meteora DYN, you can use this api. Only use [this API
+If you want to get OHLC data for any specific currency pair on Meteora DYN, you can use this api. Only use.
 
 ▶️ [Meteora DYN OHLC API](https://ide.bitquery.io/Meteora-DYN-OHLC-API)
 
@@ -1074,13 +1075,13 @@ DecreaseLiquidityV2 latest raydium clmm. Uses the `Instructions` cube. Replace t
 
 #### Latest Price of a LetsBonk.fun Token on Launchpad
 
-Returns provides the most recent price data for a specific LetsBonk.fun token `token Mint Address` launched on Raydium Launchpad. You can filter by the token’s `MintAddress`, and the query will return the last recorded trade price.
+Provides the most recent price data for a specific LetsBonk.fun token `token Mint Address` launched on Raydium Launchpad. You can filter by the token’s `MintAddress`, and the query will return the last recorded trade price.
 
 ▶️ [Latest Price of a LetsBonk.fun Token on Launchpad](https://ide.bitquery.io/Latest-Price-of-a-LetsBonkfun-Token-on-Launchpad)
 
 #### Latest Trades of a letsbonk.fun token on Launchpad
 
-Returns fetches the most recent trades of a LetsBonk.fun Token `token Mint Address` on the Raydium Launchpad. Run the query: [Latest trades of a LetsBonk.fun token ➤
+Fetches the most recent trades of a LetsBonk.fun Token `token Mint Address` on the Raydium Launchpad. Run the query.
 
 ▶️ [Latest Trades of a letsbonk.fun token on Launchpad](https://ide.bitquery.io/Latest-Trades-of-a-letsbonkfun-token-on-Launchpad)
 
@@ -1138,25 +1139,25 @@ Get all trades by a particular trader.
 
 #### All dexs info on bsc
 
-Returns will fetch you all the DEXs info for the BSC network. You can test the query [here
+Will fetch all the DEXs info for the BSC network.
 
 ▶️ [All dexs info on bsc](https://ide.bitquery.io/all-dexs-info-on-bsc)
 
 #### First 500 buyers of a specific BSC chain token
 
-Below API gets you the first 500 buyers of a specific BSC token, here as example we have taken this token `0x031b41e504677879370e9DBcF937283A8691Fa7f`. Try the API [here
+Below API gets you the first 500 buyers of a specific BSC token, here as example we have taken this token `0x031b41e504677879370e9DBcF937283A8691Fa7f`.
 
 ▶️ [First 500 buyers of a specific BSC chain token](https://ide.bitquery.io/first-500-buyers-of-a-specific-BSC-chain-token_2)
 
 #### Get all dex markets for a token
 
-Returns will fetch you all the DEXs where a token is listed for the BSC network. You can test the query [here
+Will fetch all the DEXs where a token is listed for the BSC network.
 
 ▶️ [Get all dex markets for a token](https://ide.bitquery.io/get-all-dex-markets-for-a-token)
 
 #### Get all the DEXs on BSC network
 
-Returns retrieves all the DEXes operating on BSC network and gives info such as `ProtocolName` , `ProtocolVersion` and `ProtocolFamily`. Find the query [here
+Retrieves all the DEXes operating on BSC network and gives info such as `ProtocolName` , `ProtocolVersion` and `ProtocolFamily`.
 
 ▶️ [Get all the DEXs on BSC network](https://ide.bitquery.io/Get-all-the-DEXs-on-BSC-network)
 
@@ -1176,7 +1177,7 @@ Monitor all recent trades across Flap.sh tokens using the DEXTrades API.
 
 #### Gra fun redeem transactions
 
-Retrieve all redeemed transactions using [this query
+Gra fun redeem transactions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [Gra fun redeem transactions](https://ide.bitquery.io/Gra-fun-redeem-transactions)
 
@@ -1214,7 +1215,7 @@ Fetches the developer address that created a specific Four.Meme token on BSC by 
 
 #### First transfers of a token
 
-Returns retrieves the first transfer of a token to each address, providing the timestamp when each address first received the token.
+Retrieves the first transfer of a token to each address, providing the timestamp when each address first received the token.
 
 ▶️ [First transfers of a token](https://ide.bitquery.io/first-transfers-of-a-token_5)
 
@@ -1252,13 +1253,13 @@ Get latest BNB balance of an wallet.
 
 #### Average Tip in terms of avg gas Fee bsc
 
-Compares average user tip to average total gas fee per block across the last 10 blocks. Test the query [here
+Compares average user tip to average total gas fee per block across the last 10 blocks.
 
 ▶️ [Average Tip in terms of avg gas Fee bsc](https://ide.bitquery.io/Average-Tip-in-terms-of-avg-gas-Fee-bsc)
 
 #### Latest balance of an address for a specific token bsc
 
-This API gives you latest balance of a specific address (here in example `0x238a358808379702088667322f80ac48bad5e6c4`) for a specific token (here we have taken example of USDC `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`). Try it out [here
+This API gives you latest balance of a specific address (here in example `0x238a358808379702088667322f80ac48bad5e6c4`) for a specific token (here we have taken example of USDC `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`). Try it out.
 
 ▶️ [Latest balance of an address for a specific token bsc](https://ide.bitquery.io/Latest-balance-of-an-address-for-a-specific-token-bsc)
 
@@ -1270,7 +1271,7 @@ Calculates the percentage of total supply held by the top 10 holders of a specif
 
 #### Track recent ephemeral contract patterns bsc
 
-Many MEV bots and arbitrage executors create contracts that are destroyed within the same transaction. These short-lived contracts are used for:
+Many MEV bots and arbitrage executors create contracts that are destroyed within the same transaction. These short-lived contracts are used for.
 
 ▶️ [Track recent ephemeral contract patterns bsc](https://ide.bitquery.io/Track-recent-ephemeral-contract-patterns-bsc)
 
@@ -1332,7 +1333,7 @@ This query gets you top 10 BSC Tokens by Price Change in last 1h.
 
 #### BSC OHLC API For Token Pair
 
-Returns will fetch you the OHLC of a token pair for the BSC network. You can test the query [here
+Will fetch the OHLC of a token pair for the BSC network.
 
 ▶️ [BSC OHLC API For Token Pair](https://ide.bitquery.io/BSC-OHLC-API-For-Token-Pair)
 
@@ -1344,7 +1345,7 @@ Fetches the All-Time High (ATH) price of a specific Meme Rush token on BSC, usin
 
 #### Latest price of a token on bsc
 
-Returns will fetch you latest trades for a token pair for the BSC network. You can test the query [here
+Will fetch latest trades for a token pair for the BSC network.
 
 ▶️ [Latest price of a token on bsc](https://ide.bitquery.io/Latest-price-of-a-token-on-bsc)
 
@@ -1362,7 +1363,7 @@ Get OHLCV (Open, High, Low, Close, Volume) data for Flap.sh tokens quoted in USD
 
 #### Percentage price change for a meme rush token
 
-Use the below query to get the price change in percentage for various time fields including `24 hours`, `1 hour` and `5 minutes`. Try it [here
+Use the below query to get the price change in percentage for various time fields including `24 hours`, `1 hour` and `5 minutes`. Try it.
 
 ▶️ [Percentage price change for a meme rush token](https://ide.bitquery.io/Percentage-price-change-for-a-meme-rush-token)
 
@@ -1376,13 +1377,13 @@ Get Total Supply and Marketcap of an ERC20 token.
 
 #### Top Tokens by Market Cap on bsc
 
-You can run this query [in the Bitquery IDE
+Ranks tokens on BNB Smart Chain by `Supply.MarketCap`, with 24h window, 1s interval, $1,000+ USD volume, `limitBy` per `Token_Id`, up to 50 rows. `Token.Network` is Binance Smart Chain.
 
 ▶️ [Top Tokens by Market Cap on bsc](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-bsc)
 
 #### Total Supply and onchain Marketcap of a specific token bsc
 
-This API gives you latest Supply and Marketcap of a token on BSC (here as example we have taken a BEP-20 token `0x55d398326f99059ff775485246999027b3197955`). Try it out [here
+This API gives you latest Supply and Marketcap of a token on BSC (here as example we have taken a BEP-20 token `0x55d398326f99059ff775485246999027b3197955`). Try it out.
 
 ▶️ [Total Supply and onchain Marketcap of a specific token bsc](https://ide.bitquery.io/Total-Supply-and-onchain-Marketcap-of-a-specific-token-bsc)
 
@@ -1396,7 +1397,7 @@ This query retrieves the latest slippage data for a specific DEX pool on BSC. Us
 
 #### Latest Liquidity Changes of a Specific Pool
 
-Returns retrieves the latest liquidity events for a specific DEX pool on BSC. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
+Retrieves the latest liquidity events for a specific DEX pool on BSC. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
 
 ▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_2)
 
@@ -1410,13 +1411,13 @@ Get transactions ordered by block number in descending order.
 
 #### Gra fun buy transactions
 
-Retrieve all buy transactions from GRA.fun using [this query
+Retrieve all buy transactions from GRA.fun using.
 
 ▶️ [Gra fun buy transactions](https://ide.bitquery.io/Gra-fun-buy-transactions)
 
 #### Gra fun sell transactions
 
-Retrieve all sell transactions on GRA fun using [this query
+Retrieve all sell transactions on GRA fun using.
 
 ▶️ [Gra fun sell transactions](https://ide.bitquery.io/Gra-fun-sell-transactions)
 
@@ -1424,7 +1425,7 @@ Retrieve all sell transactions on GRA fun using [this query
 
 #### Latest Calls on BSC network
 
-Returns retrieves the latest successful smart contract calls on the BNB Smart Chain (BSC). It fetches details about contract interactions, transaction metadata, and associated block information.
+Retrieves the latest successful smart contract calls on the BNB Smart Chain (BSC). It fetches details about contract interactions, transaction metadata, and associated block information.
 
 ▶️ [Latest Calls on BSC network](https://ide.bitquery.io/Latest-Calls-on-BSC-network)
 
@@ -1438,25 +1439,25 @@ Monitor token creation events directly from the Flap.sh portal contract for more
 
 #### Aggregate Self-Destruct Statistics bsc
 
-Calculate total ETH destroyed or received from self-destructs using aggregation functions: Try the API [here
+Calculate total ETH destroyed or received from self-destructs using aggregation functions.
 
 ▶️ [Aggregate Self-Destruct Statistics bsc](https://ide.bitquery.io/Aggregate-Self-Destruct-Statistics-bsc)
 
 #### Self-Destruct Balance Decrease API bsc
 
-Monitor contract balance decrease when contracts are self-destructing. [Run Query
+Monitor contract balance decrease when contracts are self-destructing.
 
 ▶️ [Self-Destruct Balance Decrease API bsc](https://ide.bitquery.io/Self-Destruct-Balance-Decrease-API-bsc)
 
 #### Self-Destruct Balance Increase API bsc
 
-Monitor contract balance increase when contracts are self-destructing. [Run query
+Monitor contract balance increase when contracts are self-destructing.
 
 ▶️ [Self-Destruct Balance Increase API bsc](https://ide.bitquery.io/Self-Destruct-Balance-Increase-API-bsc)
 
 #### Top validators by total tips in last 24 hrs bsc
 
-Ranks validators by cumulative priority fees (reason code 5) received in the last 24 hours. Test the query [here
+Ranks validators by cumulative priority fees (reason code 5) received in the last 24 hours.
 
 ▶️ [Top validators by total tips in last 24 hrs bsc](https://ide.bitquery.io/top-validators-by-total-tips-in-last-24-hrs-bsc)
 
@@ -1468,7 +1469,7 @@ Historical Miner Balance Data bsc. Uses the `TransactionBalances` cube.
 
 #### Total tips received by a validator in last 24 hrs bsc
 
-Returns the total priority fees (native and USD) earned by a specific validator over the last 24 hours. Test the query [here
+Returns the total priority fees (native and USD) earned by a specific validator over the last 24 hours.
 
 ▶️ [Total tips received by a validator in last 24 hrs bsc](https://ide.bitquery.io/total-tips-received-by-a-validator-in-last-24-hrs-bsc)
 
@@ -1506,7 +1507,7 @@ Bsc pancakeswap ohlc using trading api. Uses the `Pairs` cube.
 
 #### Get Latest Price of a token on PancakeSwap Infinity
 
-Returns will get you Latest Price of a token on PancakeSwap Infinity. Try out the API [here
+Below query will get you Latest Price of a token on PancakeSwap Infinity.
 
 ▶️ [Get Latest Price of a token on PancakeSwap Infinity](https://ide.bitquery.io/Get-Latest-Price-of-a-token-on-PancakeSwap-Infinity_1)
 
@@ -1532,19 +1533,19 @@ Get the liquidity addition events for a specific token on the Four Meme Exchange
 
 #### Four meme - token ATH price
 
-Fetches the All-Time High (ATH) price of a specific Four.Meme token on BSC, using the `DEXTradeByTokens` dataset to calculate the 98th percentile of trade prices (approximate ATH). Try the API [here
+Fetches the All-Time High (ATH) price of a specific Four.Meme token on BSC, using the `DEXTradeByTokens` dataset to calculate the 98th percentile of trade prices (approximate ATH).
 
 ▶️ [Four meme - token ATH price](https://ide.bitquery.io/four-meme---token-ATH-price)
 
 #### Get first buys of an address list of a specific token
 
-Returns checks if the addresses from Query 1 ever bought the token and when. Pass the address array from Query 1 as a variable to this query.
+This query checks if the addresses from Query 1 ever bought the token and when. Pass the address array from Query 1 as a variable to this query.
 
 ▶️ [Get first buys of an address list of a specific token](https://ide.bitquery.io/get-first-buys-of-an-address-list-of-a-specific-token_2)
 
 #### If meme rush token migrated from four meme or not
 
-Returns will only show response if a the mentioned meme rush tokens have migrated to Pancakeswap. Note: Please use a `Block{Date}` filter to minimize the data processing and hence the query processing time and get fast responses. Try the query [here
+Below query will only show response if a the mentioned meme rush tokens have migrated to Pancakeswap. Note: Please use a `Block{Date}` filter to minimize the data processing and hence the query processing time and get fast responses.
 
 ▶️ [If meme rush token migrated from four meme or not](https://ide.bitquery.io/if-meme-rush-token-migrated-from-four-meme-or-not)
 
@@ -1558,7 +1559,7 @@ Get all trading pairs present on a BSC network DEX.
 
 #### Get metadata
 
-Use the below query to get Token's metadata like `Name`, `symbol`, `SmartContract Address`, `Decimals`. Try out the API [here
+Use the below query to get Token's metadata like `Name`, `symbol`, `SmartContract Address`, `Decimals`.
 
 ▶️ [Get metadata](https://ide.bitquery.io/get-metadata_1)
 
@@ -1570,13 +1571,13 @@ Latest Trades for a currency pair on bsc. Uses the `DEXTrades` cube.
 
 #### OHLC on BSC Uniswap v3
 
-Returns retrieves the Open, High, Low, and Close (OHLC) prices in USD for a specific token traded on Uniswap v3 over a defined time period and interval. You can try out the API [here
+Retrieves the Open, High, Low, and Close (OHLC) prices in USD for a specific token traded on Uniswap v3 over a defined time period and interval.
 
 ▶️ [OHLC on BSC Uniswap v3](https://ide.bitquery.io/OHLC-on-BSC-Uniswap-v3)
 
 #### Top bought tokens on bsc uniswap v3
 
-Returns will fetch you the top bought tokens on uniswap v3. Try out the query [here
+Will fetch the top bought tokens on uniswap v3.
 
 ▶️ [Top bought tokens on bsc uniswap v3](https://ide.bitquery.io/top-bought-tokens-on-bsc-uniswap-v3)
 
@@ -1610,7 +1611,7 @@ Get all trades by a particular trader.
 
 #### First 500 buyers of a specific base token
 
-Below API gets you the first 500 buyers of a specific Base chain token, here as example we have taken this token `0x58538e6A46E07434d7E7375Bc268D3cb839C0133`. Try the API [here
+Below API gets you the first 500 buyers of a specific Base chain token, here as example we have taken this token `0x58538e6A46E07434d7E7375Bc268D3cb839C0133`.
 
 ▶️ [First 500 buyers of a specific base token](https://ide.bitquery.io/first-500-buyers-of-a-specific-base-token)
 
@@ -1622,7 +1623,7 @@ Latest Trades of a Token on Zora Base. Uses the `DEXTrades` cube. Change the tok
 
 #### Latest Zora Trades on Base
 
-Returns fetches the latest DEX trades on the Zora protocol (`zora_v4`) on Base blockchain. Try out the API [here
+Fetches the latest DEX trades on the Zora protocol (`zora_v4`) on Base blockchain.
 
 ▶️ [Latest Zora Trades on Base](https://ide.bitquery.io/Latest-Zora-Trades-on-Base)
 
@@ -1634,13 +1635,13 @@ Discover the most actively traded tokens on Aerodrome Finance over any time peri
 
 #### Top Traders by PnL of a specific base pool
 
-You can run this query [in the Bitquery IDE
+Rank traders by `PnL` on one pool: filter `Pair.Market.Address`, last 30 minutes, `limit: 10`, and `orderBy` `PnL` descending. Useful for leaderboards, smart-money screens, and pool-specific trader analytics.
 
 ▶️ [Top Traders by PnL of a specific base pool](https://ide.bitquery.io/Top-Traders-by-PnL-of-a-specific-base-pool_1)
 
 #### Ape store token trades
 
-MyQuery { EVM(network: base) { Calls( where: {Transaction: {To: {is: "0x0bf8edd756ff6caf3f583d67a9fd8b237e40f58a"}, From: {is: "0x2870cbffae4cf005dd1c3587e2f0db3cb00dbafd"}}, Call: {Signature: {Name: {is: "buy"}}}} ) { Arguments { Name Type Value { ...
+Ape store token trades. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [Ape store token trades](https://ide.bitquery.io/ape-store-token-trades)
 
@@ -1660,7 +1661,7 @@ Get token transactions ordered by block number in descending order.
 
 #### Newly created zora tokens
 
-Returns retrieves the list of newly created tokens on Zora Launchpad by monitoring transfers where new tokens are minted (sender is the zero address) with a specific amount. Try out the API [here
+Retrieves the list of newly created tokens on Zora Launchpad by monitoring transfers where new tokens are minted (sender is the zero address) with a specific amount.
 
 ▶️ [Newly created zora tokens](https://ide.bitquery.io/Newly-created-zora-tokens)
 
@@ -1722,7 +1723,7 @@ Returns the native ETH balance for a wallet on Base (not ERC-20 tokens). Filter 
 
 #### Latest balance of an address for a specific token base
 
-This API gives you latest balance of a specific address (here in example `0x238a358808379702088667322f80ac48bad5e6c4`) for a specific token (here we have taken example of USDC `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`). Try it out [here
+This API gives you latest balance of a specific address (here in example `0x238a358808379702088667322f80ac48bad5e6c4`) for a specific token (here we have taken example of USDC `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`). Try it out.
 
 ▶️ [Latest balance of an address for a specific token base](https://ide.bitquery.io/Latest-balance-of-an-address-for-a-specific-token-base)
 
@@ -1792,7 +1793,7 @@ Retrieve the total supply and market capitalization of a specific token. This qu
 
 #### Top Tokens by Market Cap on Base
 
-You can run this query [in the Bitquery IDE
+This query ranks Base tokens by `Supply.MarketCap`. It uses roughly the last 24 hours (`since_relative: { hours_ago: 24 }`), 1-second intervals, at least $1,000 USD volume, `limitBy` one row per `Token_Id`, and up to 50 tokens.
 
 ▶️ [Top Tokens by Market Cap on Base](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-Base)
 
@@ -1810,7 +1811,7 @@ Bankr token latest marketcap OHLC. Uses the `Tokens` cube.
 
 #### Total Supply and onchain Marketcap of a specific token base
 
-This API gives you latest Supply and Marketcap of a token on Base. Try it out [here
+This API gives you latest Supply and Marketcap of a token on Base. Try it out.
 
 ▶️ [Total Supply and onchain Marketcap of a specific token base](https://ide.bitquery.io/Total-Supply-and-onchain-Marketcap-of-a-specific-token-base)
 
@@ -1830,7 +1831,7 @@ This query retrieves the latest slippage data for a specific DEX pool on Base. U
 
 #### Latest Liquidity Changes of a Specific Pool
 
-Returns retrieves the latest liquidity events for a specific DEX pool on Base. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
+Retrieves the latest liquidity events for a specific DEX pool on Base. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
 
 ▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_4)
 
@@ -1842,13 +1843,13 @@ Track newly created liquidity pools on Aerodrome Finance in real-time. Discover 
 
 #### Top liquidity pools of cbBTC
 
-Returns separates results by whether cbBTC is listed as the first token (`CurrencyA`) or the second token (`CurrencyB`) in the DEX pool, returning the 10 pools with the highest liquidity for each category.
+This query separates results by whether cbBTC is listed as the first token (`CurrencyA`) or the second token (`CurrencyB`) in the DEX pool, returning the 10 pools with the highest liquidity for each category.
 
 ▶️ [Top liquidity pools of cbBTC](https://ide.bitquery.io/top-liquidity-pools-of-cbBTC)
 
 #### Latest liquidity of a base pool
 
-This API gives you latest liquidity of a Base Pool. Try it out [here
+This API gives you latest liquidity of a Base Pool. Try it out.
 
 ▶️ [Latest liquidity of a base pool](https://ide.bitquery.io/latest-liquidity-of-a-base-pool)
 
@@ -1906,31 +1907,31 @@ Filter `Create` events on the Airlock by `Transaction.From` to list every Bankr 
 
 #### Ape store buys from a wallet
 
-MyQuery { EVM(network: base) { Calls( where: {Transaction: {To: {is: "0x0bf8edd756ff6caf3f583d67a9fd8b237e40f58a"}}, Call: {Signature: {Name: {is: "buy"}}}} ) { Arguments { Name Type Value { ... on EVM_ABI_Integer_Value_Arg { integer } ...
+Ape store buys from a wallet. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [Ape store buys from a wallet](https://ide.bitquery.io/ape-store-buys-from-a-wallet)
 
 #### Ape store token event
 
-Firstly, we can find the smart contract address of the APE Store using [this
+Firstly, we can find the smart contract address of the APE Store using.
 
 ▶️ [Ape store token event](https://ide.bitquery.io/ape-store-token-event_1)
 
 #### Ape-store-buys
 
-MyQuery { EVM(network: base) { Calls( where: {Transaction: {To: {is: "0x0bf8edd756ff6caf3f583d67a9fd8b237e40f58a"}}} orderBy: {descendingByField: "count"} ) { Call { Signature { Name Signature } } count } } } ``` From the results we get a signature named…
+Ape-store-buys. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [Ape-store-buys](https://ide.bitquery.io/ape-store-buys_1)
 
 #### Base jump token event
 
-Firstly, we can find the smart contract address of the Base Jump using [this
+Firstly, we can find the smart contract address of the Base Jump using.
 
 ▶️ [Base jump token event](https://ide.bitquery.io/base-jump-token-event)
 
 #### Base-jump-buys
 
-MyQuery { EVM(network: base) { Calls( where: {Transaction: {To: {is: "0x31C0282Fa6D0A82aD22ab63BbaCd87F62B2a9bfD"}}} orderBy: {descendingByField: "count"} ) { Call { Signature { Name Signature } } count } } } ``` From the results we get a signature named…
+Base-jump-buys. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [Base-jump-buys](https://ide.bitquery.io/base-jump-buys)
 
@@ -1944,19 +1945,19 @@ In the recent times, base network has seen rise of many Memecoins and token base
 
 #### Aggregate Self Destruct Statistics base
 
-Calculate total ETH destroyed or received from self-destructs using aggregation functions: Try the API [here
+Calculate total ETH destroyed or received from self-destructs using aggregation functions.
 
 ▶️ [Aggregate Self Destruct Statistics base](https://ide.bitquery.io/Aggregate-Self-Destruct-Statistics-base)
 
 #### Self Destruct Balance Decrease API base
 
-Monitor contract balance decrease when contracts are self-destructing. [Run Query
+Monitor contract balance decrease when contracts are self-destructing.
 
 ▶️ [Self Destruct Balance Decrease API base](https://ide.bitquery.io/Self-Destruct-Balance-Decrease-API-base)
 
 #### Self Destruct Balance Increase API base
 
-Monitor contract balance increase when contracts are self-destructing. [Run query
+Monitor contract balance increase when contracts are self-destructing.
 
 ▶️ [Self Destruct Balance Increase API base](https://ide.bitquery.io/Self-Destruct-Balance-Increase-API-base)
 
@@ -1970,31 +1971,31 @@ This subscription returns the real-time trades happening on Uniswap. You can mod
 
 #### Get metadata for base uniswap token
 
-Use the below query to get Token's metadata like `Name`, `symbol`, `SmartContract Address`, `Decimals`. Try out the API [here
+Use the below query to get Token's metadata like `Name`, `symbol`, `SmartContract Address`, `Decimals`.
 
 ▶️ [Get metadata for base uniswap token](https://ide.bitquery.io/get-metadata-for-base-uniswap-token)
 
 #### Latest slippage of a pool on Uniswap v3
 
-Returns retrieves the latest slippage data for a specific DEX pool on Arbitrum. Use this to check current liquidity depth and price impact for a particular token pair.
+Retrieves the latest slippage data for a specific DEX pool on Arbitrum. Use this to check current liquidity depth and price impact for a particular token pair.
 
 ▶️ [Latest slippage of a pool on Uniswap v3](https://ide.bitquery.io/Latest-slippage-of-a-pool-on-Uniswap-v3)
 
 #### OHLC on BASE Uniswap v3
 
-Returns retrieves the Open, High, Low, and Close (OHLC) prices in USD for a specific token traded on Uniswap v3 over a defined time period and interval. You can try out the API [here
+Retrieves the Open, High, Low, and Close (OHLC) prices in USD for a specific token traded on Uniswap v3 over a defined time period and interval.
 
 ▶️ [OHLC on BASE Uniswap v3](https://ide.bitquery.io/OHLC-on-BASE-Uniswap-v3)
 
 #### Top bought tokens on uniswap v3
 
-Returns will fetch you the top bought tokens on uniswap v3. Try out the query [here
+Will fetch the top bought tokens on uniswap v3.
 
 ▶️ [Top bought tokens on uniswap v3](https://ide.bitquery.io/top-bought-tokens-on-uniswap-v3)
 
 #### Top sold tokens on uniswap v3
 
-Returns will fetch you the top bought tokens on uniswap v3. Try out the query [here
+Will fetch the top bought tokens on uniswap v3.
 
 ▶️ [Top sold tokens on uniswap v3](https://ide.bitquery.io/top-sold-tokens-on-uniswap-v3)
 
@@ -2002,37 +2003,37 @@ Returns will fetch you the top bought tokens on uniswap v3. Try out the query [h
 
 #### Get Latest Price of a token on PancakeSwap Infinity
 
-Returns will get you Latest Price of a token on PancakeSwap Infinity. Try out the API [here
+Below query will get you Latest Price of a token on PancakeSwap Infinity.
 
 ▶️ [Get Latest Price of a token on PancakeSwap Infinity](https://ide.bitquery.io/Get-Latest-Price-of-a-token-on-PancakeSwap-Infinity)
 
 #### Pancakeswap infinity trades
 
-Returns will subscribe you to the latest DEX Trades on PancakeSwap Infinity. Try out the API [here
+Below query will subscribe you to the latest DEX Trades on PancakeSwap Infinity.
 
 ▶️ [Pancakeswap infinity trades](https://ide.bitquery.io/pancakeswap-infinity-trades)
 
 #### Top bought tokens on pancakeswap_infinity
 
-Returns will fetch you the top bought tokens on PancakeSwap Infinity. Try out the query [here
+Will fetch the top bought tokens on PancakeSwap Infinity.
 
 ▶️ [Top bought tokens on pancakeswap_infinity](https://ide.bitquery.io/top-bought-tokens-on-pancakeswap_infinity)
 
 #### Top sold tokens on pancake infinty
 
-Returns will fetch you the top bought tokens on PancakeSwap Infinity. Try out the query [here
+Will fetch the top bought tokens on PancakeSwap Infinity.
 
 ▶️ [Top sold tokens on pancake infinty](https://ide.bitquery.io/top-sold-tokens-on-pancake-infinty)
 
 #### Get metadata for base pancakeswap infnity token
 
-Use the below query to get Token's metadata like `Name`, `symbol`, `SmartContract Address`, `Decimals`. Try out the API [here
+Use the below query to get Token's metadata like `Name`, `symbol`, `SmartContract Address`, `Decimals`.
 
 ▶️ [Get metadata for base pancakeswap infnity token](https://ide.bitquery.io/get-metadata-for-base-pancakeswap-infnity-token)
 
 #### OHLC on BASE pancakeswap infinity
 
-Returns retrieves the Open, High, Low, and Close (OHLC) prices in USD for a specific token traded on PancakeSwap Infinity over a defined time period and interval. You can try out the API [here
+Retrieves the Open, High, Low, and Close (OHLC) prices in USD for a specific token traded on PancakeSwap Infinity over a defined time period and interval.
 
 ▶️ [OHLC on BASE pancakeswap infinity](https://ide.bitquery.io/OHLC-on-BASE-pancakeswap-infinity)
 
@@ -2062,25 +2063,25 @@ Filter withdraw activity for a single gauge pool. Useful for monitoring liquidit
 
 #### Pair last trades
 
-Returns retrieves all DEX trades on the arbitrum where the Arbitrum currency is `ArbitrumCurrency` and the quote currency is `quoteCurrency` that occurred between the specified dates. You can find the query [here
+Retrieves all DEX trades on the arbitrum where the Arbitrum currency is `ArbitrumCurrency` and the quote currency is `quoteCurrency` that occurred between the specified dates.
 
 ▶️ [Pair last trades](https://ide.bitquery.io/Pair-last-trades_2)
 
 #### Swap Events Arbitrum
 
-The query returns the 10 most recent `swap` events on the Arbitrum network. We get this by using the signature hash `c42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67` for the swap event.
+Returns the 10 most recent `swap` events on the Arbitrum network. We get this by using the signature hash `c42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67` for the swap event.
 
 ▶️ [Swap Events Arbitrum](https://ide.bitquery.io/Swap-Events-Arbitrum)
 
 #### Top Sold Tokens on Arbitrum
 
-Returns will give you top sold tokens on Arbitrum network in last 1 hour. Change the timestamp in `{Block: {Time: {since: "2024-12-24T08:20:00Z"}}}` accordingly. You can find the query [here
+Top Sold Tokens on Arbitrum. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
 
 ▶️ [Top Sold Tokens on Arbitrum](https://ide.bitquery.io/Top-Sold-Tokens-on-Arbitrum)
 
 #### Top bought tokens on Arbitrum
 
-Returns will give you top bought tokens on Arbitrum network in last 1 hour. Change the timestamp in `{Block: {Time: {since: "2024-12-24T08:20:00Z"}}}` accordingly. You can find the query [here
+Top bought tokens on Arbitrum. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
 
 ▶️ [Top bought tokens on Arbitrum](https://ide.bitquery.io/top-bought-tokens-on-Arbitrum)
 
@@ -2158,7 +2159,7 @@ Top 10 arb tokens by price change in last 1 hr. Uses the `DEXTradeByTokens` cube
 
 #### Top Tokens by Market Cap on Arbitrum
 
-You can run this query [in the Bitquery IDE
+This query ranks Arbitrum tokens by `Supply.MarketCap`. It uses roughly the last 24 hours (`since_relative: { hours_ago: 24 }`), 1-second intervals, at least $1,000 USD volume, `limitBy` one row per `Token_Id`, and up to 50 tokens.
 
 ▶️ [Top Tokens by Market Cap on Arbitrum](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-Arbitrum)
 
@@ -2166,7 +2167,7 @@ You can run this query [in the Bitquery IDE
 
 #### Latest liquidity changes of a specific pool
 
-Returns retrieves the latest liquidity events for a specific DEX pool on Arbitrum. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
+Retrieves the latest liquidity events for a specific DEX pool on Arbitrum. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
 
 ▶️ [Latest liquidity changes of a specific pool](https://ide.bitquery.io/latest-liquidity-changes-of-a-specific-pool)
 
@@ -2174,13 +2175,13 @@ Returns retrieves the latest liquidity events for a specific DEX pool on Arbitru
 
 #### Latest Transactions
 
-The query below retrieves the latest 10 transactions on the Arbitrum network. You can find the query [here
+Retrieves the latest 10 transactions on the Arbitrum network.
 
 ▶️ [Latest Transactions](https://ide.bitquery.io/Latest-Transactions_3)
 
 #### Transaction Call Trace Arbitrum
 
-Returns gets the transaction call trace for an Arbitrum transaction. The `Calls` API in the query returns a list of all calls made by the transaction. You can find the query [here
+This query gets the transaction call trace for an Arbitrum transaction. The `Calls` API in the query returns a list of all calls made by the transaction.
 
 ▶️ [Transaction Call Trace Arbitrum](https://ide.bitquery.io/Transaction-Call-Trace-Arbitrum)
 
@@ -2188,13 +2189,13 @@ Returns gets the transaction call trace for an Arbitrum transaction. The `Calls`
 
 #### Latest GMX Events
 
-Returns retrieves the latest liquidated positions on the GMX DEX, providing information on the account, collateral token, index token, position, reserve amount, realised PnL, and mark price.
+The following query retrieves the latest liquidated positions on the GMX DEX, providing information on the account, collateral token, index token, position, reserve amount, realised PnL, and mark price.
 
 ▶️ [Latest GMX Events](https://ide.bitquery.io/latest-GMX-Events)
 
 #### Latest vGLP Withdraw Events
 
-Returns retrieves the latest vGLP withdrawals on the Arbitrum network:
+The following query retrieves the latest vGLP withdrawals on the Arbitrum network.
 
 ▶️ [Latest vGLP Withdraw Events](https://ide.bitquery.io/latest-vGLP-Withdraw-Events)
 
@@ -2206,7 +2207,7 @@ SpokePool events in Across Protocol can be used to monitor the status of bridge 
 
 #### Latest vGLP Deposit Events
 
-Returns retrieves the latest vGLP deposits on the Arbitrum network:
+The following query retrieves the latest vGLP deposits on the Arbitrum network.
 
 ▶️ [Latest vGLP Deposit Events](https://ide.bitquery.io/latest-vGLP-Deposit-Events)
 
@@ -2214,7 +2215,7 @@ Returns retrieves the latest vGLP deposits on the Arbitrum network:
 
 #### Latest Arbitrum blocks
 
-The query below retrieves the latest 10 blocks on the Arbitrum network. You can find the query [here
+Retrieves the latest 10 blocks on the Arbitrum network.
 
 ▶️ [Latest Arbitrum blocks](https://ide.bitquery.io/Latest-Arbitrum-blocks)
 
@@ -2342,13 +2343,13 @@ Trade stats for a token pair on uniswap v4 optimism. Uses the `DEXTradeByTokens`
 
 #### Top Traders by PnL of a specific polygon pool
 
-You can run this query [in the Bitquery IDE
+Rank traders by `PnL` on one pool: filter `Pair.Market.Address`, last 30 minutes, `limit: 10`, and `orderBy` `PnL` descending. Useful for leaderboards, smart-money screens, and pool-specific trader analytics.
 
 ▶️ [Top Traders by PnL of a specific polygon pool](https://ide.bitquery.io/Top-Traders-by-PnL-of-a-specific-polygon-pool)
 
 #### Top traders of a token on matic
 
-Returns ranks traders of one token by volume, splitting bought and sold amounts and totalling volume in native and USD terms. `since_relative` keeps the window rolling.
+This query ranks traders of one token by volume, splitting bought and sold amounts and totalling volume in native and USD terms. `since_relative` keeps the window rolling.
 
 ▶️ [Top traders of a token on matic](https://ide.bitquery.io/top-traders-of-a-token-on-matic_1)
 
@@ -2414,7 +2415,7 @@ The number of unique holders, token supply, and Gini coefficient for the balance
 
 #### Top Tokens by Market Cap on Polygon
 
-You can run this query [in the Bitquery IDE
+This query ranks Polygon tokens by `Supply.MarketCap`. Set `Token.Network` to Matic (Polygon’s label in the Trading API). It uses roughly the last 24 hours, 1-second intervals, at least $1,000 USD volume, `limitBy` one row per `Token_Id`, and up to 50 tokens.
 
 ▶️ [Top Tokens by Market Cap on Polygon](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-Polygon_1)
 
@@ -2422,7 +2423,7 @@ You can run this query [in the Bitquery IDE
 
 #### Latest Liquidity Changes of a Specific Pool
 
-Returns retrieves the latest liquidity events for a specific DEX pool on Matic. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
+Retrieves the latest liquidity events for a specific DEX pool on Matic. Use this to check current pool reserves, spot prices, and recent liquidity changes for a particular token pair.
 
 ▶️ [Latest Liquidity Changes of a Specific Pool](https://ide.bitquery.io/Latest-Liquidity-Changes-of-a-Specific-Pool_6)
 
@@ -2436,31 +2437,31 @@ Get virtual pool address for a token on uniswap v4 matic. Uses the `DEXTradeByTo
 
 #### OHLCV on MATIC uniswap v3
 
-Returns retrieves the Open, High, Low, and Close (OHLC) prices in USD for a specific token traded on Uniswap v3 over a defined time period and interval. You can try out the API [here
+Retrieves the Open, High, Low, and Close (OHLC) prices in USD for a specific token traded on Uniswap v3 over a defined time period and interval.
 
 ▶️ [OHLCV on MATIC uniswap v3](https://ide.bitquery.io/OHLCV-on-MATIC-uniswap-v3)
 
 #### Top bought tokens on matic uniswap v3
 
-Returns will fetch you the top bought tokens on uniswap v3. Try out the query [here
+Will fetch the top bought tokens on uniswap v3.
 
 ▶️ [Top bought tokens on matic uniswap v3](https://ide.bitquery.io/top-bought-tokens-on-matic-uniswap-v3_4)
 
 #### Top sold tokens on matic uniswap v3
 
-Returns will fetch you the top bought tokens on uniswap v3. Try out the query [here
+Will fetch the top bought tokens on uniswap v3.
 
 ▶️ [Top sold tokens on matic uniswap v3](https://ide.bitquery.io/top-sold-tokens-on-matic-uniswap-v3)
 
 #### Top traders of a token on uniswapv3 matic
 
-Returns will fetch you top traders of a token for the selected network. You can test the query [here
+Will fetch top traders of a token for the selected network.
 
 ▶️ [Top traders of a token on uniswapv3 matic](https://ide.bitquery.io/top-traders-of-a-token-on-uniswapv3-matic)
 
 #### Trade volume matic uniswapv3
 
-Returns fetches you the traded volume, buy volume and sell volume of a token `0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270`. Try out the API [here
+Fetches the traded volume, buy volume and sell volume of a token `0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270`.
 
 ▶️ [Trade volume matic uniswapv3](https://ide.bitquery.io/trade_volume_matic_uniswapv3)
 
@@ -2494,13 +2495,13 @@ This query returns the latest token trades on the TRON network.
 
 #### All dexs info
 
-Returns fetches you all the DEXs information on Tron network such as unique sellers, unique buyers etc. You can try the query [here
+Fetches all the DEXs information on Tron network such as unique sellers, unique buyers etc.
 
 ▶️ [All dexs info](https://ide.bitquery.io/all-dexs-info)
 
 #### DEX Markets for a token
 
-Returns fetches you the DEXs where a specific token is being traded on Tron network. You can try the query [here
+Fetches the DEXs where a specific token is being traded on Tron network.
 
 ▶️ [DEX Markets for a token](https://ide.bitquery.io/DEX-Markets-for-a-token_1)
 
@@ -2518,13 +2519,13 @@ Browse multi-chain stablecoin DEX prices on DEXrabbit's Stablecoins category.
 
 #### Sunmpump launchtoDEX
 
-Returns allows you to track when tokens are launched on SunSwap using the `launchToDEX` function. It returns the most recent 10 token launches, displaying details such as the token address, transaction hash, block timestamp, and the method call signature.
+This query allows you to track when tokens are launched on SunSwap using the `launchToDEX` function. It returns the most recent 10 token launches, displaying details such as the token address, transaction hash, block timestamp, and the method call signature.
 
 ▶️ [Sunmpump launchtoDEX](https://ide.bitquery.io/sunmpump-launchtoDEX_1)
 
 #### Sunswap v2 latest Trades
 
-The query retrieves details about each trade, including the amounts and prices of tokens bought and sold, as well as information about the trading pair. You can find the query [here
+Retrieves details about each trade, including the amounts and prices of tokens bought and sold, as well as information about the trading pair.
 
 ▶️ [Sunswap v2 latest Trades](https://ide.bitquery.io/sunswap-v2-latest-Trades)
 
@@ -2550,31 +2551,31 @@ Aggregate daily transfer volume in USD for any TRC20 token for analytics dashboa
 
 #### Top transfers of a token
 
-Returns retrieves the top 10 transfers by amount of the token `TXL6rJbvmjD46zeN1JssfgxvSo99qC8MRT`. Try the query [here
+Retrieves the top 10 transfers by amount of the token `TXL6rJbvmjD46zeN1JssfgxvSo99qC8MRT`.
 
 ▶️ [Top transfers of a token](https://ide.bitquery.io/top-transfers-of-a-token_2)
 
 #### Tron total txn fees paid by the Account
 
-Get the total fees (in SOL and USD) paid by a specific Tron account across all transfers. You can test the query [here
+Get the total fees (in SOL and USD) paid by a specific Tron account across all transfers.
 
 ▶️ [Tron total txn fees paid by the Account](https://ide.bitquery.io/Tron-total-txn-fees-paid-by-the-Account)
 
 #### Transfers of a wallet API
 
-Returns fetches you the recent 10 transfers of a specific wallet address `TFXttAWURRrXrd9JvFPVLEh1esJK8NHxn7`. Try the query [here
+Fetches the recent 10 transfers of a specific wallet address `TFXttAWURRrXrd9JvFPVLEh1esJK8NHxn7`.
 
 ▶️ [Transfers of a wallet API](https://ide.bitquery.io/Transfers-of-a-wallet-API)
 
 #### Tron Transaction fees paid by Account aggregated by currency
 
-Get total fees paid by a Tron account for transferring each type of token. You can test the query [here
+Get total fees paid by a Tron account for transferring each type of token.
 
 ▶️ [Tron Transaction fees paid by Account aggregated by currency](https://ide.bitquery.io/Tron-Transaction-fees-paid-by-Account-aggregated-by-currency)
 
 #### Tron wallet transfers with transaction fees paid
 
-Track wallet token transfers and get the fees paid for each by the address. You can test the query [here
+Track wallet token transfers and get the fees paid for each by the address.
 
 ▶️ [Tron wallet transfers with transaction fees paid](https://ide.bitquery.io/tron-wallet-transfers-with-transaction-fees-paid)
 
@@ -2638,7 +2639,7 @@ Calculated as `balance = in_sum - out_sum`
 
 #### Sun Pump Virtual Liquidity Pools
 
-Sun Pump does not use a dedicated pool for each pair; instead, all liquidity is managed within a single contract. You can query the virtual liquidity pools directly by running the following query
+Sun Pump does not use a dedicated pool for each pair; instead, all liquidity is managed within a single contract. You can query the virtual liquidity pools directly by running the following query.
 
 ▶️ [Sun Pump Virtual Liquidity Pools](https://ide.bitquery.io/Sun-Pump-Virtual-Liquidity-Pools_1)
 
@@ -2646,19 +2647,19 @@ Sun Pump does not use a dedicated pool for each pair; instead, all liquidity is 
 
 #### Latest created Sunpump tokens
 
-If you remove `subscription` from the below GraphQL query it will become API, for example check [this api
+If you remove `subscription` from the below GraphQL query it will become API, for example check.
 
 ▶️ [Latest created Sunpump tokens](https://ide.bitquery.io/latest-created-Sunpump-tokens)
 
 #### Latest tokens created on Sunpump
 
-The `Arguments` include the token address, creator, and token index. You can run it [here
+The `Arguments` include the token address, creator, and token index. You can run it.
 
 ▶️ [Latest tokens created on Sunpump](https://ide.bitquery.io/Latest-tokens-created-on-Sunpump_2)
 
 #### TokenPurchased on Sunpump
 
-Returns allows you to track `TokenPurchased` events on SunPump. It retrieves the 10 most recent token purchase events, showing important details such as the token address, buyer information, transaction hash, and token amount involved.
+This query allows you to track `TokenPurchased` events on SunPump. It retrieves the 10 most recent token purchase events, showing important details such as the token address, buyer information, transaction hash, and token amount involved.
 
 ▶️ [TokenPurchased on Sunpump](https://ide.bitquery.io/TokenPurchased-on-Sunpump)
 
@@ -2686,7 +2687,7 @@ The decoded `TokenCreated` event on the two entry contracts is the cleanest laun
 
 #### Pools trade Latest trades for a token
 
-Tokens also migrate onto other venues once liquid — the same token can show `uniswap_v3` and `pancake_swap_v3` markets with `WETH` and `USDG` quotes. :::
+Tokens also migrate onto other venues once liquid — the same token can show `uniswap_v3` and `pancake_swap_v3` markets with `WETH` and `USDG` quotes.
 
 ▶️ [Pools trade Latest trades for a token](https://ide.bitquery.io/Pools-trade-Latest-trades-for-a-token)
 
@@ -2766,13 +2767,13 @@ Robinhood Chain API - Latest Token Transfers. Uses the `Transfers` cube.
 
 #### Robinhood Chain Token Lookup by Contract Address
 
-Metadata splits across two sources. Name, symbol, decimals, and contract are indexed on every transfer's `Currency` object — one query against the launch mint gives you all four for any token:
+Metadata splits across two sources. Name, symbol, decimals, and contract are indexed on every transfer's `Currency` object — one query against the launch mint gives you all four for any token.
 
 ▶️ [Robinhood Chain Token Lookup by Contract Address](https://ide.bitquery.io/Pools-trade-Token-name-symbol-decimals)
 
 #### Token Lookup by Contract Address - Robinhood Chain
 
-Follow the steps here: How to generate Bitquery API token ➤ :::
+Follow the steps here: How to generate Bitquery API token ➤.
 
 ▶️ [Token Lookup by Contract Address - Robinhood Chain](https://ide.bitquery.io/token-lookup-by-address-robinhood-chain)
 
@@ -2806,7 +2807,7 @@ Wallet Token Balances on Robinhood Chain. Uses the `Balances` cube. Replace the 
 
 #### Latest price of a token
 
-If you want to monitor price for a particular pool, we suggest usage of `Trading.Pairs` instead of `Trading.Tokens` where you could specify the pool address. :::
+If you want to monitor price for a particular pool, we suggest usage of `Trading.Pairs` instead of `Trading.Tokens` where you could specify the pool address.
 
 ▶️ [Latest price of a token](https://ide.bitquery.io/latest-price-of-a-token_10)
 
@@ -2848,19 +2849,19 @@ The v4 PoolManager's `Initialize` is decoded, so you can read the same `PoolKey`
 
 #### Daily Active Wallets on Robinhood Chain
 
-Swap the filter to `Block: { Number: { eq: "…" } }` for every log in a block (the `eth_getBlockReceipts` logs, flattened).
+Daily Active Wallets on Robinhood Chain. Uses the `Transactions` cube. Needs the historical data add-on — see the comment at the top of the query.
 
 ▶️ [Daily Active Wallets on Robinhood Chain](https://ide.bitquery.io/robinhood-chain-active-wallets)
 
 #### Robinhood Chain Daily Transaction Count
 
-Swap the filter to `Block: { Number: { eq: "…" } }` for every log in a block (the `eth_getBlockReceipts` logs, flattened).
+Robinhood Chain Daily Transaction Count. Uses the `Transactions` cube. Needs the historical data add-on — see the comment at the top of the query.
 
 ▶️ [Robinhood Chain Daily Transaction Count](https://ide.bitquery.io/robinhood-chain-daily-transactions)
 
 #### Robinhood Chain Gas Usage and Gas Price
 
-Swap the filter to `Block: { Number: { eq: "…" } }` for every log in a block (the `eth_getBlockReceipts` logs, flattened).
+Robinhood Chain Gas Usage and Gas Price. Uses the `Transactions` cube.
 
 ▶️ [Robinhood Chain Gas Usage and Gas Price](https://ide.bitquery.io/robinhood-chain-gas-fees)
 
@@ -2880,7 +2881,7 @@ Filter Flap.sh `TokenCreated` events and decode argument values (token address, 
 
 #### New Contracts Deployed on Robinhood Chain
 
-To pin one exact ABI variant — or to match an undecoded method — filter the 4-byte selector instead (uppercase hex, no `0x`):
+To pin one exact ABI variant — or to match an undecoded method — filter the 4-byte selector instead (uppercase hex, no `0x`)
 
 ▶️ [New Contracts Deployed on Robinhood Chain](https://ide.bitquery.io/new-contracts-deployed-robinhood-chain)
 
@@ -2888,7 +2889,7 @@ To pin one exact ABI variant — or to match an undecoded method — filter the 
 
 #### Robinhood Chain Blocks per Day and Block Time
 
-Swap the filter to `Block: { Number: { eq: "…" } }` for every log in a block (the `eth_getBlockReceipts` logs, flattened).
+Robinhood Chain Blocks per Day and Block Time. Uses the `Blocks` cube. Needs the historical data add-on — see the comment at the top of the query.
 
 ▶️ [Robinhood Chain Blocks per Day and Block Time](https://ide.bitquery.io/robinhood-chain-block-time)
 
@@ -2912,6 +2913,104 @@ Three realtime cubes carry data traders usually have to compute themselves. All 
 
 ▶️ [Uniswap v4 Pool Liquidity on Robinhood Chain (pools.trade)](https://ide.bitquery.io/Pools-trade-Live-pool-liquidity)
 
+## Avalanche
+
+### Trades
+
+#### Latest DEX trades
+
+The most recent DEX trades on Avalanche, with both sides of the pair, the venue and USD value. Add a `baseCurrency` filter to scope it to one token.
+
+▶️ [Latest DEX trades](https://ide.bitquery.io/Avalanche-Latest-DEX-trades)
+
+#### Top DEXs by trade count
+
+Ranks the DEXs on Avalanche by number of trades, so you can see which venues actually carry volume.
+
+▶️ [Top DEXs by trade count](https://ide.bitquery.io/Avalanche-Top-DEXs-by-trade-count)
+
+### Transfers
+
+#### Latest token transfers
+
+Recent token transfers on Avalanche. Add a `currency` filter to follow one token, or a sender/receiver filter to follow one wallet.
+
+▶️ [Latest token transfers](https://ide.bitquery.io/Avalanche-Latest-token-transfers)
+
+### Balances & Holders
+
+#### Balances of an address
+
+Native and token balances held by one Avalanche address. Replace the address to use it.
+
+▶️ [Balances of an address](https://ide.bitquery.io/Avalanche-Balances-of-an-address)
+
+### Transactions
+
+#### Latest transactions
+
+Recent Avalanche transactions with value, gas and sender/receiver. Move `since` in the Variables pane to change the window — a wide window on a busy chain will exceed the query memory limit.
+
+▶️ [Latest transactions](https://ide.bitquery.io/Avalanche-Latest-transactions)
+
+### Events & Calls
+
+#### Latest smart contract events
+
+Decoded event logs on Avalanche. Filter by `smartContractAddress` to watch a single contract.
+
+▶️ [Latest smart contract events](https://ide.bitquery.io/Avalanche-Latest-smart-contract-events)
+
+### Blocks & Validators
+
+#### Latest blocks
+
+The most recent blocks on Avalanche, with height, time, gas used and transaction count.
+
+▶️ [Latest blocks](https://ide.bitquery.io/Avalanche-Latest-blocks_1)
+
+## Celo
+
+### Transfers
+
+#### Latest token transfers
+
+Recent token transfers on Celo. Add a `currency` filter to follow one token, or a sender/receiver filter to follow one wallet.
+
+▶️ [Latest token transfers](https://ide.bitquery.io/Celo-Latest-token-transfers)
+
+### Balances & Holders
+
+#### Balances of an address
+
+Native and token balances held by one Celo address. Replace the address to use it.
+
+▶️ [Balances of an address](https://ide.bitquery.io/Celo-Balances-of-an-address)
+
+### Transactions
+
+#### Latest transactions
+
+Recent Celo transactions with value, gas and sender/receiver. Move `since` in the Variables pane to change the window — a wide window on a busy chain will exceed the query memory limit.
+
+▶️ [Latest transactions](https://ide.bitquery.io/Celo-Latest-transactions)
+
+### Events & Calls
+
+#### Latest smart contract events
+
+Decoded event logs on Celo. Filter by `smartContractAddress` to watch a single contract.
+
+▶️ [Latest smart contract events](https://ide.bitquery.io/Celo-Latest-smart-contract-events)
+
+### Blocks & Validators
+
+#### Latest blocks
+
+The most recent blocks on Celo, with height, time, gas used and transaction count.
+
+▶️ [Latest blocks](https://ide.bitquery.io/Celo-Latest-blocks)
+
 ## Bitcoin
 
 ### Transfers
@@ -2932,7 +3031,7 @@ This query calculates the combined balance of multiple Bitcoin wallet addresses 
 
 #### BTC balance api for multiple addresses
 
-Pass an array of addresses to `inputAddress` and `outputAddress` with `{in: [...]}` to get per-wallet totals in a single request. Useful for exchanges, custodians, and portfolio dashboards that monitor many wallets at once. [Run query
+Pass an array of addresses to `inputAddress` and `outputAddress` with `{in: [...]}` to get per-wallet totals in a single request. Useful for exchanges, custodians, and portfolio dashboards that monitor many wallets at once.
 
 ▶️ [BTC balance api for multiple addresses](https://ide.bitquery.io/BTC-balance-API-for-multiple-addresses)
 
@@ -2950,7 +3049,7 @@ Need to know what a wallet held at a particular point in time? The `height` filt
 
 #### Bitcoin balance on a given block height
 
-Sum outputs and subtract inputs with a `height: {lteq: N}` cap to get the wallet's balance at a specific point on-chain. Useful for audits, tax snapshots, and point-in-time portfolio reporting. [Run query
+Sum outputs and subtract inputs with a `height: {lteq: N}` cap to get the wallet's balance at a specific point on-chain. Useful for audits, tax snapshots, and point-in-time portfolio reporting.
 
 ▶️ [Bitcoin balance on a given block height](https://ide.bitquery.io/bitcoin-balance-on-a-given-block-height)
 
@@ -2958,7 +3057,7 @@ Sum outputs and subtract inputs with a `height: {lteq: N}` cap to get the wallet
 
 #### Btc price in 2016
 
-Pulls the BTC/USD price implied by any output on a given date — Bitquery stores the spot value at the time of each transaction, so you can derive a historical price by dividing USD value by BTC value. [Run query
+Pulls the BTC/USD price implied by any output on a given date — Bitquery stores the spot value at the time of each transaction, so you can derive a historical price by dividing USD value by BTC value.
 
 ▶️ [Btc price in 2016](https://ide.bitquery.io/btc-price-in-2016)
 
@@ -2980,13 +3079,13 @@ Mining rewards live in coinbase outputs (the first transaction in every block, `
 
 #### Get miners activity in a specific timeframe
 
-Pulls the activity count per miner address inside a date range. Drop or extend the date window to size the cohort however you need. [Run query
+Pulls the activity count per miner address inside a date range. Drop or extend the date window to size the cohort however you need.
 
 ▶️ [Get miners activity in a specific timeframe](https://ide.bitquery.io/get-miners-activity-in-a-specific-timeframe)
 
 #### Get miners first activity
 
-For a specific set of miner addresses, this query returns the first block each one mined. Useful for cohort analysis, miner onboarding studies, or building "first seen" timelines. [Run query
+For a specific set of miner addresses, this query returns the first block each one mined. Useful for cohort analysis, miner onboarding studies, or building "first seen" timelines.
 
 ▶️ [Get miners first activity](https://ide.bitquery.io/get-miners-first-activity)
 
@@ -3220,52 +3319,6 @@ The most recent blocks on Zcash, with height, time, transaction count and size.
 
 ▶️ [Latest blocks](https://ide.bitquery.io/Zcash-Latest-blocks)
 
-## Bitcoin SV
-
-### Transfers
-
-#### Largest transfers in the last 24 hours
-
-The biggest Bitcoin SV outputs of the past day, ranked by value — a quick way to spot whale movement. Change the `since` date to widen the window.
-
-▶️ [Largest transfers in the last 24 hours](https://ide.bitquery.io/Bitcoin-SV-Largest-transfers-in-the-last-24-hours)
-
-### Balances & Holders
-
-#### Total received by an address
-
-Sums everything an address has ever received on Bitcoin SV, with a first-and-last-seen window. Replace the address to use it.
-
-▶️ [Total received by an address](https://ide.bitquery.io/Bitcoin-SV-Total-received-by-an-address)
-
-#### Total sent from an address
-
-Sums everything an address has ever spent on Bitcoin SV. Subtract this from total received to get the current balance.
-
-▶️ [Total sent from an address](https://ide.bitquery.io/Bitcoin-SV-Total-sent-from-an-address)
-
-#### Address activity summary
-
-First seen, last seen, and lifetime in/out totals for one Bitcoin SV address in a single request.
-
-▶️ [Address activity summary](https://ide.bitquery.io/Bitcoin-SV-Address-activity-summary)
-
-### Transactions
-
-#### Latest transactions
-
-The most recent transactions on Bitcoin SV, with value, fee and input/output counts. Raise the limit to page further back.
-
-▶️ [Latest transactions](https://ide.bitquery.io/Bitcoin-SV-Latest-transactions)
-
-### Blocks & Validators
-
-#### Latest blocks
-
-The most recent blocks on Bitcoin SV, with height, time, transaction count and size.
-
-▶️ [Latest blocks](https://ide.bitquery.io/Bitcoin-SV-Latest-blocks)
-
 ## Cardano
 
 ### Trades
@@ -3338,13 +3391,13 @@ This query uses transaction hash and date range as filter to fetch tx details.
 
 #### All the transfers of an asset on Algorand Mainnet in a specific timeframe
 
-Returns transfers for asset ID `31566704` between two dates, ordered by block height descending. Swap the `currency` filter for any ASA ID or ALGO. [Run query
+Returns transfers for asset ID `31566704` between two dates, ordered by block height descending. Swap the `currency` filter for any ASA ID or ALGO.
 
 ▶️ [All the transfers of an asset on Algorand Mainnet in a specific timeframe](https://ide.bitquery.io/All-the-transfers-of-an-asset-on-Algorand-Mainnet-in-a-specific-timeframe)
 
 #### Traansfers where a currency is sent from or sent to a particular address
 
-Uses the `any` filter to match transfers where the address appears as either sender or receiver. [Run query
+Uses the `any` filter to match transfers where the address appears as either sender or receiver.
 
 ▶️ [Traansfers where a currency is sent from or sent to a particular address](https://ide.bitquery.io/traansfers-where-a-currency-is-sent-from-or-sent-to-a-particular-address)
 
@@ -3352,7 +3405,7 @@ Uses the `any` filter to match transfers where the address appears as either sen
 
 #### Get Count of Smart Contract Calls in Latest Block
 
-Returns the count of unique smart contract calls in the most recent block after a given date. [Run query
+Returns the count of unique smart contract calls in the most recent block after a given date.
 
 ▶️ [Get Count of Smart Contract Calls in Latest Block](https://ide.bitquery.io/Get-Count-of-Smart-Contract-Calls-in-Latest-Block_1)
 
@@ -3360,19 +3413,19 @@ Returns the count of unique smart contract calls in the most recent block after 
 
 #### All Transactions on Algorand
 
-Paginated query for all transactions in a specific window. [Run query
+Paginated query for all transactions in a specific window.
 
 ▶️ [All Transactions on Algorand](https://ide.bitquery.io/All-Transactions-on-Algorand)
 
 #### Daily Transaction Count for last 10 days
 
-Returns the number of transactions per day over the last 10 days, ordered by date descending. [Run query
+Returns the number of transactions per day over the last 10 days, ordered by date descending.
 
 ▶️ [Daily Transaction Count for last 10 days](https://ide.bitquery.io/Daily-Transaction-Count-for-last-10-days)
 
 #### Daily Unique Txn Senders on algorand
 
-Counts distinct transaction senders on a specific date. [Run query
+Counts distinct transaction senders on a specific date.
 
 ▶️ [Daily Unique Txn Senders on algorand](https://ide.bitquery.io/Daily-Unique-Txn-Senders-on-algorand)
 
@@ -3382,61 +3435,61 @@ Counts distinct transaction senders on a specific date. [Run query
 
 #### Average fee per trade, Total fees, total volume, trades count per DEX program
 
-You can run this query [in the Bitquery IDE
+Average fee per trade, Total fees, total volume, trades count per DEX program. Uses the `Trades` cube.
 
 ▶️ [Average fee per trade, Total fees, total volume, trades count per DEX program](https://ide.bitquery.io/Average-fee-per-trade-Total-fees-total-volume-trades-count-per-DEX-program)
 
 #### Last 10 WSOL USDC Token pair trades
 
-You can run this query [in the Bitquery IDE
+Last 10 WSOL USDC Token pair trades. Uses the `Trades` cube.
 
 ▶️ [Last 10 WSOL USDC Token pair trades](https://ide.bitquery.io/Last-10-WSOL-USDC-Token-pair-trades)
 
 #### Most active market pools by trades
 
-You can run this query [in the Bitquery IDE
+Most active market pools by trades. Uses the `Trades` cube.
 
 ▶️ [Most active market pools by trades](https://ide.bitquery.io/Most-active-market-pools-by-trades)
 
 #### Most active traders by trade count
 
-You can run this query [in the Bitquery IDE
+Most active traders by trade count. Uses the `Trades` cube.
 
 ▶️ [Most active traders by trade count](https://ide.bitquery.io/Most-active-traders-by-trade-count)
 
 #### Most traded token in last 1 hour on solana and it's average trade amount and total volume
 
-You can run this query [in the Bitquery IDE
+Most traded token in last 1 hour on solana and it's average trade amount and total volume. Uses the `Trades` cube.
 
 ▶️ [Most traded token in last 1 hour on solana and it's average trade amount and total volume](https://ide.bitquery.io/Most-traded-token-in-last-1-hour-on-solana-and-its-average-trade-amount-and-total-volume)
 
 #### Net flow (buys - sells) per token symbol
 
-You can run this query [in the Bitquery IDE
+Net flow (buys - sells) per token symbol. Uses the `Trades` cube.
 
 ▶️ [Net flow (buys - sells) per token symbol](https://ide.bitquery.io/Net-flow-buys---sells-per-token-symbol_2)
 
 #### Tokens with highest trade frequency
 
-You can run this query [in the Bitquery IDE
+Tokens with highest trade frequency. Uses the `Trades` cube.
 
 ▶️ [Tokens with highest trade frequency](https://ide.bitquery.io/Tokens-with-highest-trade-frequency)
 
 #### Tokens with most unique buyers
 
-You can run this query [in the Bitquery IDE
+Tokens with most unique buyers. Uses the `Trades` cube.
 
 ▶️ [Tokens with most unique buyers](https://ide.bitquery.io/Tokens-with-most-unique-buyers)
 
 #### Top Traders on Solana
 
-You can run this query [in the Bitquery IDE
+Top Traders on Solana. Uses the `Trades` cube.
 
 ▶️ [Top Traders on Solana](https://ide.bitquery.io/Top-Traders-on-Solana_2)
 
 #### Total SOL fees, Total Volume, Total count trades
 
-You can run this query [in the Bitquery IDE
+Total SOL fees, Total Volume, Total count trades. Uses the `Trades` cube.
 
 ▶️ [Total SOL fees, Total Volume, Total count trades](https://ide.bitquery.io/Total-SOL-fees-Total-Volume-Total-count-trades)
 
@@ -3450,7 +3503,7 @@ Recent Bitcoin OHLC using the Crypto Price API (time range in the query matches 
 
 #### OHLC of a currency on multiple blockchains
 
-Stream real-time Bitcoin OHLC data aggregated from all supported blockchains (Bitcoin, Ethereum WBTC, Solana, etc.) with 60-second intervals:
+Stream real-time Bitcoin OHLC data aggregated from all supported blockchains (Bitcoin, Ethereum WBTC, Solana, etc.) with 60-second intervals.
 
 ▶️ [OHLC of a currency on multiple blockchains](https://ide.bitquery.io/OHLC-of-a-currency-on-multiple-blockchains)
 
@@ -3464,7 +3517,7 @@ Set token address and read `Supply.MarketCap` from the query below. See the Supp
 
 #### Tokens ranked by market cap
 
-You can run this query [in the Bitquery IDE
+Tokens ranked by market cap. Uses the `Trades` cube.
 
 ▶️ [Tokens ranked by market cap](https://ide.bitquery.io/Tokens-ranked-by-market-cap_1)
 
@@ -3474,7 +3527,7 @@ You can run this query [in the Bitquery IDE
 
 #### Solana USDT trades query
 
-Returns is to track USDT trading activity on Solana.
+Below example is to track USDT trading activity on Solana.
 
 ▶️ [Solana USDT trades query](https://ide.bitquery.io/solana-USDT-trades-query)
 
@@ -3500,19 +3553,19 @@ Listen to stablecoin payments across all major blockchains. The Mempool option l
 
 #### Stablecoin Transfers from/to an address
 
-Returns will give you `EURC` transfers from/to `cHxJ2uC6vgcCfoFSfupkfCWbKHAkekrGfG39DXRamXT` on Solana. Test the query [here
+Below query will give you `EURC` transfers from/to `cHxJ2uC6vgcCfoFSfupkfCWbKHAkekrGfG39DXRamXT` on Solana.
 
 ▶️ [Stablecoin Transfers from/to an address](https://ide.bitquery.io/stablecoin-Transfers-fromto-an-address)
 
 #### Stablecoin recieved and sent by an address
 
-Returns will give you `USDT` transfers from/to `TUTQj7VJ1QjR3t2GJByvrP25yZNFcj38VJ` on Tron. Test the query [here
+Below query will give you `USDT` transfers from/to `TUTQj7VJ1QjR3t2GJByvrP25yZNFcj38VJ` on Tron.
 
 ▶️ [Stablecoin recieved and sent by an address](https://ide.bitquery.io/Stablecoin-recieved-and-sent-by-an-address)
 
 #### USDT Stablecoin reserves on Ethereum
 
-Below API query will give you realtime reserves data of `USDT` on Ethereum. Test the API [here
+Below API query will give you realtime reserves data of `USDT` on Ethereum.
 
 ▶️ [USDT Stablecoin reserves on Ethereum](https://ide.bitquery.io/USDT-Stablecoin-reserves-on-Ethereum)
 
@@ -3524,7 +3577,7 @@ This GraphQL stream provides live USDT and USDC stablecoin transfers on Solana.
 
 #### USDT token Transfers api on solana
 
-Track live USDT stablecoin transfers. USDT is ideal for payments, settlements, etc and you can track those in real-time using this API/Stream -
+Track live USDT stablecoin transfers. USDT is ideal for payments, settlements, etc and you can track those in real-time using this API/Stream -.
 
 ▶️ [USDT token Transfers api on solana](https://ide.bitquery.io/USDT-token-Transfers-api-on-solana)
 
@@ -3544,7 +3597,7 @@ Get real-time and historical USDT prices, OHLCV, and moving averages across supp
 
 #### Usdt latest price arbitrage
 
-Returns compares USDT prices across different blockchain networks in real-time. It fetches the latest price data for USDT from different networks, showing you where the same stablecoin trades at different prices.
+This query compares USDT prices across different blockchain networks in real-time. It fetches the latest price data for USDT from different networks, showing you where the same stablecoin trades at different prices.
 
 ▶️ [Usdt latest price arbitrage](https://ide.bitquery.io/usdt-latest-price-arbitrage)
 
@@ -3552,7 +3605,7 @@ Returns compares USDT prices across different blockchain networks in real-time. 
 
 #### USDC Stablecoin reserves on Solana
 
-Below API query will give you realtime reserves data of `USDC` on Solana. Test the API [here
+Below API query will give you realtime reserves data of `USDC` on Solana.
 
 ▶️ [USDC Stablecoin reserves on Solana](https://ide.bitquery.io/USDC-Stablecoin-reserves-on-Solana)
 
@@ -3568,37 +3621,37 @@ Monitor USDT reserve or get lateast reserve value on Solana using below Stream/A
 
 #### Hyperliquid BTC Perp Trades
 
-Run it in the IDE: [Hyperliquid BTC Perp Trades ➤
+Hyperliquid BTC Perp Trades. Uses the `Trades` cube.
 
 ▶️ [Hyperliquid BTC Perp Trades](https://ide.bitquery.io/hyperliquid-btc-perp-trades)
 
 #### Hyperliquid Latest Trades (Perps + Spot + HIP-3)
 
-Run it in the IDE: [Hyperliquid Latest Trades ➤
+Each fill carries the execution (price, size, side, aggressor flag), the position it changed (leverage, margin mode, size before, realized PnL) and fees. `Direction` is one of `Open Long`, `Open Short`, `Close Long`, `Close Short`.
 
 ▶️ [Hyperliquid Latest Trades (Perps + Spot + HIP-3)](https://ide.bitquery.io/hyperliquid-latest-trades)
 
 #### Hyperliquid Trader Leverage Updates
 
-Run it in the IDE: [Hyperliquid Leverage Updates ➤
+Hyperliquid Trader Leverage Updates.
 
 ▶️ [Hyperliquid Trader Leverage Updates](https://ide.bitquery.io/hyperliquid-leverage-updates)
 
 #### Phoenix Perps Fills by Trader Wallet - Solana
 
-You can run the wallet-fills version [in the Bitquery IDE
+Stream every stop-loss and take-profit placement as it happens.
 
 ▶️ [Phoenix Perps Fills by Trader Wallet - Solana](https://ide.bitquery.io/sol_perps_filled_orders_by_signer)
 
 #### Trader Realized PnL on Solana Perps
 
-You can run this query [in the Bitquery IDE
+Rows with `Size: 0` are markets they've fully closed — drop them and the rest is the live book, with entry prices.
 
 ▶️ [Trader Realized PnL on Solana Perps](https://ide.bitquery.io/solana-perps-trader-pnl)
 
 #### Whale Trades on Solana Perps (Phoenix)
 
-You can run the query version [in the Bitquery IDE
+Positive = received, negative = paid. Replace the field list with `total: sum(of: Position_Funding)` for the net carry cost of holding their positions.
 
 ▶️ [Whale Trades on Solana Perps (Phoenix)](https://ide.bitquery.io/solana-perps-whale-trades)
 
@@ -3606,19 +3659,19 @@ You can run the query version [in the Bitquery IDE
 
 #### Hyperliquid BTC OHLCV Candles (1 minute)
 
-Run it in the IDE: [Hyperliquid BTC OHLCV Candles ➤
+The `Candles` cube provides OHLCV per market and interval. `Interval.Time.Duration` is the candle length in seconds (e.g. `60` for one minute), `Start` the interval open time. OHLCV values are floats.
 
 ▶️ [Hyperliquid BTC OHLCV Candles (1 minute)](https://ide.bitquery.io/hyperliquid-btc-ohlcv-candles)
 
 #### Hyperliquid Mark Prices (All Markets)
 
-Run it in the IDE: [Hyperliquid Mark Prices ➤
+Follow the steps here: How to generate Bitquery API token ➤.
 
 ▶️ [Hyperliquid Mark Prices (All Markets)](https://ide.bitquery.io/hyperliquid-mark-prices)
 
 #### Solana Perps OHLC Candles from Mark Price
 
-You can run this query [in the Bitquery IDE
+As a `query`, add `orderBy: { descending: Block_Time }` and a `limit` for the recent whale prints.
 
 ▶️ [Solana Perps OHLC Candles from Mark Price](https://ide.bitquery.io/solana-perps-ohlc-candles)
 
@@ -3664,13 +3717,13 @@ Latests OpenSea Trades.
 
 #### Latest NFT trades on Ethereum network
 
-Returns retrieves the latest NFT Trades on Ethereum for Seaport v1.4 protocol. Many marketplaces utilize the Seaport protocol, we can add a Smart contract in Trade → Dex → SmartContract to get a specific marketplace for this protocol.
+Retrieves the latest NFT Trades on Ethereum for Seaport v1.4 protocol. Many marketplaces utilize the Seaport protocol, we can add a Smart contract in Trade → Dex → SmartContract to get a specific marketplace for this protocol.
 
 ▶️ [Latest NFT trades on Ethereum network](https://ide.bitquery.io/latest-NFT-trades-on-Ethereum-network)
 
 #### Pairs of blur token new dataset
 
-Open the above query on GraphQL IDE using this [link
+Open the above query on GraphQL IDE using this.
 
 ▶️ [Pairs of blur token new dataset](https://ide.bitquery.io/pairs-of-blur-token-new-dataset_1)
 
@@ -3682,7 +3735,7 @@ Position NFTs as they are minted — who is adding liquidity to v3 pools, and to
 
 #### NFT currencies on Solana by DEX'es
 
-The subscription query provided fetches the most-traded NFTs in the last few hours. For Solana, only realtime information is available, so the aggregate might not be accurate beyond a few hours. You can find the query [here
+The subscription query provided fetches the most-traded NFTs in the last few hours. For Solana, only realtime information is available, so the aggregate might not be accurate beyond a few hours.
 
 ▶️ [NFT currencies on Solana by DEX'es](https://ide.bitquery.io/NFT-currencies-on-Solana-by-DEXes_1)
 
@@ -3696,7 +3749,7 @@ Get transfers of NFTs given the wallet.
 
 #### All transfers of an NFT
 
-Returns retrieves the most recent transfers of a specific non-fungible token (NFT) on the Ethereum network. You can find the GraphQL query [here
+Retrieves the most recent transfers of a specific non-fungible token (NFT) on the Ethereum network. You can find the GraphQL query.
 
 ▶️ [All transfers of an NFT](https://ide.bitquery.io/All-transfers-of-an-NFT)
 
@@ -3708,19 +3761,19 @@ NFT Token Transfers By Date.
 
 #### Top transfered NFT tokens in network
 
-Returns fetches the most frequently transferred NFTs on the Ethereum Blockchain within the specified date range.
+Fetches the most frequently transferred NFTs on the Ethereum Blockchain within the specified date range.
 
 ▶️ [Top transfered NFT tokens in network](https://ide.bitquery.io/Top-transfered-NFT-tokens-in-network)
 
 #### Array_intersect example for NFT
 
-Read more about using `array_intersect` here
+Array_intersect example for NFT.
 
 ▶️ [Array_intersect example for NFT](https://ide.bitquery.io/array_intersect-example-for-NFT)
 
 #### Get all transfers of a specific nft
 
-This below query will give you all the transfers of a particular NFT `0xb68CA010776B4584cf49893E75b66583eb884948`.
+Will give all the transfers of a particular NFT `0xb68CA010776B4584cf49893E75b66583eb884948`.
 
 ▶️ [Get all transfers of a specific nft](https://ide.bitquery.io/get-all-transfers-of-a-specific-nft)
 
@@ -3746,13 +3799,13 @@ Check the current owner of a specific NFT token ID. This query returns ownership
 
 #### Get NFT Balances for Multiple Addresses
 
-Get NFT balances for multiple addresses in a single query. Useful for portfolio tracking or wallet monitoring applications. Try the API [here
+Get NFT balances for multiple addresses in a single query. Useful for portfolio tracking or wallet monitoring applications.
 
 ▶️ [Get NFT Balances for Multiple Addresses](https://ide.bitquery.io/Get-NFT-Balances-for-Multiple-Addresses_1)
 
 #### Get NFT Ownership History
 
-Retrieve the NFT ownership history of a specific NFT over a specific time period. This helps track NFT transfers and ownership changes. Try the API [here
+Retrieve the NFT ownership history of a specific NFT over a specific time period. This helps track NFT transfers and ownership changes.
 
 ▶️ [Get NFT Ownership History](https://ide.bitquery.io/Get-NFT-Ownership-History_2)
 
@@ -3768,13 +3821,13 @@ Smart contract calls to an nft contract.
 
 #### All refinance loans for specific NFT collection
 
-To retrieve all refinance loans for a specific NFT collection, we filter Refinance event arguments in [this
+To retrieve all refinance loans for a specific NFT collection, we filter Refinance event arguments in.
 
 ▶️ [All refinance loans for specific NFT collection](https://ide.bitquery.io/All-refinance-loans-for-specificNFT-collection)
 
 #### Auction on blur marketplace
 
-The 'StartAuction' event is triggered when an NFT auction starts on the Blur : Blend Contract. The following [query
+The 'StartAuction' event is triggered when an NFT auction starts on the Blur : Blend Contract. The following.
 
 ▶️ [Auction on blur marketplace](https://ide.bitquery.io/Auction-on-blur-marketplace)
 
@@ -3786,7 +3839,7 @@ Creator_of_an_NFT.
 
 #### Latest Cancelled offers on Blur NFT marketplace
 
-On the BLUR market, the 'OfferCancelled' event initiates when an offer is withdrawn or cancelled. The following [query
+On the BLUR market, the 'OfferCancelled' event initiates when an offer is withdrawn or cancelled. The following.
 
 ▶️ [Latest Cancelled offers on Blur NFT marketplace](https://ide.bitquery.io/Latest-Cancelled-offers-on-Blur-NFT-marketplace)
 
@@ -3798,7 +3851,7 @@ Same as previous queries, this query will return details about the block, transa
 
 #### Latest Seized NFTs on Blur marketplace
 
-When a seizure event happens, control of the NFT shifts to the lender or an enforcing third party. The [query
+When a seizure event happens, control of the NFT shifts to the lender or an enforcing third party. The.
 
 ▶️ [Latest Seized NFTs on Blur marketplace](https://ide.bitquery.io/Latest-Seized-NFTs-on-Blur-marketplace)
 
@@ -3816,19 +3869,19 @@ Loan history for specific NFT ID.
 
 #### Loan repayment of blur marketplace
 
-For loan repayment transactions on the BLUR market, use the [following
+For loan repayment transactions on the BLUR market, use the.
 
 ▶️ [Loan repayment of blur marketplace](https://ide.bitquery.io/Loan-repayment-of-blur-marketplace)
 
 #### Loans above a specific amount on the Blur NFT marketplace
 
-If we want to track loans above a specific amount on the Blur marketplace, we can use the following [query
+If we want to track loans above a specific amount on the Blur marketplace, we can use the following.
 
 ▶️ [Loans above a specific amount on the Blur NFT marketplace](https://ide.bitquery.io/Loans-above-a-specific-amount-on-the-Blur-NFT-marketplace)
 
 #### Locked NFT bought on Blur marketplace
 
-Locked NFTs are temporarily non-transferrable and can be traded or transferred after the lock period. These NFTs are often cheaper than non-locked. The following [query
+Locked NFTs are temporarily non-transferrable and can be traded or transferred after the lock period. These NFTs are often cheaper than non-locked. The following.
 
 ▶️ [Locked NFT bought on Blur marketplace](https://ide.bitquery.io/Locked-NFT-bought-on-Blur-marketplace)
 
@@ -3892,7 +3945,7 @@ Returns AI markets (title includes the standalone word " AI ") ranked by USD tra
 
 #### Top Buyers/Sellers of Bitcoin up down market
 
-Returns returns the top 10 buyers and top 10 sellers by traded volume in Bitcoin Up or Down markets on Polymarket over the last 24 hours. Results are aggregated by trader address and ordered by `buy_amount` (buyers) or `sell_amount` (sellers).
+Returns the top 10 buyers and top 10 sellers by traded volume in Bitcoin Up or Down markets on Polymarket over the last 24 hours. Results are aggregated by trader address and ordered by `buy_amount` (buyers) or `sell_amount` (sellers).
 
 ▶️ [Top Buyers/Sellers of Bitcoin up down market](https://ide.bitquery.io/Top-BuyersSellers-of-Bitcoin-up-down-market)
 
@@ -4076,7 +4129,7 @@ Returns OHLC (Open, High, Low, Close) in USD for one outcome of a Gold market, b
 
 #### Polymarket AI odds movement OHLC
 
-Returns OHLC (Open, High, Low, Close) in USD for one outcome of an AI market, bucketed by interval (here 5 minutes). It shows how the implied probability moved over time, and powers charts and backtests. Replace `"<MARKET_ID>"` and `"<OUTCOME_LABEL>"` (e.g.
+Returns OHLC (Open, High, Low, Close) in USD for one outcome of an AI market, bucketed by interval (here 5 minutes). It shows how the implied probability moved over time, and powers charts and backtests. Replace `"<MARKET_ID>"` and `"<OUTCOME_LABEL>"`
 
 ▶️ [Polymarket AI odds movement OHLC](https://ide.bitquery.io/Polymarket-AI-odds-movement-OHLC)
 
@@ -4124,13 +4177,13 @@ AsterDEX - OpenMarketTrade. Uses the `Events` cube. Replace the address in the `
 
 #### Trader's specific event
 
-You can look for `Transaction -> From` or in some cases the address might be in arguments, for example: [Traders specific event
+You can look for `Transaction -> From` or in some cases the address might be in arguments, for example.
 
 ▶️ [Trader's specific event](https://ide.bitquery.io/Traders-specific-event)
 
 #### Traders data - 0x01554d63537d3c62715826a268d4eab645d64b92
 
-You can actually merge these two queries. Here is an example: [Combined Traders data - 0x01554d63537d3c62715826a268d4eab645d64b92
+You can actually merge these two queries. Here is an example.
 
 ▶️ [Traders data - 0x01554d63537d3c62715826a268d4eab645d64b92](https://ide.bitquery.io/Copy-of-Traders-data---0x01554d63537d3c62715826a268d4eab645d64b92)
 

--- a/docs/start/starter-subscriptions.md
+++ b/docs/start/starter-subscriptions.md
@@ -712,44 +712,6 @@ We will use this subscription to listen to `consumeEvents` transactions on OpenB
 
 ▶️ [ConsumeEvents instruction on OpenBook V2](https://ide.bitquery.io/consumeEvents-instruction-on-OpenBook-V2_3)
 
-### Pump.fun
-
-#### PumpFun Token Creation
-
-This subscription tracks in real-time newly created Pumpfun tokens, including their metadata and associated developer addresses.
-
-▶️ [PumpFun Token Creation](https://ide.bitquery.io/newly-created-PF-token-developer-address-metadata)
-
-#### PumpFun Trades Stream
-
-This stream returns the real time trades on Pumpfun platform. This stream could be modified to get real time trades for a particular token or trades by a particular trader.
-
-▶️ [PumpFun Trades Stream](https://ide.bitquery.io/Pumpfun-DEX-Trades_1)
-
-#### Pumpswap Trades Stream
-
-This stream returns the real time trades on Pumpswap exchange. This stream could be modified to get real time trades for a particular token or trades by a particular trader.
-
-▶️ [Pumpswap Trades Stream](https://ide.bitquery.io/pumpswap-trades)
-
-#### Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply
-
-Stream all PumpFun DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.ProtocolFamily: Pumpfun` to capture every swap across Pumpfun in a single subscription.
-
-▶️ [Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Pumpfun-With-Price-Market-Cap-and-Supply)
-
-#### Latest Trades for a token on Pumpswap
-
-Subscribe to `DEXTradeByTokens` with PumpSwap `ProgramAddress` and the token mint. Each update is a new trade involving that token on PumpSwap—use this to stream per-token activity without polling.
-
-▶️ [Latest Trades for a token on Pumpswap](https://ide.bitquery.io/Latest-Trades-for-a-token-on-Pumpswap)
-
-#### Price of a pump fun token using price index in usd
-
-Live stream of token price updates on Pump.fun.
-
-▶️ [Price of a pump fun token using price index in usd](https://ide.bitquery.io/Price-of-a-pump-fun-token-using-price-index-in-usd)
-
 ### Raydium
 
 #### Latest Pools Created on Raydium
@@ -793,6 +755,44 @@ This stream gives info about the real time liquidity pool creation on Raydium ex
 Returns Raydium Launchpad tokens which have more than 95% bonding curve progress.
 
 ▶️ [Track Raydium Launchpad tokens above 95% Bonding Curve Progress in realtime](https://ide.bitquery.io/LetsBonkfun-Tokens-between-95-and-100-bonding-curve-progress_2)
+
+### Pump.fun
+
+#### PumpFun Token Creation
+
+This subscription tracks in real-time newly created Pumpfun tokens, including their metadata and associated developer addresses.
+
+▶️ [PumpFun Token Creation](https://ide.bitquery.io/newly-created-PF-token-developer-address-metadata)
+
+#### PumpFun Trades Stream
+
+This stream returns the real time trades on Pumpfun platform. This stream could be modified to get real time trades for a particular token or trades by a particular trader.
+
+▶️ [PumpFun Trades Stream](https://ide.bitquery.io/Pumpfun-DEX-Trades_1)
+
+#### Pumpswap Trades Stream
+
+This stream returns the real time trades on Pumpswap exchange. This stream could be modified to get real time trades for a particular token or trades by a particular trader.
+
+▶️ [Pumpswap Trades Stream](https://ide.bitquery.io/pumpswap-trades)
+
+#### Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply
+
+Stream all PumpFun DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.ProtocolFamily: Pumpfun` to capture every swap across Pumpfun in a single subscription.
+
+▶️ [Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Pumpfun-With-Price-Market-Cap-and-Supply)
+
+#### Latest Trades for a token on Pumpswap
+
+Subscribe to `DEXTradeByTokens` with PumpSwap `ProgramAddress` and the token mint. Each update is a new trade involving that token on PumpSwap—use this to stream per-token activity without polling.
+
+▶️ [Latest Trades for a token on Pumpswap](https://ide.bitquery.io/Latest-Trades-for-a-token-on-Pumpswap)
+
+#### Price of a pump fun token using price index in usd
+
+Live stream of token price updates on Pump.fun.
+
+▶️ [Price of a pump fun token using price index in usd](https://ide.bitquery.io/Price-of-a-pump-fun-token-using-price-index-in-usd)
 
 ### Meteora
 
@@ -2032,19 +2032,19 @@ Track token activity (OHLC, price, volume) every 1 second on FourMeme DEX (BSC).
 
 #### PumpAMM 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders
 
-Real-time (1-second interval) price, OHLC, volume, and moving averages for Pump.fun AMM tokens on Solana. Useful for high-frequency trading bots.
+PumpAMM 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders. Uses the `Pairs` cube.
 
 ▶️ [PumpAMM 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders](https://ide.bitquery.io/PumpAMM-tokens-1-second-price-stream-with-OHLC_1)
 
 #### Raydium Launchlab 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders
 
-Monitor Raydium Launchlab token listings on Solana with 1-second OHLC and volume streams. Perfect for tracking new token launches.
+Raydium Launchlab 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders. Uses the `Pairs` cube.
 
 ▶️ [Raydium Launchlab 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders](https://ide.bitquery.io/Raydium-Launchpad-DEX-tokens-1-second-price-stream-with-OHLC)
 
 #### 5 minute price change api on solana
 
-Stream the top 10 tokens on Solana by 5-minute price change (in USD), filtered by $100k+ volume. Updates continuously.
+5 minute price change api on solana. Uses the `Tokens` cube.
 
 ▶️ [5 minute price change api on solana](https://ide.bitquery.io/5-minute-price-change-api-on-solana_6)
 
@@ -2062,13 +2062,13 @@ Real-time (1s) stream of prices, OHLC, and volumes for tokens traded on Heaven D
 
 #### Meteora DBC DEX tokens 1 second price stream with OHLC
 
-Real-time (1s) OHLC, price, and volume feed for Meteora DBC DEX on Solana.
+Meteora DBC DEX tokens 1 second price stream with OHLC. Uses the `Pairs` cube.
 
 ▶️ [Meteora DBC DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/Meteora-DBC-DEX-tokens-1-second-price-stream-with-OHLC)
 
 #### Real Time USD price on solana chain
 
-Stream live OHLC (Open, High, Low, Close) price and volume data for all tokens on Solana, quoted directly in USD. Useful for dashboards, analytics, or bots that need stable fiat-based prices.
+Real Time USD price on solana chain. Uses the `Pairs` cube.
 
 ▶️ [Real Time USD price on solana chain](https://ide.bitquery.io/Real-Time-USD-price-on-solana-chain_2)
 
@@ -2093,26 +2093,6 @@ Subscribe to `Solana.DEXPools` with Raydium’s program and positive base change
 Use the same Raydium program filter with negative `ChangeAmount` on the base side to stream liquidity withdrawals.
 
 ▶️ [Liquidity removal for radium](https://ide.bitquery.io/liquidity-removal-for-radium_1)
-
-### Pump.fun
-
-#### All Pumpswap Trade Stream
-
-All Pumpswap Trade Stream. Uses the `Trades` cube.
-
-▶️ [All Pumpswap Trade Stream](https://ide.bitquery.io/All-Pumpswap-Trade-Stream)
-
-#### All pumpfun Trade Stream
-
-All pumpfun Trade Stream. Uses the `Trades` cube.
-
-▶️ [All pumpfun Trade Stream](https://ide.bitquery.io/All-pumpfun-Trade-Stream_2)
-
-#### Pump fun token live prices using trades api
-
-Pump fun token live prices using trades api. Uses the `Trades` cube.
-
-▶️ [Pump fun token live prices using trades api](https://ide.bitquery.io/pump-fun-token-live-prices-using-trades-api_1)
 
 ### PancakeSwap
 
@@ -2148,25 +2128,45 @@ Filter `DEXTrades` with `ProtocolName` in `uniswap_v3`, `uniswap_v2`, `uniswap_v
 
 ▶️ [Uniswap all versions trades stream](https://ide.bitquery.io/uniswap-all-versions-trades-stream)
 
+### Pump.fun
+
+#### All Pumpswap Trade Stream
+
+All Pumpswap Trade Stream. Uses the `Trades` cube.
+
+▶️ [All Pumpswap Trade Stream](https://ide.bitquery.io/All-Pumpswap-Trade-Stream)
+
+#### All pumpfun Trade Stream
+
+All pumpfun Trade Stream. Uses the `Trades` cube.
+
+▶️ [All pumpfun Trade Stream](https://ide.bitquery.io/All-pumpfun-Trade-Stream_2)
+
+#### Pump fun token live prices using trades api
+
+Pump fun token live prices using trades api. Uses the `Trades` cube.
+
+▶️ [Pump fun token live prices using trades api](https://ide.bitquery.io/pump-fun-token-live-prices-using-trades-api_1)
+
 ## Stablecoins
 
 ### Trades
 
 #### Solana trades subscription
 
-Below stream will give you realtime trades of `USDT` on Solana. Test the stream.
+Solana trades subscription. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Solana trades subscription](https://ide.bitquery.io/solana-trades-subscription_10_1)
 
 #### Stablecoin Depeg tracking Stream for evm
 
-Below stream tracks USDT on Ethereum when PriceInUSD is outside 0.95–1.05 (depeg-style band).
+Stablecoin Depeg tracking Stream for evm. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Stablecoin Depeg tracking Stream for evm](https://ide.bitquery.io/Stablecoin-Depeg-tracking-Stream-for-evm)
 
 #### Stablecoin Depeg tracking Stream for tron
 
-Below stream tracks USDT on Tron when PriceInUSD is outside 0.95–1.05 (depeg-style band).
+Stablecoin Depeg tracking Stream for tron. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Stablecoin Depeg tracking Stream for tron](https://ide.bitquery.io/Stablecoin-Depeg-tracking-Stream-for-tron)
 
@@ -2178,13 +2178,13 @@ Below stream will be able to track specific Stablecoin depeg. In this query exam
 
 #### Stablecoin trades for etheruem
 
-Below stream will give you realtime USDT DEX trades on Ethereum. Test the stream.
+Stablecoin trades for etheruem. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Stablecoin trades for etheruem](https://ide.bitquery.io/Stablecoin-trades-for-etheruem)
 
 #### Stablecoin trades for tron
 
-Below stream will give you realtime USDT DEX trades on Tron. Test the stream.
+Stablecoin trades for tron. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Stablecoin trades for tron](https://ide.bitquery.io/Stablecoin-trades-for-tron)
 
@@ -2216,7 +2216,7 @@ Listen to stablecoin payments across all major blockchains. The Mempool option l
 
 #### Listening to All USDT and USDC Payments on Solana - stream
 
-This subscription streams USDT (`TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`) transfers on Tron — the highest-volume stablecoin payments network globally.
+Listening to All USDT and USDC Payments on Solana - stream. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Listening to All USDT and USDC Payments on Solana - stream](https://ide.bitquery.io/Listening-to-All-USDT-and-USDC-Payments-on-Solana---stream)
 
@@ -2228,25 +2228,25 @@ Listen to USDT sent or received by address `TUTQj7VJ1QjR3t2GJByvrP25yZNFcj38VJ`.
 
 #### Stablecoin Realtime Payments Stream on Eth Mainnet
 
-A single-contract USDC payments stream on Ethereum mainnet. Swap the `SmartContract` for `0xdAC17F958D2ee523a2206206994597C13D831ec7` to get USDT, or extend with an `in: [...]` list to multiplex stablecoins.
+Stablecoin Realtime Payments Stream on Eth Mainnet. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Stablecoin Realtime Payments Stream on Eth Mainnet](https://ide.bitquery.io/Stablecoin-Realtime-Payments-Stream-on-Eth-Mainnet)
 
 #### Stablecoin Realtime Transfers Stream on tron
 
-Below stream will give you realtime transfers of `USDT` on Tron. Test the stream.
+Stablecoin Realtime Transfers Stream on tron. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Stablecoin Realtime Transfers Stream on tron](https://ide.bitquery.io/Stablecoin-Realtime-Transfers-Stream-on-tron)
 
 #### Stablecoin transfers websocket
 
-Below stream will give you realtime transfers of `USDC` on Solana. Test the stream.
+Stablecoin transfers websocket. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Stablecoin transfers websocket](https://ide.bitquery.io/stablecoin-transfers-websocket)
 
 #### USDT and USDC token Transfers stream on solana
 
-This GraphQL stream provides live USDT and USDC stablecoin transfers on Solana.
+USDT and USDC token Transfers stream on solana. Uses the `Transfers` cube.
 
 ▶️ [USDT and USDC token Transfers stream on solana](https://ide.bitquery.io/USDT-and-USDC-token-Transfers-stream-on-solana)
 
@@ -2276,7 +2276,7 @@ Get real-time and historical USDT prices, OHLCV, and moving averages across supp
 
 #### USDT Stablecoin reserves on Solana
 
-Monitor USDT reserve or get lateast reserve value on Solana using below Stream/API.
+USDT Stablecoin reserves on Solana. Uses the `TokenSupplyUpdates` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [USDT Stablecoin reserves on Solana](https://ide.bitquery.io/USDT-Stablecoin-reserves-on-Solana)
 
@@ -2374,7 +2374,7 @@ Let's see an example of NFT token transfers using GraphQL Subscription (Webhook)
 
 #### NFT Token Transfers API
 
-Let's see an example of NFT token transfers using GraphQL Subscription (Webhook). In the following NFT Token Transfers API, we will be subscribing to all NFT token transfers on Base network.
+NFT Token Transfers API.
 
 ▶️ [NFT Token Transfers API](https://ide.bitquery.io/NFT-Token-Transfers-API_4)
 
@@ -2392,7 +2392,7 @@ This query subscribes you to the real time non-fungible token (NFT) transfers of
 
 #### Track realtime NFT Transfers on BSC chain
 
-Let's see an example of NFT token transfers using GraphQL Subscription (Webhook). In the following NFT Token Transfers API, we will be subscribing to all NFT token transfers on BSC network.
+Track realtime NFT Transfers on BSC chain.
 
 ▶️ [Track realtime NFT Transfers on BSC chain](https://ide.bitquery.io/Track-realtime-NFT-Transfers-on-BSC-chain)
 
@@ -2428,7 +2428,7 @@ Monitor NFT transfers for a specific collection across all transactions. This he
 
 #### Real-Time Trades Stream
 
-Subscribe to live prediction market trades as they occur on Polygon (successful transactions only).
+Real-Time Trades Stream.
 
 ▶️ [Real-Time Trades Stream](https://ide.bitquery.io/prediction-market-trades-subscription)
 
@@ -2484,7 +2484,7 @@ Stream successful Polymarket trades whose collateral exceeds $10,000 USD. Adjust
 
 #### Real-Time Management Stream (Creations + Resolutions)
 
-Subscribe to all prediction market lifecycle events (Created and Resolved) as they occur on Polygon.
+Real-Time Management Stream (Creations + Resolutions).
 
 ▶️ [Real-Time Management Stream (Creations + Resolutions)](https://ide.bitquery.io/Prediction-Managements-subscription-resolutions-creations)
 
@@ -2504,7 +2504,7 @@ Subscribe only to Resolved events. Winning outcome is in Prediction.Outcome; tok
 
 #### Real-Time Settlement Stream
 
-Subscribe to live Split, Merge, and Redemption events as they occur on Polygon.
+Real-Time Settlement Stream.
 
 ▶️ [Real-Time Settlement Stream](https://ide.bitquery.io/realtime-predicion-market-settlements-stream)
 
@@ -2514,13 +2514,13 @@ Subscribe to live Split, Merge, and Redemption events as they occur on Polygon.
 
 #### Real-Time Payment Monitoring for x402 Server
 
-Real-time subscription to monitor payments to a specific x402 server on Base network using WebSockets.
+Real-Time Payment Monitoring for x402 Server. Uses the `Transfers` cube.
 
 ▶️ [Real-Time Payment Monitoring for x402 Server](https://ide.bitquery.io/Monitoring-the-latest-payment-to-the-specific-X402-server)
 
 #### Real-Time Payment Monitoring for x402 Server on Solana
 
-Real-time subscription to monitor payments to a specific x402 server on Solana network using WebSockets.
+Real-Time Payment Monitoring for x402 Server on Solana. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [Real-Time Payment Monitoring for x402 Server on Solana](https://ide.bitquery.io/Real-Time---Solana-transfers-stream)
 

--- a/docs/start/starter-subscriptions.md
+++ b/docs/start/starter-subscriptions.md
@@ -46,19 +46,19 @@ Every Ethereum DEX trade as it happens. Add a `where` filter to narrow to a toke
 
 #### All swap events
 
-Returns provides information on the latest real-time swap events on Ethereum. You can run it [here
+Provides information on the latest real-time swap events on Ethereum. You can run it.
 
 ▶️ [All swap events](https://ide.bitquery.io/all-swap-events)
 
 #### Get pair trades data just like dexcsreener
 
-The query will subscribe you to real-time trade transactions for a pair, providing a continuous stream of data as new trades are processed and recorded. You can find the query [here
+Will subscribe to real-time trade transactions for a pair, providing a continuous stream of data as new trades are processed and recorded.
 
 ▶️ [Get pair trades data just like dexcsreener](https://ide.bitquery.io/Get-pair-trades-data-just-like-dexcsreener)
 
 #### Get pair trades data just like geckoterminal
 
-The query will subscribe you to real-time trade transactions for a pair, providing a continuous stream of data as new trades are processed and recorded. You can find the query [here
+Will subscribe to real-time trade transactions for a pair, providing a continuous stream of data as new trades are processed and recorded.
 
 ▶️ [Get pair trades data just like geckoterminal](https://ide.bitquery.io/Get-pair-trades-data-just-like-geckoterminal)
 
@@ -88,13 +88,13 @@ Track new position mints on the Fluid DEX Vault Factory contract. This query mon
 
 #### Subscribe to dex trades on ethereum mainnet
 
-Returns will get you the realtime DEX trades happening on Ethereum Mainnet. Open it in the GraphQL IDE using this [link
+Will get the realtime DEX trades happening on Ethereum Mainnet. Open it in the GraphQL IDE using this.
 
 ▶️ [Subscribe to dex trades on ethereum mainnet](https://ide.bitquery.io/subscribe-to-dex-trades-on-ethereum-mainnet_2)
 
 #### Trades of a specific trader of a specific token
 
-Crypto Trades API: filter `Pair.Market.Network: Ethereum` and `Trader.Address`. More examples: Trades API, [trader + token (IDE)
+Crypto Trades API: filter `Pair.Market.Network: Ethereum` and `Trader.Address`. More examples: Trades API.
 
 ▶️ [Trades of a specific trader of a specific token](https://ide.bitquery.io/trades-of-a-specific-trader-of-a-specific-token)
 
@@ -114,13 +114,13 @@ Subscribe to PEPE transfers above 1 billion tokens the moment they hit the chain
 
 #### Subscribe to Latest WETH token transfers
 
-Returns subscribes to WETH (Wrapped Ethereum) token transfers. The contract address is 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.
+This example subscribes to WETH (Wrapped Ethereum) token transfers. The contract address is 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.
 
 ▶️ [Subscribe to Latest WETH token transfers](https://ide.bitquery.io/Subscribe-to-Latest-WETH-token-transfers)
 
 #### Subscribe to latest Axie infinity token transfers
 
-You can open this API on our GraphQL IDE using this [link
+You can open this API on our GraphQL IDE using this.
 
 ▶️ [Subscribe to latest Axie infinity token transfers](https://ide.bitquery.io/Subscribe-to-latest-Axie-infinity-token-transfers_1)
 
@@ -234,7 +234,7 @@ Mints and burns as they change a token's supply.
 
 #### All trades on Ethereum with Price, Marketcap, supply
 
-You can run this subscription [in the Bitquery IDE
+Stream all Ethereum DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.Network: Ethereum` to capture every swap across all Ethereum DEXs in a single subscription.
 
 ▶️ [All trades on Ethereum with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Ethereum-with-Price-Marketcap-supply)
 
@@ -248,13 +248,13 @@ Slippage on every trade as it happens, across all pools.
 
 #### Realtime Liquidity Stream
 
-Returns query returns real-time liquidity data for all DEX pools on Ethereum. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
+This subscription query returns real-time liquidity data for all DEX pools on Ethereum. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
 
 ▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_4)
 
 #### Realtime Liquidity Stream of a Specific Pool
 
-Returns query monitors real-time liquidity changes for a specific DEX pool on Ethereum. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
+This subscription query monitors real-time liquidity changes for a specific DEX pool on Ethereum. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
 
 ▶️ [Realtime Liquidity Stream of a Specific Pool](https://ide.bitquery.io/Realtime-Liquidity-Stream-of-a-Specific-Pool_4)
 
@@ -276,7 +276,7 @@ Stream pool and pair creation on ethereum. Uses the `Events` cube.
 
 #### Subscribe to the Same Event Across Multiple Contracts
 
-In the below query we listen for a specific event (Approval) across multiple smart contracts on the Ethereum (ETH) network. Run the query [here
+In the below query we listen for a specific event (Approval) across multiple smart contracts on the Ethereum (ETH) network.
 
 ▶️ [Subscribe to the Same Event Across Multiple Contracts](https://ide.bitquery.io/Subscribe-to-the-Same-Event-Across-Multiple-Contracts)
 
@@ -284,19 +284,19 @@ In the below query we listen for a specific event (Approval) across multiple sma
 
 #### Binance Mempool Transactions
 
-The example below retrieves mempool transactions from the specified address (Binance / BSC mempool context).
+Mempool Transactions API provides real-time data from the Binance mempool. You can use it to build applications that require up-to-date information about transactions associated with a specific address.
 
 ▶️ [Binance Mempool Transactions](https://ide.bitquery.io/Binance-Mempool-Transactions_1)
 
 #### Eth subscribe("logs")
 
-You can subscribe to all incoming logs filtered by any of the fields including method signature, tx value,sender , receiver and so on. In the below example we are tracking only logs where the method name is `transfer`. You can run it [here
+You can subscribe to all incoming logs filtered by any of the fields including method signature, tx value,sender , receiver and so on. In the below example we are tracking only logs where the method name is `transfer`. You can run it.
 
 ▶️ [Eth subscribe("logs")](https://ide.bitquery.io/eth_subscribelogs)
 
 #### Eth subscribe(“pendingTransactions”)
 
-To subscribe to incoming pending transactions, use the below subscription. You can run it [here
+To subscribe to incoming pending transactions, use the below subscription. You can run it.
 
 ▶️ [Eth subscribe(“pendingTransactions”)](https://ide.bitquery.io/eth_subscribependingTransactions)
 
@@ -308,7 +308,7 @@ Gas prices being offered by pending transactions right now.
 
 #### Mempool event stream
 
-Returns listens to real-time mempool events on the Ethereum (ETH) blockchain. The query is designed to capture details of transactions, logs, events, and arguments from the Ethereum Virtual Machine (EVM) before they are confirmed in a block.
+This query listens to real-time mempool events on the Ethereum (ETH) blockchain. The query is designed to capture details of transactions, logs, events, and arguments from the Ethereum Virtual Machine (EVM) before they are confirmed in a block.
 
 ▶️ [Mempool event stream](https://ide.bitquery.io/Mempool-event-stream)
 
@@ -332,7 +332,7 @@ Catches pool creation at broadcast time rather than after the block.
 
 #### Vrs signature
 
-Returns query retrieves real-time mempool transactions and includes key details such as the block time, block number, transaction hash, transaction cost, and the V, R, S components of the transaction signature. You can run it [here
+The following subscription query retrieves real-time mempool transactions and includes key details such as the block time, block number, transaction hash, transaction cost, and the V, R, S components of the transaction signature. You can run it.
 
 ▶️ [Vrs signature](https://ide.bitquery.io/vrs-signature)
 
@@ -382,19 +382,19 @@ Rewards paid to validators, block by block.
 
 #### Filter by MEV Bot or Builder Address
 
-Track balance changes for specific MEV bots or block builders: Try the API [here
+Track balance changes for specific MEV bots or block builders.
 
 ▶️ [Filter by MEV Bot or Builder Address](https://ide.bitquery.io/Filter-by-MEV-Bot-or-Builder-Address)
 
 #### Filter by Miner Address
 
-Track balance changes for a specific miner address: Try the API [here
+Track balance changes for a specific miner address.
 
 ▶️ [Filter by Miner Address](https://ide.bitquery.io/Filter-by-Miner-Address)
 
 #### Filter by Validator Address
 
-Track balance changes for a specific validator address: Try the API [here
+Track balance changes for a specific validator address.
 
 ▶️ [Filter by Validator Address](https://ide.bitquery.io/Filter-by-Validator-Address)
 
@@ -426,13 +426,13 @@ If looking to monitor a currency pair across all virtual pools within Uniswap V4
 
 #### Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4
 
-Returns query monitors real-time liquidity changes for all pools in a specific DEX protocol on Ethereum. Here we have taken example of Uniswap V4.
+This subscription query monitors real-time liquidity changes for all pools in a specific DEX protocol on Ethereum. Here we have taken example of Uniswap V4.
 
 ▶️ [Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4](https://ide.bitquery.io/Latest-Liquidity-Changes-of-Pools-in-a-Specific-DEX-Protocol---Uniswap-V4_6)
 
 #### Latest pools created Uniswap v3
 
-Open this query on our GraphQL IDE using this [link
+Open this query on our GraphQL IDE using this.
 
 ▶️ [Latest pools created Uniswap v3](https://ide.bitquery.io/Latest-pools-created-Uniswap-v3_9)
 
@@ -472,31 +472,31 @@ Get all trades of Bags FM tokens from Meteora and other DEXs. This Bags FM token
 
 #### CPMM trades
 
-Returns subscribes to real-time trades on the Raydium CPMM on the Solana blockchain by filtering using `{Program: {Address: {is: "CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C"}}}:`. You can run the query [here
+In this section we will see how to get data on Raydium CPMM trades in real-time. You can check out our Pump Fun docs, Raydium v4 docs and Raydium LaunchPad docs too.
 
 ▶️ [CPMM trades](https://ide.bitquery.io/CPMM-trades)
 
 #### Get Solana pair trades data
 
-The query will subscribe you to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded. You can find the query [here
+Will subscribe to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded.
 
 ▶️ [Get Solana pair trades data](https://ide.bitquery.io/Get-Solana-pair-trades-data)
 
 #### Get Solana pair trades data just like dexcsreener
 
-The query will subscribe you to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded. You can find the query [here
+Will subscribe to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded.
 
 ▶️ [Get Solana pair trades data just like dexcsreener](https://ide.bitquery.io/Get-Solana-pair-trades-data-just-like-dexcsreener)
 
 #### Get Solana pair trades data just like geckoTerminal
 
-The query will subscribe you to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded. You can find the query [here
+Will subscribe to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded.
 
 ▶️ [Get Solana pair trades data just like geckoTerminal](https://ide.bitquery.io/Get-Solana-pair-trades-data-just-like-geckoTerminal_1)
 
 #### Latest Trades of TESLA onchain xStock
 
-Returns will give you realtime trades of Tesla xStock (TESLAx). You can run the query [here
+Below query will give you realtime trades of Tesla xStock (TESLAx).
 
 ▶️ [Latest Trades of TESLA onchain xStock](https://ide.bitquery.io/Latest-Trades-of-TESLA-onchain-xStock_1)
 
@@ -534,13 +534,13 @@ Jito foundation has Tip Payment Program that allows users to transfer tips to a 
 
 #### Transfers of Tip Payment Accounts on Solana
 
-The subscription that provides you the transfer data of one of these addresses is [writen below
+The subscription that provides you the transfer data of one of these addresses is.
 
 ▶️ [Transfers of Tip Payment Accounts on Solana](https://ide.bitquery.io/Transfers-of-Tip-Payment-Accounts-on-Solana_1)
 
 #### Transfers where sender is the specified address
 
-This websocket retrieves transfers where the sender is a particular address `2g9NLWUM6bPm9xq2FBsb3MT3F3G5HDraGqZQEVzcCWTc`.
+Transfers where sender is the specified address. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [Transfers where sender is the specified address](https://ide.bitquery.io/transfers-where-sender-is-the-specified-address_1)
 
@@ -574,13 +574,13 @@ This stream delivers real-time token prices on Solana based on the latest trades
 
 #### Byreal token live prices using trades api
 
-Run the subscription [in the Bitquery IDE
+Lock onto one token with `Pair.Token.Id` (e.g. `bid:solana:<mint>`) and the Byreal program address.
 
 ▶️ [Byreal token live prices using trades api](https://ide.bitquery.io/Byreal-token-live-prices-using-trades-api)
 
 #### Get Latest Price of SOL in USD Real-time
 
-Returns retrieves the USD price of a token on Solana by setting `MintAddress: {is: "J5FAZ6bV7CCGHcU4CTXWVG6nnKHcwD9Pn4DntY93pump"}` and `Side: {Currency: {MintAddress: {is: "11111111111111111111111111111111"}}}` .
+Get Latest Price of SOL in USD Real-time. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Get Latest Price of SOL in USD Real-time](https://ide.bitquery.io/Get-Latest-Price-of-SOL-in--USD-Real-time)
 
@@ -598,7 +598,7 @@ Below API will give you realtime prices, OHLC, and volume data for all GoonFi tr
 
 #### Latest price for more than 1 markets on solana
 
-You can retrieve data from multiple Solana DEX markets using our APIs or streams. The [following query
+You can retrieve data from multiple Solana DEX markets using our APIs or streams. The.
 
 ▶️ [Latest price for more than 1 markets on solana](https://ide.bitquery.io/latest-price-for-more-than-1-markets-on-solana_1)
 
@@ -610,7 +610,7 @@ Latest price for more than 1 markets on solana for specific currencies. Uses the
 
 #### Price of a moonshot token
 
-Returns gets real-time price of the specified Token `A1XqfcD1vMEhUNwEKvBVRWFV48ZLDL4oheFVCPEcM3Vk` on the Moonit DEX. You can run the query [here
+The below query gets real-time price of the specified Token `A1XqfcD1vMEhUNwEKvBVRWFV48ZLDL4oheFVCPEcM3Vk` on the Moonit DEX.
 
 ▶️ [Price of a moonshot token](https://ide.bitquery.io/Price-of-a-Moonshot-token)
 
@@ -624,37 +624,37 @@ Subscribe when **`Token.Id`** matches Solana and **`Supply.MarketCap`** &gt; 1,0
 
 #### All trades on Solana with Price, Marketcap, supply
 
-You can run this subscription [in the Bitquery IDE
+Stream all Solana DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data.
 
 ▶️ [All trades on Solana with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Solana-with-Price-Marketcap-supply)
 
 #### Bags.fm token creation stream using Solana token supply updates
 
-Track Bags FM token creation using the Solana TokenSupply API. This endpoint provides Bags FM token data including supply information and creation timestamps. For the same API as a WebSocket stream, [try this
+Track Bags FM token creation using the Solana TokenSupply API. This endpoint provides Bags FM token data including supply information and creation timestamps. For the same API as a WebSocket stream.
 
 ▶️ [Bags.fm token creation stream using Solana token supply updates](https://ide.bitquery.io/Bagsfm-token-creation-stream-using-Solana-token-supply-updates)
 
 #### Get All DEX Trades on DBC With Price, Market Cap, and Supply
 
-You can run this subscription [in the Bitquery IDE
+Stream all Meteora DBC DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.Protocol: dynamic_bonding_curve` to capture every swap across Meteora DBC in a single subscription.
 
 ▶️ [Get All DEX Trades on DBC With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-DBC-With-Price-Market-Cap-and-Supply)
 
 #### Get newly created Moonshot tokens with metadata
 
-Now you can track the newly created Moonit Tokens along with their metadata and supply. `PostBalance` will give you the current supply for the token. Check the query [here
+Now you can track the newly created Moonit Tokens along with their metadata and supply. `PostBalance` will give you the current supply for the token.
 
 ▶️ [Get newly created Moonshot tokens with metadata](https://ide.bitquery.io/Get-newly-created-Moonshot-tokens-with-metadata)
 
 #### Newly created PF token, dev address, metadata
 
-Now you can track the newly created Pump Fun Tokens along with their dev address, metadata and supply. `PostBalance` will give you the current supply for the token. Check the query [here
+Now you can track the newly created Pump Fun Tokens along with their dev address, metadata and supply. `PostBalance` will give you the current supply for the token.
 
 ▶️ [Newly created PF token, dev address, metadata](https://ide.bitquery.io/newly-created-PF-token-dev-address-metadata)
 
 #### Realtime heaven tokens with marketcap 10k
 
-Run the subscription [in the Bitquery IDE
+Subscribe when the token is on Solana, `Market.Protocol` is `Heaven`, `Supply.MarketCap` &gt; 10,000 (USD), and interval duration &gt; 1 second. Adjust `gt` to change the threshold.
 
 ▶️ [Realtime heaven tokens with marketcap 10k](https://ide.bitquery.io/realtime-heaven-tokens-with-marketcap-10k)
 
@@ -686,13 +686,13 @@ Liquidity for a launchpad token pair stream. Uses the `DEXPools` cube. Replace t
 
 #### Search tokens with liquidity over 1 million
 
-You can use the below query to get the tokens which are getting traded and have liquidity over 1 million USD. Try out the query [here
+You can use the below query to get the tokens which are getting traded and have liquidity over 1 million USD.
 
 ▶️ [Search tokens with liquidity over 1 million](https://ide.bitquery.io/Search-tokens-with-liquidity-over-1-million)
 
 #### Trends fun tokens between 95 and 100 bonding curve progress
 
-Track Trends.fun tokens that are approaching graduation with high bonding curve progress percentages. Run the query: [Trends.fun tokens between 95–100% bonding-curve progress ➤
+Track Trends.fun tokens that are approaching graduation with high bonding curve progress percentages. Run the query.
 
 ▶️ [Trends fun tokens between 95 and 100 bonding curve progress](https://ide.bitquery.io/trends-fun-tokens-between-95-and-100-bonding-curve-progress)
 
@@ -700,7 +700,7 @@ Track Trends.fun tokens that are approaching graduation with high bonding curve 
 
 #### Realtime Solana Transactions
 
-The subscription query below fetches the most recent transactions on the Solana blockchain You can find the query [here
+The subscription query below fetches the most recent transactions on the Solana blockchain.
 
 ▶️ [Realtime Solana Transactions](https://ide.bitquery.io/Realtime-Solana-Transactions)
 
@@ -734,7 +734,7 @@ This stream returns the real time trades on Pumpswap exchange. This stream could
 
 #### Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply
 
-You can run this subscription [in the Bitquery IDE
+Stream all PumpFun DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.ProtocolFamily: Pumpfun` to capture every swap across Pumpfun in a single subscription.
 
 ▶️ [Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Pumpfun-With-Price-Market-Cap-and-Supply)
 
@@ -746,7 +746,7 @@ Subscribe to `DEXTradeByTokens` with PumpSwap `ProgramAddress` and the token min
 
 #### Price of a pump fun token using price index in usd
 
-Live stream of token price updates on Pump.fun
+Live stream of token price updates on Pump.fun.
 
 ▶️ [Price of a pump fun token using price index in usd](https://ide.bitquery.io/Price-of-a-pump-fun-token-using-price-index-in-usd)
 
@@ -816,19 +816,19 @@ Liquidity removal for meteora. Uses the `DEXPools` cube.
 
 #### Meteora DBC token migrations to Meteors DEX
 
-Returns will give you the latest migrated tokens Meteora DBC in realtime. You can test the query [here
+Below query will give you the latest migrated tokens Meteora DBC in realtime.
 
 ▶️ [Meteora DBC token migrations to Meteors DEX](https://ide.bitquery.io/meteora-DBC-token-migrations-to-Meteors-DEX)
 
 #### Real time trades on Meteora Dynamic Bonding Curve on Solana
 
-Returns gets real-time information whenever there's a new trade on the Meteora DBC including detailed information about the trade, including the buy and sell details, the block information, and the transaction specifics. You can run the query [here
+The below query gets real-time information whenever there's a new trade on the Meteora DBC including detailed information about the trade, including the buy and sell details, the block information, and the transaction specifics.
 
 ▶️ [Real time trades on Meteora Dynamic Bonding Curve on Solana](https://ide.bitquery.io/Real-time-trades-on-Meteora-Dynamic-Bonding-Curve-on-Solana)
 
 #### Real time trades on MeteoraDAMMv2 DEX on Solana
 
-Returns subscribes to real-time trades on the Meteora DAMM v2 (Dynamic Automated Market Maker) on the Solana blockchain by filtering using the program address `cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG`. You can run the query [here
+This query subscribes to real-time trades on the Meteora DAMM v2 (Dynamic Automated Market Maker) on the Solana blockchain by filtering using the program address `cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG`.
 
 ▶️ [Real time trades on MeteoraDAMMv2 DEX on Solana](https://ide.bitquery.io/Real-time-trades-on-MeteoraDAMMv2-DEX-on-Solana)
 
@@ -854,13 +854,13 @@ With Orca’s program and negative base change, stream liquidity removals from W
 
 #### Orca DEX Trades Websocket
 
-To access a real-time stream of trades for Solana Orca DEX, [check out this GraphQL subscription (WebSocket)
+To access a real-time stream of trades for Solana Orca DEX.
 
 ▶️ [Orca DEX Trades Websocket](https://ide.bitquery.io/Orca-DEX-Trades-Websocket)
 
 #### Orca DEX Trades for a specific currency Websocket
 
-If you want to monitor [trades for a specific currency on Orca DEX
+By setting the limit to 1, you will receive the most recent trade, which reflects the latest price of the token.
 
 ▶️ [Orca DEX Trades for a specific currency Websocket](https://ide.bitquery.io/Orca-DEX-Trades-for-a-specific-currency-Websocket)
 
@@ -902,13 +902,13 @@ This subscription returns the real-time trades happening on BSC Network. You can
 
 #### All BNB Trade Stream
 
-Run this subscription [in the Bitquery IDE
+Crypto Trades API: one row per swap, with USD and supply. Filter `Pair.Market.Network: Binance Smart Chain`. When to use this vs chain DEX APIs.
 
 ▶️ [All BNB Trade Stream](https://ide.bitquery.io/All-BNB-Trade-Stream)
 
 #### Subscribe to bsc dex trades
 
-Returns uses the chain-specific DEXTrades cube via `EVM(network: bsc) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD fields can be empty on thin pools. For swap rows with trader + USD, use the stream at the top of this page.
+This example uses the chain-specific DEXTrades cube via `EVM(network: bsc) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD fields can be empty on thin pools. For swap rows with trader + USD, use the stream at the top of this page.
 
 ▶️ [Subscribe to bsc dex trades](https://ide.bitquery.io/subscribe-to-bsc-dex-trades)
 
@@ -916,7 +916,7 @@ Returns uses the chain-specific DEXTrades cube via `EVM(network: bsc) { DEXTrade
 
 #### Transfers where sender is a particular address
 
-This websocket retrieves transfers where the sender is a particular address `0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c`.
+Transfers where sender is a particular address. Uses the `Transfers` cube.
 
 ▶️ [Transfers where sender is a particular address](https://ide.bitquery.io/Transfers-where-sender-is-a-particular-address)
 
@@ -986,7 +986,7 @@ Monitor balance and gas fee paid for an address using stream bsc. Uses the `Tran
 
 #### Realtime price of a ETH in terms of WBNB
 
-Returns provides real-time updates on price of ETH `0x2170Ed0880ac9A755fd29B2688956BD959F933F8` in terms of WBNB `0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c`, including details about the DEX, market, and order specifics. Find the query [here
+Provides real-time updates on price of ETH `0x2170Ed0880ac9A755fd29B2688956BD959F933F8` in terms of WBNB `0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c`, including details about the DEX, market, and order specifics.
 
 ▶️ [Realtime price of a ETH in terms of WBNB](https://ide.bitquery.io/realtime-price-of-a-ETH-in-terms-of-WBNB)
 
@@ -1006,13 +1006,13 @@ Subscribe when **`Token.Id`** matches BSC and **`Supply.MarketCap`** &gt; 1,000,
 
 #### All trades on BSC with Price, Marketcap, supply
 
-You can run this subscription [in the Bitquery IDE
+Stream all BSC DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.Network: Binance Smart Chain` to capture every swap across all BSC DEXs in a single subscription.
 
 ▶️ [All trades on BSC with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-BSC-with-Price-Marketcap-supply)
 
 #### Bsc token marketcap stream
 
-You can run this subscription [in the Bitquery IDE
+Subscribe to `Tokens` where currency id includes `bsc`, with interval duration greater than 1 (second).
 
 ▶️ [Bsc token marketcap stream](https://ide.bitquery.io/bsc-token-marketcap-stream)
 
@@ -1032,7 +1032,7 @@ This subscription query returns real-time slippage data for all DEX pools on BSC
 
 #### Realtime Liquidity Stream
 
-Returns query returns real-time liquidity data for all DEX pools on BSC. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
+This subscription query returns real-time liquidity data for all DEX pools on BSC. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
 
 ▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_2)
 
@@ -1040,7 +1040,7 @@ Returns query returns real-time liquidity data for all DEX pools on BSC. You can
 
 #### Newly Created Tokens on BSC network
 
-Returns websocket lets you track the newly created tokens on BSC network. You will find the newly created token contract address in the response under `Receipt: ContractAddress` field. You can find the query [here
+This subscription websocket lets you track the newly created tokens on BSC network. You will find the newly created token contract address in the response under `Receipt: ContractAddress` field.
 
 ▶️ [Newly Created Tokens on BSC network](https://ide.bitquery.io/Newly-Created-Tokens-on-BSC-network_2)
 
@@ -1048,7 +1048,7 @@ Returns websocket lets you track the newly created tokens on BSC network. You wi
 
 #### Bsc mempool txs
 
-Try it in the IDE: [BSC mempool transactions
+Use a GraphQL `subscription` on the Bitquery streaming WebSocket `wss://streaming.bitquery.io/graphql` with root `EVM(network: bsc, mempool: true)`.
 
 ▶️ [Bsc mempool txs](https://ide.bitquery.io/bsc-mempool-txs)
 
@@ -1074,49 +1074,49 @@ This stream monitors MEV activities and Balance Updates on BSC in real time.
 
 #### All Self-Destruct Event Balances Stream bsc
 
-Monitor all contract self-destruct event balances in real-time using this GraphQL subscription. [Run Stream
+Monitor all contract self-destruct event balances in real-time using this GraphQL subscription.
 
 ▶️ [All Self-Destruct Event Balances Stream bsc](https://ide.bitquery.io/All-Self-Destruct-Event-Balances-Stream-bsc)
 
 #### Filter by MEV Bot or Builder Address bsc
 
-Track balance changes for specific MEV bots or block builders: Try the API [here
+Track balance changes for specific MEV bots or block builders.
 
 ▶️ [Filter by MEV Bot or Builder Address bsc](https://ide.bitquery.io/Filter-by-MEV-Bot-or-Builder-Address-bsc)
 
 #### Filter by Miner Address bsc
 
-Track balance changes for a specific miner address: Try the API [here
+Track balance changes for a specific miner address.
 
 ▶️ [Filter by Miner Address bsc](https://ide.bitquery.io/Filter-by-Miner-Address-bsc)
 
 #### Filter by Validator Address bsc
 
-Track balance changes for a specific validator address: Try the API [here
+Track balance changes for a specific validator address.
 
 ▶️ [Filter by Validator Address bsc](https://ide.bitquery.io/Filter-by-Validator-Address-bsc_1)
 
 #### Track Block Mining Rewards bsc
 
-Track rewards received by miners for successfully mining blocks: Try the API [here
+Track rewards received by miners for successfully mining blocks.
 
 ▶️ [Track Block Mining Rewards bsc](https://ide.bitquery.io/Track-Block-Mining-Rewards-bsc)
 
 #### Track Ephemeral MEV Contract Balance Changes bsc
 
-Monitor balance changes for short-lived contracts that are created and destroyed in the same transaction (typical pattern for MEV bots) using this subscription: Try the API [here
+Monitor balance changes for short-lived contracts that are created and destroyed in the same transaction (typical pattern for MEV bots) using this subscription.
 
 ▶️ [Track Ephemeral MEV Contract Balance Changes bsc](https://ide.bitquery.io/Track-Ephemeral-MEV-Contract-Balance-Changes-bsc)
 
 #### Track Large MEV Transactions bsc
 
-Monitor large transaction fee rewards that may indicate significant MEV extraction: Try the API [here
+Monitor large transaction fee rewards that may indicate significant MEV extraction.
 
 ▶️ [Track Large MEV Transactions bsc](https://ide.bitquery.io/Track-Large-MEV-Transactions-bsc)
 
 #### Track Large Self-Destruct Transaction Balances bsc
 
-Monitor significant self-destruct balance changes (e.g., > $1000 USD) using this subscription: Try the API [here
+Monitor significant self-destruct balance changes (e.g., > $1000 USD) using this subscription.
 
 ▶️ [Track Large Self-Destruct Transaction Balances bsc](https://ide.bitquery.io/Track-Large-Self-Destruct-Transaction-Balances-bsc)
 
@@ -1174,7 +1174,7 @@ This query tracks four meme token migrations to Pancakeswap in realtime by monit
 
 #### Binance meme rush migration to pancakeswap
 
-Returns tracks Binance Meme Rush token migrations to Pancakeswap in realtime by monitoring transactions sent to the Four Meme factory address (`0x5c952063c7fc8610ffdb798152d69f0b9550762b`) and filtering for `PairCreated` and `PoolCreated` events.
+Tracks Binance Meme Rush token migrations to Pancakeswap in realtime by monitoring transactions sent to the Four Meme factory address (`0x5c952063c7fc8610ffdb798152d69f0b9550762b`) and filtering for `PairCreated` and `PoolCreated` events.
 
 ▶️ [Binance meme rush migration to pancakeswap](https://ide.bitquery.io/binance-meme-rush-migration-to-pancakeswap)
 
@@ -1200,13 +1200,13 @@ Stream - BSC PancakeSwap v3 Trades for a token. Uses the `DEXTradeByTokens` cube
 
 #### Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4
 
-Returns query monitors real-time liquidity changes for all pools in a specific DEX protocol on BSC. Here we have taken example of Uniswap V4.
+This subscription query monitors real-time liquidity changes for all pools in a specific DEX protocol on BSC. Here we have taken example of Uniswap V4.
 
 ▶️ [Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4](https://ide.bitquery.io/Latest-Liquidity-Changes-of-Pools-in-a-Specific-DEX-Protocol---Uniswap-V4)
 
 #### Newly Created Pools on Uniswap v3 on BSC network
 
-Returns websocket lets you track the newly created pools on Uniswap V3 `0xdB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7`.
+This subscription websocket lets you track the newly created pools on Uniswap V3 `0xdB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7`.
 
 ▶️ [Newly Created Pools on Uniswap v3 on BSC network](https://ide.bitquery.io/Newly-Created-Pools-on-Uniswap-v3-on-BSC-network_3)
 
@@ -1218,13 +1218,13 @@ The Uniswap v4 PoolManager contract emits all pool-related events, including poo
 
 #### Uniswap v4 pool liquidity bsc
 
-Stream live liquidity for all Uniswap v4 pools on BSC. [Run in the Bitquery IDE
+Stream live liquidity for all Uniswap v4 pools on BSC.
 
 ▶️ [Uniswap v4 pool liquidity bsc](https://ide.bitquery.io/uniswap-v4-pool-liquidity-bsc)
 
 #### Uniswap v4 pool liquidity by poolid bsc
 
-Filter to a specific pool by `PoolId`. [Run in the Bitquery IDE
+Liquidity for v4 pools is reconstructed by stepping through each price range where liquidity is concentrated , so `AmountCurrencyA` / `AmountCurrencyB` reflect the actual PoolManager balances for that `PoolId`.
 
 ▶️ [Uniswap v4 pool liquidity by poolid bsc](https://ide.bitquery.io/uniswap-v4-pool-liquidity-by-poolid-bsc)
 
@@ -1240,13 +1240,13 @@ This stream returns all the real time DEX trades happening on Base. You can modi
 
 #### All Base Trade Stream
 
-Run this subscription [in the Bitquery IDE
+Crypto Trades API: one row per swap, with USD and supply. Filter `Pair.Market.Network: Base`. When to use this vs chain DEX APIs.
 
 ▶️ [All Base Trade Stream](https://ide.bitquery.io/All-Base-Trade-Stream)
 
 #### Subscribe to dex trades on base
 
-Read DEXTrades vs DEXTradeByTokens vs Trades cube to get a better understanding on when to use which cube. You can find the query [here
+Read DEXTrades vs DEXTradeByTokens vs Trades cube to get a better understanding on when to use which cube.
 
 ▶️ [Subscribe to dex trades on base](https://ide.bitquery.io/subscribe-to-dex-trades-on-base)
 
@@ -1266,19 +1266,19 @@ This stream lets you monitor all the token transfers for a particular token. You
 
 #### Newly created zora tokens stream
 
-You can also stream the latest tokens created in real-time using [this subscription
+You can also stream the latest tokens created in real-time using.
 
 ▶️ [Newly created zora tokens stream](https://ide.bitquery.io/Newly-created-zora-tokens-stream)
 
 #### Sender is a particular address
 
-This websocket retrieves transfers where the sender is a particular address `0x3304E22DDaa22bCdC5fCa2269b418046aE7b566A`.
+Sender is a particular address. Uses the `Transfers` cube.
 
 ▶️ [Sender is a particular address](https://ide.bitquery.io/Sender-is-a-particular-address_3)
 
 #### Whale transfers of USDC on base
 
-The subscription query below fetches the whale transactions on the Base network. We have used USDC address `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`. You can find the query [here
+The subscription query below fetches the whale transactions on the Base network. We have used USDC address `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`.
 
 ▶️ [Whale transfers of USDC on base](https://ide.bitquery.io/Whale-transfers-of-USDC-on-base)
 
@@ -1316,25 +1316,25 @@ Balance update from transfer for an address stream base. Uses the `TransactionBa
 
 #### Subscribe to All Transaction Balances base
 
-Returns provides real-time balance updates for all addresses involved in transactions on the Base network. Try the API [here
+Provides real-time balance updates for all addresses involved in transactions on the Base network.
 
 ▶️ [Subscribe to All Transaction Balances base](https://ide.bitquery.io/Subscribe-to-All-Transaction-Balances-base)
 
 #### Subscribe to Transaction Balances for a Specific Address base
 
-Returns filters transaction balances for a specific address. Try the API [here
+This subscription filters transaction balances for a specific address.
 
 ▶️ [Subscribe to Transaction Balances for a Specific Address base](https://ide.bitquery.io/Subscribe-to-Transaction-Balances-for-a-Specific-Address-base)
 
 #### Track Block Builder Rewards base
 
-Monitor transaction fee rewards received by block builders (MEV extractors): Try the API [here
+Monitor transaction fee rewards received by block builders (MEV extractors)
 
 ▶️ [Track Block Builder Rewards base](https://ide.bitquery.io/Track-Block-Builder-Rewards-base)
 
 #### Track Transaction Fee Rewards base
 
-Monitor transaction fee rewards received by miners: Try the API [here
+Monitor transaction fee rewards received by miners.
 
 ▶️ [Track Transaction Fee Rewards base](https://ide.bitquery.io/Track-Transaction-Fee-Rewards-base)
 
@@ -1360,13 +1360,13 @@ Below API gives you instant access to live Aerodrome market data with pre-calcul
 
 #### Get latest price of DAI in USD on Base
 
-Returns retrieves the USD price of a token on Base chain by setting `SmartContract: {is: "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb"}` . Check the field `PriceInUSD` for the USD value. You can access the query [here
+Retrieves the USD price of a token on Base chain by setting `SmartContract: {is: "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb"}` . Check the field `PriceInUSD` for the USD value. You can access the query.
 
 ▶️ [Get latest price of DAI in USD on Base](https://ide.bitquery.io/Get-latest-price-of-DAI-in-USD-on-Base)
 
 #### Price of USDC in terms of DAI on Base network
 
-Returns provides real-time updates on price of USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` in terms of DAI `0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb`, including details about the DEX, market, and order specifics. Find the query [here
+Provides real-time updates on price of USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` in terms of DAI `0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb`, including details about the DEX, market, and order specifics.
 
 ▶️ [Price of USDC in terms of DAI on Base network](https://ide.bitquery.io/Price-of-USDC-in-terms-of-DAI-on-Base-network)
 
@@ -1386,7 +1386,7 @@ Subscribe when **`Token.Id`** matches Base and **`Supply.MarketCap`** &gt; 1,000
 
 #### All trades on Base with Price, Marketcap, supply
 
-You can run this subscription [in the Bitquery IDE
+Stream all Base DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.Network: Base` to capture every swap across all Base DEXs in a single subscription.
 
 ▶️ [All trades on Base with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Base-with-Price-Marketcap-supply)
 
@@ -1412,13 +1412,13 @@ This subscription query returns real-time slippage data for all DEX pools on Bas
 
 #### Realtime Liquidity Stream
 
-Returns query returns real-time liquidity data for all DEX pools on Base. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
+This subscription query returns real-time liquidity data for all DEX pools on Base. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
 
 ▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_3)
 
 #### Realtime Liquidity Stream of a Specific Pool
 
-Returns query monitors real-time liquidity changes for a specific DEX pool on Base. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
+This subscription query monitors real-time liquidity changes for a specific DEX pool on Base. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
 
 ▶️ [Realtime Liquidity Stream of a Specific Pool](https://ide.bitquery.io/Realtime-Liquidity-Stream-of-a-Specific-Pool_3)
 
@@ -1470,25 +1470,25 @@ Track validator rewards and balance increases from staking activities in real-ti
 
 #### All Self Destruct Event Balances Stream base
 
-Monitor all contract self-destruct event balances in real-time using this GraphQL subscription. [Run Stream
+Monitor all contract self-destruct event balances in real-time using this GraphQL subscription.
 
 ▶️ [All Self Destruct Event Balances Stream base](https://ide.bitquery.io/All-Self-Destruct-Event-Balances-Stream-base)
 
 #### Filter by MEV Bot or Builder Address base
 
-Track balance changes for specific MEV bots or block builders: Try the API [here
+Track balance changes for specific MEV bots or block builders.
 
 ▶️ [Filter by MEV Bot or Builder Address base](https://ide.bitquery.io/Filter-by-MEV-Bot-or-Builder-Address-base)
 
 #### Filter by Miner Address base
 
-Track balance changes for a specific miner address: Try the API [here
+Track balance changes for a specific miner address.
 
 ▶️ [Filter by Miner Address base](https://ide.bitquery.io/Filter-by-Miner-Address-base)
 
 #### Track Block Mining Rewards base
 
-Track rewards received by miners for successfully mining blocks: Try the API [here
+Track rewards received by miners for successfully mining blocks.
 
 ▶️ [Track Block Mining Rewards base](https://ide.bitquery.io/Track-Block-Mining-Rewards-base)
 
@@ -1514,7 +1514,7 @@ Bankr trades clear on the Uniswap V4 singleton. Use the Crypto Trades API (`Trad
 
 #### Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4
 
-Returns query monitors real-time liquidity changes for all pools in a specific DEX protocol on Base. Here we have taken example of Uniswap V4.
+This subscription query monitors real-time liquidity changes for all pools in a specific DEX protocol on Base. Here we have taken example of Uniswap V4.
 
 ▶️ [Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4](https://ide.bitquery.io/Latest-Liquidity-Changes-of-Pools-in-a-Specific-DEX-Protocol---Uniswap-V4_5)
 
@@ -1526,7 +1526,7 @@ The Uniswap v4 PoolManager contract emits all pool-related events, including poo
 
 #### Uniswap v4 pool liquidity base
 
-Stream live liquidity for all Uniswap v4 pools on Base. [Run in the Bitquery IDE
+Stream live liquidity for all Uniswap v4 pools on Base.
 
 ▶️ [Uniswap v4 pool liquidity base](https://ide.bitquery.io/uniswap-v4-pool-liquidity-base)
 
@@ -1536,7 +1536,7 @@ Stream live liquidity for all Uniswap v4 pools on Base. [Run in the Bitquery IDE
 
 #### Arbitrum Dextrades subscription
 
-Returns uses the chain-specific DEXTrades cube via `EVM(network: arbitrum) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD can be weak on thin pools. For trader + USD swap rows, use the stream at the top.
+This example uses the chain-specific DEXTrades cube via `EVM(network: arbitrum) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD can be weak on thin pools. For trader + USD swap rows, use the stream at the top.
 
 ▶️ [Arbitrum Dextrades subscription](https://ide.bitquery.io/Arbitrum-Dextrades-subscription)
 
@@ -1544,13 +1544,13 @@ Returns uses the chain-specific DEXTrades cube via `EVM(network: arbitrum) { DEX
 
 #### Arbitrum token marketcap stream
 
-You can run this subscription [in the Bitquery IDE
+Subscribe to `Tokens` where currency id includes `arbitrum`, with interval duration greater than 1 (second). You get token fields, block time, supply (MarketCap, FullyDilutedValuationUsd), price (OHLC and mean), and volume.
 
 ▶️ [Arbitrum token marketcap stream](https://ide.bitquery.io/arbitrum-token-marketcap-stream)
 
 #### Realtime stream arbitrum tokens with marketcap above 1 million
 
-You can run this subscription [in the Bitquery IDE
+Subscribe when `Token.Id` matches Arbitrum (`arbitrum`) and `Supply.MarketCap` > 1,000,000 (USD).
 
 ▶️ [Realtime stream arbitrum tokens with marketcap above 1 million](https://ide.bitquery.io/realtime-stream-arbitrum-tokens-with-marketcap-above-1-million)
 
@@ -1558,19 +1558,19 @@ You can run this subscription [in the Bitquery IDE
 
 #### Realtime liquidity stream
 
-Returns query returns real-time liquidity data for all DEX pools on Arbitrum. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
+This subscription query returns real-time liquidity data for all DEX pools on Arbitrum. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
 
 ▶️ [Realtime liquidity stream](https://ide.bitquery.io/realtime-liquidity-stream_1)
 
 #### Realtime liquidity stream of a specific pool
 
-Returns query monitors real-time liquidity changes for a specific DEX pool on Arbitrum. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
+This subscription query monitors real-time liquidity changes for a specific DEX pool on Arbitrum. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
 
 ▶️ [Realtime liquidity stream of a specific pool](https://ide.bitquery.io/realtime-liquidity-stream-of-a-specific-pool)
 
 #### Realtime slippage on arbitrum
 
-Returns query returns real-time slippage data for all DEX pools on Arbitrum. You can monitor price impact and liquidity depth as trades occur.
+This subscription query returns real-time slippage data for all DEX pools on Arbitrum. You can monitor price impact and liquidity depth as trades occur.
 
 ▶️ [Realtime slippage on arbitrum](https://ide.bitquery.io/realtime-slippage-on-arbitrum)
 
@@ -1586,7 +1586,7 @@ Use the following subscription in the Bitquery IDE to watch every TimeBoost auct
 
 #### Latest liquidity changes in uniswap v4 pools
 
-Returns query monitors real-time liquidity changes for all pools in a specific DEX protocol on Arbitrum. Here we have taken example of Uniswap V4.
+This subscription query monitors real-time liquidity changes for all pools in a specific DEX protocol on Arbitrum. Here we have taken example of Uniswap V4.
 
 ▶️ [Latest liquidity changes in uniswap v4 pools](https://ide.bitquery.io/latest-liquidity-changes-in-uniswap-v4-pools)
 
@@ -1608,7 +1608,7 @@ The Uniswap v4 PoolManager contract emits all pool-related events, including poo
 
 #### Realtime optimism dex trades websocket
 
-Returns uses the chain-specific DEXTrades cube via `EVM(network: optimism) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD can be weak on thin pools. For trader + USD swap rows, use the stream at the top.
+This example uses the chain-specific DEXTrades cube via `EVM(network: optimism) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD can be weak on thin pools. For trader + USD swap rows, use the stream at the top.
 
 ▶️ [Realtime optimism dex trades websocket](https://ide.bitquery.io/Realtime-optimism-dex-trades-websocket)
 
@@ -1616,13 +1616,13 @@ Returns uses the chain-specific DEXTrades cube via `EVM(network: optimism) { DEX
 
 #### Sender is a particular address
 
-This websocket retrieves transfers where the sender is a particular address `0xEbe80f029b1c02862B9E8a70a7e5317C06F62Cae`.
+Sender is a particular address. Uses the `Transfers` cube.
 
 ▶️ [Sender is a particular address](https://ide.bitquery.io/Sender-is-a-particular-address)
 
 #### Whale transfers of USDT on optimism
 
-The subscription query below fetches the whale transactions on the Optimism network. We have used USDT address `0x94b008aA00579c1307B0EF2c499aD98a8ce58e58` You can find the query [here
+The subscription query below fetches the whale transactions on the Optimism network. We have used USDT address `0x94b008aA00579c1307B0EF2c499aD98a8ce58e58`
 
 ▶️ [Whale transfers of USDT on optimism](https://ide.bitquery.io/Whale-transfers-of-USDT-on-optimism)
 
@@ -1630,13 +1630,13 @@ The subscription query below fetches the whale transactions on the Optimism netw
 
 #### Get latest price of WBTC in USD on optimism
 
-Returns retrieves the USD price of a token on Optimism by setting `SmartContract: {is: "0x68f180fcCe6836688e9084f035309E29Bf0A2095"}` . Check the field `PriceInUSD` for the USD value. You can access the query [here
+Retrieves the USD price of a token on Optimism by setting `SmartContract: {is: "0x68f180fcCe6836688e9084f035309E29Bf0A2095"}` . Check the field `PriceInUSD` for the USD value. You can access the query.
 
 ▶️ [Get latest price of WBTC in USD on optimism](https://ide.bitquery.io/Get-latest-price-of-WBTC-in-USD-on-optimism)
 
 #### Price of WETH in terms of USDC on Optimism
 
-Returns provides real-time updates on price of WETH `0x4200000000000000000000000000000000000006` in terms of USD Coin `0x7f5c764cbc14f9669b88837ca1490cca17c31607`, including details about the DEX, market, and order specifics. Find the query [here
+Provides real-time updates on price of WETH `0x4200000000000000000000000000000000000006` in terms of USD Coin `0x7f5c764cbc14f9669b88837ca1490cca17c31607`, including details about the DEX, market, and order specifics.
 
 ▶️ [Price of WETH in terms of USDC on Optimism](https://ide.bitquery.io/Price-of-WETH-in-terms-of-USDC-on-Optimism)
 
@@ -1652,7 +1652,7 @@ The Uniswap v4 PoolManager contract emits all pool-related events, including poo
 
 #### Realtime matic dex trades websocket
 
-Read DEXTrades vs DEXTradeByTokens vs Trades cube to understand when to use which cube. You can find the query [here
+Read DEXTrades vs DEXTradeByTokens vs Trades cube to understand when to use which cube.
 
 ▶️ [Realtime matic dex trades websocket](https://ide.bitquery.io/Realtime-matic-dex-trades-websocket)
 
@@ -1660,13 +1660,13 @@ Read DEXTrades vs DEXTradeByTokens vs Trades cube to understand when to use whic
 
 #### Sender is a particular address
 
-This websocket retrieves transfers where the sender is a particular address `0x1A8f43e01B78979EB4Ef7feBEC60F32c9A72f58E`.
+Sender is a particular address. Uses the `Transfers` cube.
 
 ▶️ [Sender is a particular address](https://ide.bitquery.io/Sender-is-a-particular-address_2)
 
 #### Whale transfers of USDC on matic
 
-The subscription query below fetches the whale transactions on the MATIC network. We have used USDC address `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359`. You can find the query [here
+The subscription query below fetches the whale transactions on the MATIC network. We have used USDC address `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359`.
 
 ▶️ [Whale transfers of USDC on matic](https://ide.bitquery.io/Whale-transfers-of-USDC-on-matic)
 
@@ -1674,13 +1674,13 @@ The subscription query below fetches the whale transactions on the MATIC network
 
 #### All trades on Polygon with Price, Marketcap, supply
 
-Run this subscription [in the Bitquery IDE
+Crypto Trades API: one row per swap, with USD and supply. For Polygon use `Pair.Market.Network: Matic`. When to use this vs chain DEX APIs.
 
 ▶️ [All trades on Polygon with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Polygon-with-Price-Marketcap-supply)
 
 #### Matic token marketcap stream
 
-You can run this subscription [in the Bitquery IDE
+Subscribe to `Tokens` where currency id includes `matic`, with interval duration greater than 1 (second).
 
 ▶️ [Matic token marketcap stream](https://ide.bitquery.io/matic-token-marketcap-stream)
 
@@ -1688,25 +1688,25 @@ You can run this subscription [in the Bitquery IDE
 
 #### Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4
 
-Returns query monitors real-time liquidity changes for all pools in a specific DEX protocol on Matic. Here we have taken example of Uniswap V4.
+This subscription query monitors real-time liquidity changes for all pools in a specific DEX protocol on Matic. Here we have taken example of Uniswap V4.
 
 ▶️ [Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4](https://ide.bitquery.io/Latest-Liquidity-Changes-of-Pools-in-a-Specific-DEX-Protocol---Uniswap-V4_7)
 
 #### Realtime Liquidity Stream
 
-Returns query returns real-time liquidity data for all DEX pools on Matic. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
+This subscription query returns real-time liquidity data for all DEX pools on Matic. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
 
 ▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_5)
 
 #### Realtime Liquidity Stream of a Specific Pool
 
-Returns query monitors real-time liquidity changes for a specific DEX pool on Matic. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
+This subscription query monitors real-time liquidity changes for a specific DEX pool on Matic. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
 
 ▶️ [Realtime Liquidity Stream of a Specific Pool](https://ide.bitquery.io/Realtime-Liquidity-Stream-of-a-Specific-Pool_5)
 
 #### Realtime slippage on matic
 
-Returns query returns real-time slippage data for all DEX pools on Matic. You can monitor price impact and liquidity depth as trades occur.
+This subscription query returns real-time slippage data for all DEX pools on Matic. You can monitor price impact and liquidity depth as trades occur.
 
 ▶️ [Realtime slippage on matic](https://ide.bitquery.io/realtime-slippage-on-matic)
 
@@ -1728,7 +1728,7 @@ This stream returns all the real time DEX trades happening on the Tron network. 
 
 #### Sunpump trades
 
-To subscribe to latest Sunpump trades you can use [the following stream
+To subscribe to latest Sunpump trades you can use.
 
 ▶️ [Sunpump trades](https://ide.bitquery.io/Sunpump-trades)
 
@@ -1748,13 +1748,13 @@ This subscription streams the latest USDT (TRC20) transfers on the TRON network.
 
 #### Sender is particular address
 
-This websocket retrieves transfers where the sender is a particular address `TDqSquXBgUCLYvYC4XZgrprLK589dkhSCf`.
+Sender is particular address. Uses the `Transfers` cube.
 
 ▶️ [Sender is particular address](https://ide.bitquery.io/Sender-is-particular-address)
 
 #### Whale transfers of USDT on Tron
 
-The subscription query below fetches the whale transactions on the Tron network. We have used USDT address `TThzxNRLrW2Brp9DcTQU8i4Wd9udCWEdZ3`. You can find the query [here
+The subscription query below fetches the whale transactions on the Tron network. We have used USDT address `TThzxNRLrW2Brp9DcTQU8i4Wd9udCWEdZ3`.
 
 ▶️ [Whale transfers of USDT on Tron](https://ide.bitquery.io/Whale-transfers-of-USDT-on-Tron)
 
@@ -1762,7 +1762,7 @@ The subscription query below fetches the whale transactions on the Tron network.
 
 #### Track price of a tron token in realtime
 
-Returns provides real-time updates on price of token `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` in terms of USDT `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`, including details about the DEX. Try the query [here
+Provides real-time updates on price of token `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` in terms of USDT `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`, including details about the DEX.
 
 ▶️ [Track price of a tron token in realtime](https://ide.bitquery.io/Track-price-of-a-tron-token-in-realtime)
 
@@ -1770,7 +1770,7 @@ Returns provides real-time updates on price of token `TR7NHqjeKQxGTCi8q8ZY4pL8ot
 
 #### Get All DEX Trades on Tron With Price, Market Cap, and Supply
 
-Run this subscription [in the Bitquery IDE
+Crypto Trades API: one row per swap, with USD and supply. Filter `Pair.Market.Network: Tron`. When to use this vs chain DEX APIs.
 
 ▶️ [Get All DEX Trades on Tron With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Tron-With-Price-Market-Cap-and-Supply)
 
@@ -1786,19 +1786,19 @@ The subscription query below fetches the transactions on the Tron network for th
 
 #### Latest Buy on SunPump
 
-You can use following stream to get latest buys on Sunpump. You can try [this stream on IDE
+You can use following stream to get latest buys on Sunpump. You can try.
 
 ▶️ [Latest Buy on SunPump](https://ide.bitquery.io/latest-Buy-on-SunPump)
 
 #### New tokens on sunpump
 
-Returns will subscribe you to the latest created sun pump tokens. You will find the newly created token address in `Log { SmartContract }`.
+Will subscribe to the latest created sun pump tokens. You will find the newly created token address in `Log { SmartContract }`.
 
 ▶️ [New tokens on sunpump](https://ide.bitquery.io/New-tokens-on-sunpump_1)
 
 #### Sunpump sell event
 
-You can use following stream to get latest sells on Sunpump. You can try [this stream on IDE
+You can use following stream to get latest sells on Sunpump. You can try.
 
 ▶️ [Sunpump sell event](https://ide.bitquery.io/sunpump-sell-event)
 
@@ -1818,13 +1818,13 @@ Events with argumens. Uses the `Events` cube. Replace the address in the `where`
 
 #### Sunpump trades mempool
 
-We simulate transactions in mempool, therefore you can also get trades directly from mempool using [following stream
+We simulate transactions in mempool, therefore you can also get trades directly from mempool using.
 
 ▶️ [Sunpump trades mempool](https://ide.bitquery.io/Sunpump-trades-mempool)
 
 #### Tron mempool transfers
 
-Returns provides real-time data on token transfers happening in the TRON mempool including the value of the transferred amount in USD.
+Provides real-time data on token transfers happening in the TRON mempool including the value of the transferred amount in USD.
 
 ▶️ [Tron mempool transfers](https://ide.bitquery.io/Tron-mempool-transfers)
 
@@ -1908,7 +1908,7 @@ Every transfer query on this page is identical except two values: the launchpad 
 
 #### Pools trade Stream launches with token detail
 
-The transfer-based stream returns the token's name, symbol, decimals, and contract in the same payload — everything a sniping bot or listings feed needs, with no follow-up metadata call. It also carries the transaction's gas economics and success flag:
+The transfer-based stream returns the token's name, symbol, decimals, and contract in the same payload — everything a sniping bot or listings feed needs, with no follow-up metadata call. It also carries the transaction's gas economics and success flag.
 
 ▶️ [Pools trade Stream launches with token detail](https://ide.bitquery.io/Pools-trade-Stream-launches-with-token-detail)
 
@@ -1944,7 +1944,7 @@ Filter Flap.sh `TokenCreated` events and decode argument values (token address, 
 
 #### Stream New Tokens on Robinhood Chain (All Launchpads)
 
-Follow the steps here: How to generate Bitquery API token ➤ :::
+Follow the steps here: How to generate Bitquery API token ➤.
 
 ▶️ [Stream New Tokens on Robinhood Chain (All Launchpads)](https://ide.bitquery.io/stream-new-tokens-robinhood-chain)
 
@@ -1964,61 +1964,61 @@ You can stream Bitcoin price at 1-second interval using the [Crypto Price APIs](
 
 #### All chains New Trades Stream - Solana, eth, bsc ,base , arbitrum, matic
 
-You can run this subscription [in the Bitquery IDE
+The same `NetworkBid` pattern applies on the Crypto Price API for `Token.NetworkBid` and `Market.NetworkBid` on Tokens and Pairs.
 
 ▶️ [All chains New Trades Stream - Solana, eth, bsc ,base , arbitrum, matic](https://ide.bitquery.io/all-chains-New-Trades-Stream---Solana-eth-bsc-base--arbitrum-matic_2)
 
 #### All trades of a trader
 
-You can run this subscription [in the Bitquery IDE
+All trades of a trader. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [All trades of a trader](https://ide.bitquery.io/All-trades-of-a-trader)
 
 #### All wsol Trade Stream
 
-You can run this subscription [in the Bitquery IDE
+All wsol Trade Stream. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [All wsol Trade Stream](https://ide.bitquery.io/All-wsol-Trade-Stream)
 
 #### How do I get a wallet's trades on a specific pair?
 
-You can run this subscription [in the Bitquery IDE
+Change the `Program` address to target different DEXs — e.g. `6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P` for Pump.fun.
 
 ▶️ [How do I get a wallet's trades on a specific pair?](https://ide.bitquery.io/How-do-I-get-a-wallets-trades-on-a-specific-pair)
 
 #### How do I monitor multiple wallets in one subscription?
 
-You can run this subscription [in the Bitquery IDE
+How do I monitor multiple wallets in one subscription?. Uses the `Trades` cube.
 
 ▶️ [How do I monitor multiple wallets in one subscription?](https://ide.bitquery.io/How-do-I-monitor-multiple-wallets-in-one-subscription)
 
 #### How do I monitor multiple wallets trading a specific token?
 
-You can run this subscription [in the Bitquery IDE
+How do I monitor multiple wallets trading a specific token?. Uses the `Trades` cube.
 
 ▶️ [How do I monitor multiple wallets trading a specific token?](https://ide.bitquery.io/How-do-I-monitor-multiple-wallets-trading-a-specific-token)
 
 #### How do I stream a wallet's trades on a specific DEX?
 
-You can run this subscription [in the Bitquery IDE
+How do I stream a wallet's trades on a specific DEX?. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [How do I stream a wallet's trades on a specific DEX?](https://ide.bitquery.io/How-do-I-stream-a-wallets-trades-on-a-specific-DEX)
 
 #### How do I stream a wallet's trades on a specific chain?
 
-You can run this subscription [in the Bitquery IDE
+How do I stream a wallet's trades on a specific chain?. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [How do I stream a wallet's trades on a specific chain?](https://ide.bitquery.io/How-do-I-stream-a-wallets-trades-on-a-specific-chain)
 
 #### How do I stream whale trades for a specific wallet?
 
-You can run this subscription [in the Bitquery IDE
+Adjust the `gt` threshold — e.g. `10000` for $10K+, `1000000` for $1M+ trades.
 
 ▶️ [How do I stream whale trades for a specific wallet?](https://ide.bitquery.io/How-do-I-stream-whale-trades-for-a-specific-wallet)
 
 #### How do I track trades for multiple tokens in one subscription?
 
-You can run this subscription [in the Bitquery IDE
+There are two ways to track multiple tokens. You can specify token IDs using the `any` combinator to match trades where your tokens appear on either side of the pair.
 
 ▶️ [How do I track trades for multiple tokens in one subscription?](https://ide.bitquery.io/How-do-I-track-trades-for-multiple-tokens-in-one-subscription)
 
@@ -2044,31 +2044,31 @@ Monitor Raydium Launchlab token listings on Solana with 1-second OHLC and volume
 
 #### 5 minute price change api on solana
 
-Here we have selected the filter `Price: {IsQuotedInUsd: true}`, this means that any price values such as OHLC or Average indicators will be in USD. If you want them in quote currency, change the filter to `Price: {IsQuotedInUsd: false}`.
+Stream the top 10 tokens on Solana by 5-minute price change (in USD), filtered by $100k+ volume. Updates continuously.
 
 ▶️ [5 minute price change api on solana](https://ide.bitquery.io/5-minute-price-change-api-on-solana_6)
 
 #### Bitcoin currency price stream
 
-Get real-time Bitcoin OHLC data across all chains:
+Get real-time Bitcoin OHLC data across all chains.
 
 ▶️ [Bitcoin currency price stream](https://ide.bitquery.io/bitcoin-currency-price-stream)
 
 #### Heaven DEX tokens 1 second price stream with OHLC
 
-Here we have selected the filter `Price: {IsQuotedInUsd: true}`, this means that any price values such as OHLC or Average indicators will be in USD. If you want them in quote currency, change the filter to `Price: {IsQuotedInUsd: false}`.
+Real-time (1s) stream of prices, OHLC, and volumes for tokens traded on Heaven DEX (Solana).
 
 ▶️ [Heaven DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/Heaven-DEX-tokens-1-second-price-stream-with-OHLC)
 
 #### Meteora DBC DEX tokens 1 second price stream with OHLC
 
-Here we have selected the filter `Price: {IsQuotedInUsd: true}`, this means that any price values such as OHLC or Average indicators will be in USD. If you want them in quote currency, change the filter to `Price: {IsQuotedInUsd: false}`.
+Real-time (1s) OHLC, price, and volume feed for Meteora DBC DEX on Solana.
 
 ▶️ [Meteora DBC DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/Meteora-DBC-DEX-tokens-1-second-price-stream-with-OHLC)
 
 #### Real Time USD price on solana chain
 
-Here we have selected the filter `Price: {IsQuotedInUsd: true}`, this means that any price values such as OHLC or Average indicators will be in USD. If you want them denominated in quote currency, change the filter to `Price: {IsQuotedInUsd: false}`.
+Stream live OHLC (Open, High, Low, Close) price and volume data for all tokens on Solana, quoted directly in USD. Useful for dashboards, analytics, or bots that need stable fiat-based prices.
 
 ▶️ [Real Time USD price on solana chain](https://ide.bitquery.io/Real-Time-USD-price-on-solana-chain_2)
 
@@ -2076,7 +2076,7 @@ Here we have selected the filter `Price: {IsQuotedInUsd: true}`, this means that
 
 #### All trades of a specific Ethereum token with Price, Marketcap, supply
 
-You can run this subscription [in the Bitquery IDE
+All trades of a specific Ethereum token with Price, Marketcap, supply. Uses the `Trades` cube.
 
 ▶️ [All trades of a specific Ethereum token with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-of-a-specific-Ethereum-token-with-Price-Marketcap-supply_1)
 
@@ -2094,6 +2094,26 @@ Use the same Raydium program filter with negative `ChangeAmount` on the base sid
 
 ▶️ [Liquidity removal for radium](https://ide.bitquery.io/liquidity-removal-for-radium_1)
 
+### Pump.fun
+
+#### All Pumpswap Trade Stream
+
+All Pumpswap Trade Stream. Uses the `Trades` cube.
+
+▶️ [All Pumpswap Trade Stream](https://ide.bitquery.io/All-Pumpswap-Trade-Stream)
+
+#### All pumpfun Trade Stream
+
+All pumpfun Trade Stream. Uses the `Trades` cube.
+
+▶️ [All pumpfun Trade Stream](https://ide.bitquery.io/All-pumpfun-Trade-Stream_2)
+
+#### Pump fun token live prices using trades api
+
+Pump fun token live prices using trades api. Uses the `Trades` cube.
+
+▶️ [Pump fun token live prices using trades api](https://ide.bitquery.io/pump-fun-token-live-prices-using-trades-api_1)
+
 ### PancakeSwap
 
 #### Real-time Trades on Pancakeswap
@@ -2107,26 +2127,6 @@ This subscription returns the real-time trades happening on Pancakeswap. You can
 PancakeSwap v3 DEX tokens 1 second price stream with OHLC. Uses the `Pairs` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [PancakeSwap v3 DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/PancakeSwap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
-
-### Pump.fun
-
-#### All Pumpswap Trade Stream
-
-You can run this subscription [in the Bitquery IDE
-
-▶️ [All Pumpswap Trade Stream](https://ide.bitquery.io/All-Pumpswap-Trade-Stream)
-
-#### All pumpfun Trade Stream
-
-You can run this subscription [in the Bitquery IDE
-
-▶️ [All pumpfun Trade Stream](https://ide.bitquery.io/All-pumpfun-Trade-Stream_2)
-
-#### Pump fun token live prices using trades api
-
-You can run this subscription [in the Bitquery IDE
-
-▶️ [Pump fun token live prices using trades api](https://ide.bitquery.io/pump-fun-token-live-prices-using-trades-api_1)
 
 ### Uniswap
 
@@ -2154,37 +2154,37 @@ Filter `DEXTrades` with `ProtocolName` in `uniswap_v3`, `uniswap_v2`, `uniswap_v
 
 #### Solana trades subscription
 
-Below stream will give you realtime trades of `USDT` on Solana. Test the stream [here
+Below stream will give you realtime trades of `USDT` on Solana. Test the stream.
 
 ▶️ [Solana trades subscription](https://ide.bitquery.io/solana-trades-subscription_10_1)
 
 #### Stablecoin Depeg tracking Stream for evm
 
-Below stream tracks USDT on Ethereum when PriceInUSD is outside 0.95–1.05 (depeg-style band). Test the query [here
+Below stream tracks USDT on Ethereum when PriceInUSD is outside 0.95–1.05 (depeg-style band).
 
 ▶️ [Stablecoin Depeg tracking Stream for evm](https://ide.bitquery.io/Stablecoin-Depeg-tracking-Stream-for-evm)
 
 #### Stablecoin Depeg tracking Stream for tron
 
-Below stream tracks USDT on Tron when PriceInUSD is outside 0.95–1.05 (depeg-style band). Test the query [here
+Below stream tracks USDT on Tron when PriceInUSD is outside 0.95–1.05 (depeg-style band).
 
 ▶️ [Stablecoin Depeg tracking Stream for tron](https://ide.bitquery.io/Stablecoin-Depeg-tracking-Stream-for-tron)
 
 #### Stablecoin depeg tracking stream for USDC
 
-Below stream will be able to track specific Stablecoin depeg. In this query example, we are tracking depeg for the stablecoin `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` which has a symbol `USDC`. Test the query [here
+Below stream will be able to track specific Stablecoin depeg. In this query example, we are tracking depeg for the stablecoin `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` which has a symbol `USDC`.
 
 ▶️ [Stablecoin depeg tracking stream for USDC](https://ide.bitquery.io/stablecoin-depeg-tracking-stream-for-USDC)
 
 #### Stablecoin trades for etheruem
 
-Below stream will give you realtime USDT DEX trades on Ethereum. Test the stream [here
+Below stream will give you realtime USDT DEX trades on Ethereum. Test the stream.
 
 ▶️ [Stablecoin trades for etheruem](https://ide.bitquery.io/Stablecoin-trades-for-etheruem)
 
 #### Stablecoin trades for tron
 
-Below stream will give you realtime USDT DEX trades on Tron. Test the stream [here
+Below stream will give you realtime USDT DEX trades on Tron. Test the stream.
 
 ▶️ [Stablecoin trades for tron](https://ide.bitquery.io/Stablecoin-trades-for-tron)
 
@@ -2216,7 +2216,7 @@ Listen to stablecoin payments across all major blockchains. The Mempool option l
 
 #### Listening to All USDT and USDC Payments on Solana - stream
 
-Returns streams USDT (`TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`) transfers on Tron — the highest-volume stablecoin payments network globally.
+This subscription streams USDT (`TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`) transfers on Tron — the highest-volume stablecoin payments network globally.
 
 ▶️ [Listening to All USDT and USDC Payments on Solana - stream](https://ide.bitquery.io/Listening-to-All-USDT-and-USDC-Payments-on-Solana---stream)
 
@@ -2234,13 +2234,13 @@ A single-contract USDC payments stream on Ethereum mainnet. Swap the `SmartContr
 
 #### Stablecoin Realtime Transfers Stream on tron
 
-Below stream will give you realtime transfers of `USDT` on Tron. Test the stream [here
+Below stream will give you realtime transfers of `USDT` on Tron. Test the stream.
 
 ▶️ [Stablecoin Realtime Transfers Stream on tron](https://ide.bitquery.io/Stablecoin-Realtime-Transfers-Stream-on-tron)
 
 #### Stablecoin transfers websocket
 
-Below stream will give you realtime transfers of `USDC` on Solana. Test the stream [here
+Below stream will give you realtime transfers of `USDC` on Solana. Test the stream.
 
 ▶️ [Stablecoin transfers websocket](https://ide.bitquery.io/stablecoin-transfers-websocket)
 
@@ -2306,13 +2306,13 @@ Listen to stablecoin payments across all major blockchains. The Mempool option l
 
 #### Hyperliquid Real-time Trades Stream (WebSocket)
 
-Run it in the IDE: [Hyperliquid Trades Stream ➤
+Hyperliquid Real-time Trades Stream (WebSocket).
 
 ▶️ [Hyperliquid Real-time Trades Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-trades-stream)
 
 #### Solana Perps Live Trades Stream (Phoenix Fills)
 
-You can run a live fills stream [in the Bitquery IDE
+Stream every stop-loss and take-profit placement as it happens.
 
 ▶️ [Solana Perps Live Trades Stream (Phoenix Fills)](https://ide.bitquery.io/solana-perps-live-trades-stream)
 
@@ -2320,19 +2320,19 @@ You can run a live fills stream [in the Bitquery IDE
 
 #### Hyperliquid Price Updates Stream (WebSocket)
 
-Run it in the IDE: [Hyperliquid Price Updates Stream ➤
+Hyperliquid Price Updates Stream (WebSocket).
 
 ▶️ [Hyperliquid Price Updates Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-price-updates-stream)
 
 #### Hyperliquid Real-time Candles Stream (WebSocket)
 
-Run it in the IDE: [Hyperliquid Candles Stream ➤
+Hyperliquid Real-time Candles Stream (WebSocket).
 
 ▶️ [Hyperliquid Real-time Candles Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-candles-stream)
 
 #### Solana Perpetuals Mark Price Stream (Phoenix)
 
-You can run this stream [in the Bitquery IDE
+Solana Perpetuals Mark Price Stream (Phoenix).
 
 ▶️ [Solana Perpetuals Mark Price Stream (Phoenix)](https://ide.bitquery.io/solana-perpetuals-mark-price-stream)
 
@@ -2348,7 +2348,7 @@ This stream allows you to monitor real time NFT trades on OpenSea. It could also
 
 #### Latest Solana NFT Trades
 
-The subscription query provided below fetches the most recent NFT trades on the Solana blockchain. You can find the query [here
+The subscription query provided below fetches the most recent NFT trades on the Solana blockchain.
 
 ▶️ [Latest Solana NFT Trades](https://ide.bitquery.io/Latest-Solana-NFT-Trades)
 
@@ -2368,43 +2368,43 @@ Using Streaming APIs, you can subscribe to real-time changes on blockchains. We 
 
 #### Subscribe to the latest NFT transfers on Solana
 
-Let's see an example of NFT token transfers using GraphQL Subscription (Webhook). In the following API, we will be subscribing to all NFT token transfers. You can run the query [here
+Let's see an example of NFT token transfers using GraphQL Subscription (Webhook). In the following API, we will be subscribing to all NFT token transfers.
 
 ▶️ [Subscribe to the latest NFT transfers on Solana](https://ide.bitquery.io/Subscribe-to-the-latest-NFT-transfers-on-Solana)
 
 #### NFT Token Transfers API
 
-Let's see an example of NFT token transfers using GraphQL Subscription (Webhook). In the following NFT Token Transfers API, we will be subscribing to all NFT token transfers on Base network. You can run the query [here
+Let's see an example of NFT token transfers using GraphQL Subscription (Webhook). In the following NFT Token Transfers API, we will be subscribing to all NFT token transfers on Base network.
 
 ▶️ [NFT Token Transfers API](https://ide.bitquery.io/NFT-Token-Transfers-API_4)
 
 #### Transfers of a particular NFT
 
-Returns subscribes you to the real time transfers of a specific non-fungible token (NFT) on the Base network. You can find the query [here
+This query subscribes you to the real time transfers of a specific non-fungible token (NFT) on the Base network.
 
 ▶️ [Transfers of a particular NFT](https://ide.bitquery.io/Transfers-of-a-particular-NFT_1)
 
 #### Track realtime NFT Transfers of a specific NFT on BSC chain
 
-Returns subscribes you to the real time non-fungible token (NFT) transfers of a specific nft contract on the BSC network. You can find the query [here
+This query subscribes you to the real time non-fungible token (NFT) transfers of a specific nft contract on the BSC network.
 
 ▶️ [Track realtime NFT Transfers of a specific NFT on BSC chain](https://ide.bitquery.io/Track-realtime-NFT-Transfers-of-a-specific-NFT-on-BSC-chain)
 
 #### Track realtime NFT Transfers on BSC chain
 
-Let's see an example of NFT token transfers using GraphQL Subscription (Webhook). In the following NFT Token Transfers API, we will be subscribing to all NFT token transfers on BSC network. You can run the query [here
+Let's see an example of NFT token transfers using GraphQL Subscription (Webhook). In the following NFT Token Transfers API, we will be subscribing to all NFT token transfers on BSC network.
 
 ▶️ [Track realtime NFT Transfers on BSC chain](https://ide.bitquery.io/Track-realtime-NFT-Transfers-on-BSC-chain)
 
 #### Websocket for tracking Transfers of a particular NFT websocket
 
-Returns subscribes you to the real time transfers of a specific non-fungible token (NFT) on the Tron network. You can find the query [here
+This query subscribes you to the real time transfers of a specific non-fungible token (NFT) on the Tron network.
 
 ▶️ [Websocket for tracking Transfers of a particular NFT websocket](https://ide.bitquery.io/Websocket-for-tracking-Transfers-of-a-particular-NFT-websocket)
 
 #### Real-time-transfer-websocket-for-NFT-token on matic
 
-Returns subscribes you to the real time transfers of a specific non-fungible token (NFT) on the Matic network. You can find the query [here
+This query subscribes you to the real time transfers of a specific non-fungible token (NFT) on the Matic network.
 
 ▶️ [Real-time-transfer-websocket-for-NFT-token on matic](https://ide.bitquery.io/Real-time-transfer-websocket-for-NFT-token-on-matic)
 
@@ -2458,13 +2458,13 @@ Start by streaming large Polymarket trades. Each event gives you a buyer address
 
 #### Monitoring specific wallets trades in realtime for Ethereum up or down market
 
-The same wallet-monitoring pattern works for every Polymarket Up or Down market — only the `Question.Title` filter changes. Open any of the pre-built IDE queries below to stream trades for the chain you care about:
+The same wallet-monitoring pattern works for every Polymarket Up or Down market — only the `Question.Title` filter changes. Open any of the pre-built IDE queries below to stream trades for the chain you care about.
 
 ▶️ [Monitoring specific wallets trades in realtime for Ethereum up or down market](https://ide.bitquery.io/monitoring-specific-wallets-trades-in-realtime-for-Ethereum-up-or-down-market)
 
 #### Monitoring specific wallets trades in realtime for XRP up or down market
 
-The same wallet-monitoring pattern works for every Polymarket Up or Down market — only the `Question.Title` filter changes. Open any of the pre-built IDE queries below to stream trades for the chain you care about:
+The same wallet-monitoring pattern works for every Polymarket Up or Down market — only the `Question.Title` filter changes. Open any of the pre-built IDE queries below to stream trades for the chain you care about.
 
 ▶️ [Monitoring specific wallets trades in realtime for XRP up or down market](https://ide.bitquery.io/monitoring-specific-wallets-trades-in-realtime-for-XRP-up-or-down-market)
 

--- a/docs/start/starter-subscriptions.md
+++ b/docs/start/starter-subscriptions.md
@@ -1,267 +1,456 @@
 ---
-title: "Starter GraphQL Subscriptions"
-description: "Starter GraphQL Subscriptions: practical Bitquery setup guidance with examples for authentication, endpoints, and first queries."
+title: "Starter Subscriptions - Bitquery Real-Time Streams by Chain"
+description: "Curated, tested Bitquery GraphQL subscriptions organised by chain and data type — real-time trades, transfers, balances, prices and liquidity streams."
+keywords:
+  [
+    "Bitquery subscriptions",
+    "real-time blockchain data",
+    "GraphQL subscriptions",
+    "WebSocket streams",
+    "Bitquery IDE"
+  ]
 ---
 # Starter Subscriptions
 
-Below is a set of subscriptions that are curated for you to get started with Bitquery.
+Every subscription below is saved in the [Bitquery IDE](https://ide.bitquery.io) and was opened against the live WebSocket endpoint before publishing. Streams are always real time; for historical data see the [Starter Queries](/docs/start/starter-queries/).
 
 ## Table of Contents
 
-- [Cross-Chain / Multi-Chain APIs](#cross-chain--multi-chain-apis)
-- [Polymarket](#polymarket)
 - [Ethereum](#ethereum)
 - [Solana](#solana)
+- [BSC](#bsc)
 - [Base](#base)
-- [Robinhood Chain](#robinhood-chain)
-- [BSC (Binance Smart Chain)](#bsc-binance-smart-chain)
+- [Arbitrum](#arbitrum)
+- [Optimism](#optimism)
+- [Polygon](#polygon)
 - [TRON](#tron)
-- [NFT Streams](#nft-streams)
-- [x402 Streams](#x402-streams)
-
-## Cross-Chain / Multi-Chain APIs
-
-#### Crypto Price Stream
-
-This subscription gives you 1-second OHLC, mean price, averages for all tokens across Solana, Ethereum, BNB, Tron.
-
-▶️ [Crypto Price Stream](https://ide.bitquery.io/1-second-crypto-price-stream-with-mcap)
-
-#### Stablecoin 1 sec Price Stream
-
-This subscription gives you 1-second OHLC, mean price, averages for all stablecoins including USDC, USDT, DAI, USDS etc.
-
-▶️ [Stablecoin Price Stream](https://ide.bitquery.io/stablecoin-1-second-price-stream)
-
-## Polymarket
-
-### Prediction Market Trades
-
-#### Real-Time Trades Stream
-
-Subscribe to live prediction market trades as they occur on Polygon (successful transactions only).
-▶️ [Prediction Market Trades Stream](https://ide.bitquery.io/prediction-market-trades-subscription)
-
-#### Trades for a Specific Market (Stream)
-
-Subscribe to trades for one market only by filtering on Question.MarketId. Replace the market ID in the query with your target market.
-▶️ [Subscribe to Specific Market Trades](https://ide.bitquery.io/subscribe-to-specific-market-trades)
-
-### Prediction Market Managements
-
-#### Real-Time Management Stream (Creations + Resolutions)
-
-Subscribe to all prediction market lifecycle events (Created and Resolved) as they occur on Polygon.
-▶️ [Prediction Managements Stream](https://ide.bitquery.io/Prediction-Managements-subscription-resolutions-creations)
-
-#### Real-Time Market Creations
-
-Subscribe only to new market (Created) events.
-▶️ [Realtime Market Creations](https://ide.bitquery.io/track-realtime-new-polymarket-creations)
-
-#### Real-Time Market Resolutions
-
-Subscribe only to Resolved events. Winning outcome is in Prediction.Outcome; token details (e.g. AssetId) in Prediction.OutcomeToken.
-▶️ [Realtime Market Resolutions](https://ide.bitquery.io/track-realtime-polymarket-resolutions)
-
-### Prediction Market Settlements
-
-#### Real-Time Settlement Stream
-
-Subscribe to live Split, Merge, and Redemption events as they occur on Polygon.
-▶️ [Real-Time Prediction Market Settlements Stream](https://ide.bitquery.io/realtime-predicion-market-settlements-stream)
+- [Robinhood Chain](#robinhood-chain)
+- [Bitcoin](#bitcoin)
+- [Trading API](#trading-api)
+- [Stablecoins](#stablecoins)
+- [Perpetuals](#perpetuals)
+- [NFTs](#nfts)
+- [Polymarket](#polymarket)
+- [x402](#x402)
+- [Cross-Chain](#cross-chain)
 
 ## Ethereum
 
-### Balance APIs
+### Trades
 
-#### Subscribe to All Transaction Balances
+#### All DEX trades
 
-This subscription provides real-time balance updates for all addresses involved in transactions on the Ethereum network.
+Every Ethereum DEX trade as it happens. Add a `where` filter to narrow to a token or protocol.
 
-▶️ [Subscribe to All Transaction Balances](https://ide.bitquery.io/Subscribe-to-All-Transaction-Balances)
+▶️ [All DEX trades](https://ide.bitquery.io/All-Ethereum-Trade-Stream_1)
 
-#### Subscribe to Transaction Balances for a Specific Address
+#### All swap events
 
-This subscription filters transaction balances for a specific address in real-time.
+All swap events. Uses the `Events` cube.
 
-▶️ [Subscribe to Transaction Balances for a Specific Address](https://ide.bitquery.io/Subscribe-to-Transaction-Balances-for-a-Specific-Address)
+▶️ [All swap events](https://ide.bitquery.io/all-swap-events)
 
-#### Stream Token Balance of a Address in Real Time
+#### Get pair trades data just like dexcsreener
 
-Subscribe to real-time token balance updates for a specific address and token. This subscription will notify you whenever the token balance changes.
+Get pair trades data just like dexcsreener. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-▶️ [Stream Token Balance Updates in Real Time](https://ide.bitquery.io/Stream-Token-Balance-Updates-in-Real-Time)
+▶️ [Get pair trades data just like dexcsreener](https://ide.bitquery.io/Get-pair-trades-data-just-like-dexcsreener)
 
-#### Track Token Balance Changes
+#### Get pair trades data just like geckoterminal
 
-Monitor token balance changes for a specific token across all transactions. This helps track token movements and transfers.
+Get pair trades data just like geckoterminal. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-▶️ [Track Token Balance Changes by Transaction](https://ide.bitquery.io/Track-Any-Token-Balance-Changes-by-Transaction-on-ETH)
+▶️ [Get pair trades data just like geckoterminal](https://ide.bitquery.io/Get-pair-trades-data-just-like-geckoterminal)
 
-#### Track Validator Balance Updates
+#### Latest token trades subscription
 
-Monitor balance changes for Ethereum validators, including staking rewards and withdrawals from the beacon chain.
+Latest token trades subscription. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
 
-▶️ [Track Validator Balance Updates](https://ide.bitquery.io/Track-Validator-Balance-Updates)
+▶️ [Latest token trades subscription](https://ide.bitquery.io/latest-token-trades-subscription)
 
-#### Track Validator Rewards
+#### Pepe live trades stream
 
-Track validator rewards and balance increases from staking activities in real-time.
+Pepe live trades stream. Uses the `DEXTradeByTokens` cube.
 
-▶️ [Track Validator Rewards](https://ide.bitquery.io/Track-Validator-Rewards)
+▶️ [Pepe live trades stream](https://ide.bitquery.io/pepe-live-trades-stream)
 
-#### Track Miner Balance Updates
+#### Real time trades of an ethereum address
 
-Monitor balance changes for Ethereum miners, including block rewards, uncle block rewards, and transaction fee rewards.
+Real time trades of an ethereum address. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
 
-▶️ [Track Miner Balance Updates](https://ide.bitquery.io/Track-Miner-Balance-Updates)
+▶️ [Real time trades of an ethereum address](https://ide.bitquery.io/Real-time-trades-of-an-ethereum-address)
 
-#### Track Block Mining Rewards
+#### Stream new position mints on Fluid DEX Vault
 
-Track rewards received by miners for successfully mining blocks in real-time.
+Stream new position mints on Fluid DEX Vault. Uses the `Events` cube. Change the token address in the `where` clause to use it.
 
-▶️ [Track Block Mining Rewards](https://ide.bitquery.io/Track-Block-Mining-Rewards)
+▶️ [Stream new position mints on Fluid DEX Vault](https://ide.bitquery.io/stream-new-position-mints-on-Fluid-DEX-Vault)
 
-#### Track MEV-Related Balance Updates
+#### Subscribe to dex trades on ethereum mainnet
 
-Monitor balance changes related to MEV activities, including transaction fee rewards and block builder rewards.
+Subscribe to dex trades on ethereum mainnet.
 
-▶️ [Track MEV-Related Balance Updates](https://ide.bitquery.io/Track-MEV-Related-Balance-Updates)
+▶️ [Subscribe to dex trades on ethereum mainnet](https://ide.bitquery.io/subscribe-to-dex-trades-on-ethereum-mainnet_2)
 
-#### Track All Self-Destruct Event Balances
+#### Trades of a specific trader of a specific token
 
-Monitor all contract self-destruct event balances in real-time.
+Trades of a specific trader of a specific token. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
 
-▶️ [Track All Self-Destruct Event Balances](https://ide.bitquery.io/All-Self-Destruct-Event-Balances-Stream)
-
-#### Monitoring Balance after Latest Gas Fee Burn
-
-Monitor the balance and gas fee burnt for a particular address in real-time.
-
-▶️ [Monitoring Balance after Latest Gas Fee Burn](https://ide.bitquery.io/Monitor-balance-and-gas-fee-paid-for-an-address-using-stream_1)
-
-### Token supply
-
-#### Monitor Token Supply
-
-Monitor Real time token supply in real time on Ethereum chain.
-
-▶️ [Monitor Latest token supply](https://ide.bitquery.io/latest-token-supply-on-eth-chain)
-
-### MarketCap Streams
-
-Real-time **Trading API `Tokens`** streams for Ethereum: aggregated **market cap**, **FDV**, **supply**, **price**, and **volume**. Use **lowercase** addresses in **`eth:`** ids. More detail: **[Ethereum Token Market Cap API](/docs/blockchain/Ethereum/token-supply/ethereum-token-marketcap-api)**.
-
-#### Ethereum token market cap stream (Trading API)
-
-Subscribe to **`Tokens`** rows for assets whose currency id includes **`eth`** (interval duration &gt; 1s).
-
-▶️ [Ethereum Token Market Cap Stream](https://ide.bitquery.io/ethereum-token-marketcap-stream_1)
-
-#### Ethereum tokens with market cap above $1 million (Trading API)
-
-Subscribe when **`Token.Id`** matches Ethereum and **`Supply.MarketCap`** &gt; 1,000,000 USD.
-
-▶️ [Ethereum Tokens With Market Cap Above $1M](https://ide.bitquery.io/realtime-stream-ethereum-tokens-with-marketcap-above-1-million)
+▶️ [Trades of a specific trader of a specific token](https://ide.bitquery.io/trades-of-a-specific-trader-of-a-specific-token)
 
 ### Transfers
 
-#### Token Transfers Stream
+#### Token transfers
 
-This stream lets you monitor all the token transfers for a particular token. You can modify this subscription to track and monitor token transfers for a particular token from or to a particular address.
+Live ERC-20 transfers. Change the token address to follow a different one.
 
-▶️ [Token Transfers Stream](https://ide.bitquery.io/Subscribe-to-Latest-WETH-token-transfers_3)
+▶️ [Token transfers](https://ide.bitquery.io/Subscribe-to-Latest-WETH-token-transfers_3)
 
-### Trades
+#### Pepe whale transfer stream
 
-#### Ethereum DEX Trades Stream
+Pepe whale transfer stream. Uses the `Transfers` cube.
 
-This stream returns all the real time DEX trades happening on Ethereum mainnet. You can modify this stream to get DEX trades on a particular DEX or trades of a particular token or trades by a particular trader.
+▶️ [Pepe whale transfer stream](https://ide.bitquery.io/pepe-whale-transfer-stream)
 
-▶️ [DEX Trades Stream](https://ide.bitquery.io/All-Ethereum-Trade-Stream_1)
+#### Subscribe to Latest WETH token transfers
 
-#### Uniswap Trades Stream
+Subscribe to Latest WETH token transfers. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
 
-This subscription returns the real-time trades happening on Uniswap. You can modify the stream to get real-time trades for a particular token, a particular token pair and even a particular trader.
+▶️ [Subscribe to Latest WETH token transfers](https://ide.bitquery.io/Subscribe-to-Latest-WETH-token-transfers)
 
-▶️ [Uniswap Trades Stream](https://ide.bitquery.io/All-Ethereum-Uniswap-Trade-Stream)
+#### Subscribe to latest Axie infinity token transfers
 
-### Slippage Streams
+Subscribe to latest Axie infinity token transfers. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
 
-#### Realtime Slippage Monitoring
+▶️ [Subscribe to latest Axie infinity token transfers](https://ide.bitquery.io/Subscribe-to-latest-Axie-infinity-token-transfers_1)
 
-This subscription query returns real-time slippage data for all DEX pools on Ethereum. You can monitor price impact and liquidity depth as trades occur.
+### Balances & Holders
 
-▶️ [Realtime Slippage Monitoring](https://ide.bitquery.io/realtime-slippage-on-ethereum)
+#### Balance of a specific address
 
-#### Realtime Slippage for Uniswap V4 Pools
+Live balance updates for one wallet. Replace the address.
 
-This subscription query retrieves real-time slippage data for Uniswap V4 pools on Ethereum. Unlike Uniswap V3, which uses the pool's smart contract address, Uniswap V4 requires using the `PoolId` to identify pools.
+▶️ [Balance of a specific address](https://ide.bitquery.io/Stream-Token-Balance-Updates-in-Real-Time)
 
-▶️ [Realtime Slippage for Uniswap V4 Pools](https://ide.bitquery.io/realtime-pair-slippage-on-ethereum-uniswap-v4)
+#### All transaction balances
 
-### Liquidity Streams
+Every balance change on the chain — high volume, filter before using in production.
+
+▶️ [All transaction balances](https://ide.bitquery.io/Subscribe-to-All-Transaction-Balances)
+
+#### Transaction balances for one address
+
+Balance changes scoped to a single wallet.
+
+▶️ [Transaction balances for one address](https://ide.bitquery.io/Subscribe-to-Transaction-Balances-for-a-Specific-Address)
+
+#### Token balance changes by transaction
+
+Balance deltas for every token, transaction by transaction.
+
+▶️ [Token balance changes by transaction](https://ide.bitquery.io/Track-Any-Token-Balance-Changes-by-Transaction-on-ETH)
+
+#### Balance update after transfer received from multiple addresses--stream
+
+Balance update after transfer received from multiple addresses--stream. Uses the `TransactionBalances` cube.
+
+▶️ [Balance update after transfer received from multiple addresses--stream](https://ide.bitquery.io/Balance-update-after-transfer-received-from-multiple-addresses--stream)
+
+#### Balance update after transfer received--stream
+
+Balance update after transfer received--stream. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Balance update after transfer received--stream](https://ide.bitquery.io/Balance-update-after-transfer-received--stream)
+
+#### Balance update after transfer sent from multiple addresses--stream
+
+Balance update after transfer sent from multiple addresses--stream. Uses the `TransactionBalances` cube.
+
+▶️ [Balance update after transfer sent from multiple addresses--stream](https://ide.bitquery.io/Balance-update-after-transfer-sent-from-multiple-addresses--stream)
+
+#### Balance update after transfer sent--stream
+
+Balance update after transfer sent--stream. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Balance update after transfer sent--stream](https://ide.bitquery.io/Balance-update-after-transfer-sent--stream_3)
+
+#### Balance update from transfer for an address--stream
+
+Balance update from transfer for an address--stream. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Balance update from transfer for an address--stream](https://ide.bitquery.io/balance-update-from-transfer-for-an-address--stream)
+
+#### Balance update from transfer for multiple addresses--stream
+
+Balance update from transfer for multiple addresses--stream. Uses the `TransactionBalances` cube.
+
+▶️ [Balance update from transfer for multiple addresses--stream](https://ide.bitquery.io/balance-update-from-transfer-for-multiple-addresses--stream)
+
+### Price & OHLC
+
+#### 1-second OHLC candles
+
+Rolling one-second candles for charting.
+
+▶️ [1-second OHLC candles](https://ide.bitquery.io/1-second-OHLC-k-line-Ethereum)
+
+#### Token price stream
+
+Live USD price updates as trades land.
+
+▶️ [Token price stream](https://ide.bitquery.io/token-price-stream)
+
+#### 1 second crypto price stream
+
+1 second crypto price stream. Uses the `Tokens` cube.
+
+▶️ [1 second crypto price stream](https://ide.bitquery.io/1-second-crypto-price-stream)
+
+#### Pepe-ohlcv-stream
+
+Pepe-ohlcv-stream. Uses the `Tokens` cube.
+
+▶️ [Pepe-ohlcv-stream](https://ide.bitquery.io/pepe-ohlcv-stream)
+
+### Supply & Market Cap
+
+#### Token market cap stream
+
+Live market cap updates for Ethereum tokens.
+
+▶️ [Token market cap stream](https://ide.bitquery.io/ethereum-token-marketcap-stream_1)
+
+#### Tokens crossing $1M market cap
+
+Only tokens above a market cap floor. Change the threshold in the `where` clause.
+
+▶️ [Tokens crossing $1M market cap](https://ide.bitquery.io/realtime-stream-ethereum-tokens-with-marketcap-above-1-million)
+
+#### Token supply changes
+
+Mints and burns as they change a token's supply.
+
+▶️ [Token supply changes](https://ide.bitquery.io/latest-token-supply-on-eth-chain)
+
+#### All trades on Ethereum with Price, Marketcap, supply
+
+All trades on Ethereum with Price, Marketcap, supply. Uses the `Trades` cube.
+
+▶️ [All trades on Ethereum with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Ethereum-with-Price-Marketcap-supply)
+
+### Liquidity & Pools
+
+#### Realtime slippage monitoring
+
+Slippage on every trade as it happens, across all pools.
+
+▶️ [Realtime slippage monitoring](https://ide.bitquery.io/realtime-slippage-on-ethereum)
 
 #### Realtime Liquidity Stream
 
-This subscription query returns real-time liquidity data for all DEX pools on Ethereum. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
+Realtime Liquidity Stream.
 
-▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_4#)
+▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_4)
 
 #### Realtime Liquidity Stream of a Specific Pool
 
-This subscription query monitors real-time liquidity changes for a specific DEX pool on Ethereum. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
+Realtime Liquidity Stream of a Specific Pool. Uses the `DEXPoolEvents` cube.
 
-▶️ [Realtime Liquidity Stream of a Specific Pool](https://ide.bitquery.io/Realtime-Liquidity-Stream-of-a-Specific-Pool_4#)
+▶️ [Realtime Liquidity Stream of a Specific Pool](https://ide.bitquery.io/Realtime-Liquidity-Stream-of-a-Specific-Pool_4)
 
-### OHLC & Price Data
+### Transactions
 
-#### Real-time 1 second OHLC
+#### Get Transaction Hash
 
-This stream provides real time price and OHLC stream for all tokens on Ethereum based on trades.
+Get Transaction Hash.
 
-▶️ [Real-time 1 second OHLC](https://ide.bitquery.io/1-second-OHLC-k-line-Ethereum)
+▶️ [Get Transaction Hash](https://ide.bitquery.io/Get-Transaction-Hash)
 
-#### Token Price Stream
+### Events & Calls
 
-This stream returns the real time trade price of a token against the token it is traded with and the price in USD. You could modify the stream to get the price of the token for a particular token pair or against a particular token.
+#### Stream pool and pair creation on ethereum
 
-▶️ [Token Price Stream](https://ide.bitquery.io/token-price-stream)
+Stream pool and pair creation on ethereum. Uses the `Events` cube.
 
-### Events Streams
+▶️ [Stream pool and pair creation on ethereum](https://ide.bitquery.io/stream-pool-and-pair-creation-on-ethereum_1)
 
-#### Pair Creation on Uniswap
+#### Subscribe to the Same Event Across Multiple Contracts
 
-This stream returns the real time liquidity pools/token pairs created on Uniswap V3. You could modify the stream to monitor newly created pools on a different protocol.
+Subscribe to the Same Event Across Multiple Contracts. Uses the `Events` cube.
 
-▶️ [Pair Creation Stream](https://ide.bitquery.io/Latest-pools-created-Uniswap-v3_10_1)
+▶️ [Subscribe to the Same Event Across Multiple Contracts](https://ide.bitquery.io/Subscribe-to-the-Same-Event-Across-Multiple-Contracts)
+
+### Mempool
+
+#### Binance Mempool Transactions
+
+Binance Mempool Transactions. Uses the `Transactions` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Binance Mempool Transactions](https://ide.bitquery.io/Binance-Mempool-Transactions_1)
+
+#### Eth subscribe("logs")
+
+Eth subscribe("logs"). Uses the `Events` cube.
+
+▶️ [Eth subscribe("logs")](https://ide.bitquery.io/eth_subscribelogs)
+
+#### Eth subscribe(“pendingTransactions”)
+
+Eth subscribe(“pendingTransactions”).
+
+▶️ [Eth subscribe(“pendingTransactions”)](https://ide.bitquery.io/eth_subscribependingTransactions)
+
+#### Current mempool fees
+
+Gas prices being offered by pending transactions right now.
+
+▶️ [Current mempool fees](https://ide.bitquery.io/Get-Mempool-Fees)
+
+#### Mempool event stream
+
+Mempool event stream.
+
+▶️ [Mempool event stream](https://ide.bitquery.io/Mempool-event-stream)
+
+#### Pending DEX trades in the mempool
+
+Swaps sitting in the mempool — see trades before they confirm.
+
+▶️ [Pending DEX trades in the mempool](https://ide.bitquery.io/mempool-token-trades_1)
+
+#### Pending transfers in the mempool
+
+Token transfers that are broadcast but not yet mined.
+
+▶️ [Pending transfers in the mempool](https://ide.bitquery.io/mempool-transfers_1)
+
+#### New pairs being created, from the mempool
+
+Catches pool creation at broadcast time rather than after the block.
+
+▶️ [New pairs being created, from the mempool](https://ide.bitquery.io/PairCreated-in-Mempool)
+
+#### Vrs signature
+
+Vrs signature.
+
+▶️ [Vrs signature](https://ide.bitquery.io/vrs-signature)
+
+### Blocks & Validators
+
+#### Balance after gas fee burn
+
+Tracks an address's balance alongside the gas it burns.
+
+▶️ [Balance after gas fee burn](https://ide.bitquery.io/Monitor-balance-and-gas-fee-paid-for-an-address-using-stream_1)
+
+#### Self-destruct balance events
+
+Balances released when a contract self-destructs.
+
+▶️ [Self-destruct balance events](https://ide.bitquery.io/All-Self-Destruct-Event-Balances-Stream)
+
+#### Block mining rewards
+
+Reward paid out per block.
+
+▶️ [Block mining rewards](https://ide.bitquery.io/Track-Block-Mining-Rewards)
+
+#### MEV-related balance changes
+
+Balance movements tied to MEV payouts and builder rewards.
+
+▶️ [MEV-related balance changes](https://ide.bitquery.io/Track-MEV-Related-Balance-Updates)
+
+#### Miner balance changes
+
+Balance movements on block producers.
+
+▶️ [Miner balance changes](https://ide.bitquery.io/Track-Miner-Balance-Updates)
+
+#### Validator balance changes
+
+Balance movements on validator addresses.
+
+▶️ [Validator balance changes](https://ide.bitquery.io/Track-Validator-Balance-Updates)
+
+#### Validator rewards
+
+Rewards paid to validators, block by block.
+
+▶️ [Validator rewards](https://ide.bitquery.io/Track-Validator-Rewards)
+
+#### Filter by MEV Bot or Builder Address
+
+Filter by MEV Bot or Builder Address. Uses the `TransactionBalances` cube.
+
+▶️ [Filter by MEV Bot or Builder Address](https://ide.bitquery.io/Filter-by-MEV-Bot-or-Builder-Address)
+
+#### Filter by Miner Address
+
+Filter by Miner Address. Uses the `TransactionBalances` cube.
+
+▶️ [Filter by Miner Address](https://ide.bitquery.io/Filter-by-Miner-Address)
+
+#### Filter by Validator Address
+
+Filter by Validator Address. Uses the `TransactionBalances` cube.
+
+▶️ [Filter by Validator Address](https://ide.bitquery.io/Filter-by-Validator-Address)
+
+### Uniswap
+
+#### New Uniswap v3 pools
+
+Pool creation events as they are mined — new pair detection.
+
+▶️ [New Uniswap v3 pools](https://ide.bitquery.io/Latest-pools-created-Uniswap-v3_10_1)
+
+#### Slippage on Uniswap v4 pools
+
+Per-trade slippage for v4 pools.
+
+▶️ [Slippage on Uniswap v4 pools](https://ide.bitquery.io/realtime-pair-slippage-on-ethereum-uniswap-v4)
+
+#### Uniswap trades
+
+Live trades on Uniswap only.
+
+▶️ [Uniswap trades](https://ide.bitquery.io/All-Ethereum-Uniswap-Trade-Stream)
+
+#### Currency pair liquidity events stream
+
+Currency pair liquidity events stream. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Currency pair liquidity events stream](https://ide.bitquery.io/currency-pair-liquidity-events-stream)
+
+#### Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4
+
+Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4. Uses the `DEXPoolEvents` cube.
+
+▶️ [Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4](https://ide.bitquery.io/Latest-Liquidity-Changes-of-Pools-in-a-Specific-DEX-Protocol---Uniswap-V4_6)
+
+#### Latest pools created Uniswap v3
+
+Latest pools created Uniswap v3. Uses the `Events` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Latest pools created Uniswap v3](https://ide.bitquery.io/Latest-pools-created-Uniswap-v3_9)
 
 ## Solana
 
-### Balance APIs
-
-#### Balance Stream
-
-This stream provides all balance updates on the Solana blockchain.
-
-▶️ [Balance Update Stream](https://ide.bitquery.io/solana-balance-update-stream_3)
-
-#### Token Balance Stream
-
-This stream provides all balance updates of a specific token on the Solana blockchain.
-
-▶️ [Token Balance Update Stream](https://ide.bitquery.io/USDC-balance-stream)
-
-### Transfers
-
-#### Token Transfers Stream
-
-This stream provides all token transfers on the Solana blockchain, including SOL transfers.
-
-▶️ [Token Transfer Stream](https://ide.bitquery.io/Solana-transfers-stream_3)
-
 ### Trades
+
+#### Graduated Tokens
+
+This query gives you tokens which are graduated from Raydium Launchpad to Raydium.
+
+▶️ [Graduated Tokens](https://ide.bitquery.io/Track-Token-Migrations-to-Raydium-DEX-and-Raydium-CPMM-in-realtime)
+
+#### Large Token Buys and Sells on Solana DEX
+
+This stream provides real-time large buy and sell on Solana DEXs.
+
+▶️ [Large Token Buys and Sells on Solana DEX](https://ide.bitquery.io/big-trades-on-solana)
 
 #### Solana Trades Stream
 
@@ -275,13 +464,107 @@ This subscription stream uses DexTradeByTokens API to stream real-time specific 
 
 ▶️ [Specific Token Trades Stream](https://ide.bitquery.io/token-trades-subscription)
 
-#### Large Token Buys and Sells on Solana DEX
+#### All Trade for Bags.fm tokens
 
-This stream provides real-time large buy and sell on Solana DEXs.
+All Trade for Bags.fm tokens. Uses the `DEXTrades` cube.
 
-▶️ [Large Token Buys and Sells on Solana DEX](https://ide.bitquery.io/big-trades-on-solana)
+▶️ [All Trade for Bags.fm tokens](https://ide.bitquery.io/All-Trade-for-Bagsfm-tokens)
 
-### OHLC & Price Data
+#### CPMM trades
+
+CPMM trades. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [CPMM trades](https://ide.bitquery.io/CPMM-trades)
+
+#### Get Solana pair trades data
+
+Get Solana pair trades data. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get Solana pair trades data](https://ide.bitquery.io/Get-Solana-pair-trades-data)
+
+#### Get Solana pair trades data just like dexcsreener
+
+Get Solana pair trades data just like dexcsreener. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get Solana pair trades data just like dexcsreener](https://ide.bitquery.io/Get-Solana-pair-trades-data-just-like-dexcsreener)
+
+#### Get Solana pair trades data just like geckoTerminal
+
+Get Solana pair trades data just like geckoTerminal. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get Solana pair trades data just like geckoTerminal](https://ide.bitquery.io/Get-Solana-pair-trades-data-just-like-geckoTerminal_1)
+
+#### Latest Trades of TESLA onchain xStock
+
+Latest Trades of TESLA onchain xStock. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Latest Trades of TESLA onchain xStock](https://ide.bitquery.io/Latest-Trades-of-TESLA-onchain-xStock_1)
+
+### Transfers
+
+#### Token Transfers Stream
+
+This stream provides all token transfers on the Solana blockchain, including SOL transfers.
+
+▶️ [Token Transfers Stream](https://ide.bitquery.io/Solana-transfers-stream_3)
+
+#### SPL transfers websocket
+
+SPL transfers websocket. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+
+▶️ [SPL transfers websocket](https://ide.bitquery.io/SPL-transfers-websocket_1)
+
+#### Solana Websocket - Subscribe to all transfers of specific addresses in realtime
+
+Solana Websocket - Subscribe to all transfers of specific addresses in realtime. Uses the `Transfers` cube.
+
+▶️ [Solana Websocket - Subscribe to all transfers of specific addresses in realtime](https://ide.bitquery.io/Solana-Websocket---Subscribe-to-all-transfers-of-specific-addresses-in-realtime)
+
+#### Subscribe to the all transfers on Solana
+
+Subscribe to the all transfers on Solana.
+
+▶️ [Subscribe to the all transfers on Solana](https://ide.bitquery.io/Subscribe-to-the-all-transfers-on-Solana)
+
+#### Transfers of All Tip Payment Accounts on Solana
+
+Transfers of All Tip Payment Accounts on Solana. Uses the `Transfers` cube.
+
+▶️ [Transfers of All Tip Payment Accounts on Solana](https://ide.bitquery.io/Transfers-of-All-Tip-Payment-Accounts-on-Solana)
+
+#### Transfers of Tip Payment Accounts on Solana
+
+Transfers of Tip Payment Accounts on Solana. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Transfers of Tip Payment Accounts on Solana](https://ide.bitquery.io/Transfers-of-Tip-Payment-Accounts-on-Solana_1)
+
+#### Transfers where sender is the specified address
+
+Transfers where sender is the specified address. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Transfers where sender is the specified address](https://ide.bitquery.io/transfers-where-sender-is-the-specified-address_1)
+
+### Balances & Holders
+
+#### Balance Stream
+
+This stream provides all balance updates on the Solana blockchain.
+
+▶️ [Balance Stream](https://ide.bitquery.io/solana-balance-update-stream_3)
+
+### Price & OHLC
+
+#### 1-Second OHLC Stream
+
+This subscription generates a real-time OHLC (Open, High, Low, Close) K-line chart for Solana in real-time, useful for Tradingview charting in real-time.
+
+▶️ [1-Second OHLC Stream](https://ide.bitquery.io/1-second-OHLC-k-line-Solana)
+
+#### Real-Time Token Prices in USD on Solana
+
+Stream live OHLC (Open, High, Low, Close) price and volume data for all tokens on Solana, quoted directly in USD. Useful for dashboards, analytics, or bots that need stable fiat-based prices.
+
+▶️ [Real-Time Token Prices in USD on Solana](https://ide.bitquery.io/Real-Time-usd-price-on-solana-chain)
 
 #### Real-time Token Prices on Solana
 
@@ -289,29 +572,93 @@ This stream delivers real-time token prices on Solana based on the latest trades
 
 ▶️ [Real-time Token Prices on Solana](https://ide.bitquery.io/Real-time-price-stream-for-specific-token-on-solana)
 
-#### 1-Second OHLC Stream
+#### Byreal token live prices using trades api
 
-This subscription generates a real-time OHLC (Open, High, Low, Close) K-line chart for Solana in real-time, useful for Tradingview charting in real-time.
+Byreal token live prices using trades api. Uses the `Trades` cube.
 
-▶️ [Seconds OHLC Stream](https://ide.bitquery.io/1-second-OHLC-k-line-Solana)
+▶️ [Byreal token live prices using trades api](https://ide.bitquery.io/Byreal-token-live-prices-using-trades-api)
 
-### MarketCap Streams
+#### Get Latest Price of SOL in USD Real-time
 
-Real-time **Trading API `Tokens`** streams for **Solana**: aggregated **market cap**, **FDV**, **supply**, **price**, and **volume**. Use **`solana:`** mint ids. More detail: **[Solana Token Market Cap API](/docs/blockchain/Solana/solana-token-marketcap-api)**.
+Get Latest Price of SOL in USD Real-time. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-#### Solana token market cap stream (Trading API)
+▶️ [Get Latest Price of SOL in USD Real-time](https://ide.bitquery.io/Get-Latest-Price-of-SOL-in--USD-Real-time)
 
-Subscribe to **`Tokens`** rows for assets whose currency id includes **`solana`** (interval duration &gt; 1s).
+#### Get realtime Price of Apple xStock in USD Real-time
 
-▶️ [Solana Token Market Cap Stream](https://ide.bitquery.io/solana-token-marketcap-stream)
+Get realtime Price of Apple xStock in USD Real-time. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get realtime Price of Apple xStock in USD Real-time](https://ide.bitquery.io/Get-realtime-Price-of-Apple-xStock-in--USD-Real-time)
+
+#### GoonFi Realtime OHLC, Price, Volume API - Crypto Price API
+
+GoonFi Realtime OHLC, Price, Volume API - Crypto Price API. Uses the `Pairs` cube.
+
+▶️ [GoonFi Realtime OHLC, Price, Volume API - Crypto Price API](https://ide.bitquery.io/GoonFi-Realtime-OHLC-Price-Volume-API---Crypto-Price-API_1)
+
+#### Latest price for more than 1 markets on solana
+
+Latest price for more than 1 markets on solana. Uses the `DEXTrades` cube.
+
+▶️ [Latest price for more than 1 markets on solana](https://ide.bitquery.io/latest-price-for-more-than-1-markets-on-solana_1)
+
+#### Latest price for more than 1 markets on solana for specific currencies
+
+Latest price for more than 1 markets on solana for specific currencies. Uses the `DEXTrades` cube.
+
+▶️ [Latest price for more than 1 markets on solana for specific currencies](https://ide.bitquery.io/latest-price-for-more-than-1-markets-on-solana-for-specific-currencies)
+
+#### Price of a moonshot token
+
+Price of a moonshot token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Price of a moonshot token](https://ide.bitquery.io/Price-of-a-Moonshot-token)
+
+### Supply & Market Cap
 
 #### Solana tokens with market cap above $1 million (Trading API)
 
 Subscribe when **`Token.Id`** matches Solana and **`Supply.MarketCap`** &gt; 1,000,000 USD.
 
-▶️ [Solana Tokens With Market Cap Above $1M](https://ide.bitquery.io/realtime-stream-solana-tokens-with-marketcap-above-1-million)
+▶️ [Solana tokens with market cap above $1 million (Trading API)](https://ide.bitquery.io/realtime-stream-solana-tokens-with-marketcap-above-1-million)
 
-### Pool/Liquidity APIs
+#### All trades on Solana with Price, Marketcap, supply
+
+All trades on Solana with Price, Marketcap, supply. Uses the `Trades` cube.
+
+▶️ [All trades on Solana with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Solana-with-Price-Marketcap-supply)
+
+#### Bags.fm token creation stream using Solana token supply updates
+
+Bags.fm token creation stream using Solana token supply updates. Uses the `TokenSupplyUpdates` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Bags.fm token creation stream using Solana token supply updates](https://ide.bitquery.io/Bagsfm-token-creation-stream-using-Solana-token-supply-updates)
+
+#### Get All DEX Trades on DBC With Price, Market Cap, and Supply
+
+Get All DEX Trades on DBC With Price, Market Cap, and Supply. Uses the `Trades` cube.
+
+▶️ [Get All DEX Trades on DBC With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-DBC-With-Price-Market-Cap-and-Supply)
+
+#### Get newly created Moonshot tokens with metadata
+
+Get newly created Moonshot tokens with metadata. Uses the `TokenSupplyUpdates` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Get newly created Moonshot tokens with metadata](https://ide.bitquery.io/Get-newly-created-Moonshot-tokens-with-metadata)
+
+#### Newly created PF token, dev address, metadata
+
+Newly created PF token, dev address, metadata. Uses the `TokenSupplyUpdates` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Newly created PF token, dev address, metadata](https://ide.bitquery.io/newly-created-PF-token-dev-address-metadata)
+
+#### Realtime heaven tokens with marketcap 10k
+
+Realtime heaven tokens with marketcap 10k. Uses the `Pairs` cube.
+
+▶️ [Realtime heaven tokens with marketcap 10k](https://ide.bitquery.io/realtime-heaven-tokens-with-marketcap-10k)
+
+### Liquidity & Pools
 
 #### DEXPool Liquidity Changes
 
@@ -319,13 +666,59 @@ This stream provides real time liquidity details for all pools on Solana.
 
 ▶️ [DEXPool Liquidity Changes](https://ide.bitquery.io/Solana-DEXPools-stream_2)
 
-### PumpFun APIs
+#### Latest pools created on trends.fun stream
+
+Latest pools created on trends.fun stream. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest pools created on trends.fun stream](https://ide.bitquery.io/latest-pools-created-on-trendsfun-stream)
+
+#### Latest price based on liquidity
+
+Latest price based on liquidity. Uses the `DEXPools` cube.
+
+▶️ [Latest price based on liquidity](https://ide.bitquery.io/latest-price-based-on-liquidity_2)
+
+#### Liquidity for a launchpad token pair stream
+
+Liquidity for a launchpad token pair stream. Uses the `DEXPools` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Liquidity for a launchpad token pair stream](https://ide.bitquery.io/liquidity-for-a-launchpad-token-pair-stream)
+
+#### Search tokens with liquidity over 1 million
+
+Search tokens with liquidity over 1 million. Uses the `DEXPools` cube.
+
+▶️ [Search tokens with liquidity over 1 million](https://ide.bitquery.io/Search-tokens-with-liquidity-over-1-million)
+
+#### Trends fun tokens between 95 and 100 bonding curve progress
+
+Trends fun tokens between 95 and 100 bonding curve progress. Uses the `DEXPools` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Trends fun tokens between 95 and 100 bonding curve progress](https://ide.bitquery.io/trends-fun-tokens-between-95-and-100-bonding-curve-progress)
+
+### Transactions
+
+#### Realtime Solana Transactions
+
+Realtime Solana Transactions. Uses the `Transactions` cube.
+
+▶️ [Realtime Solana Transactions](https://ide.bitquery.io/Realtime-Solana-Transactions)
+
+### Events & Calls
+
+#### ConsumeEvents instruction on OpenBook V2
+
+ConsumeEvents instruction on OpenBook V2. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+
+▶️ [ConsumeEvents instruction on OpenBook V2](https://ide.bitquery.io/consumeEvents-instruction-on-OpenBook-V2_3)
+
+### Pump.fun
 
 #### PumpFun Token Creation
 
 This subscription tracks in real-time newly created Pumpfun tokens, including their metadata and associated developer addresses.
 
-▶️ [PumpFun Token Creation Stream](https://ide.bitquery.io/newly-created-PF-token-developer-address-metadata)
+▶️ [PumpFun Token Creation](https://ide.bitquery.io/newly-created-PF-token-developer-address-metadata)
 
 #### PumpFun Trades Stream
 
@@ -333,49 +726,569 @@ This stream returns the real time trades on Pumpfun platform. This stream could 
 
 ▶️ [PumpFun Trades Stream](https://ide.bitquery.io/Pumpfun-DEX-Trades_1)
 
-### Pumpswap Streams
-
 #### Pumpswap Trades Stream
 
 This stream returns the real time trades on Pumpswap exchange. This stream could be modified to get real time trades for a particular token or trades by a particular trader.
 
 ▶️ [Pumpswap Trades Stream](https://ide.bitquery.io/pumpswap-trades)
 
-### Raydium APIs
+#### Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply
 
-#### New Pool Creation on Raydium v4
+Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply. Uses the `Trades` cube.
 
-This stream gives info about the real time liquidity pool creation on Raydium exchange.
+▶️ [Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Pumpfun-With-Price-Market-Cap-and-Supply)
 
-▶️ [Raydium v4 Pool Creation Stream](https://ide.bitquery.io/Latest-Radiyum-V4-pools-created_5)
+#### Latest Trades for a token on Pumpswap
 
-#### New Pool Creation on Raydium Launchpad
+Latest Trades for a token on Pumpswap. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
-This stream gives info about the real time liquidity pool creation on Raydium Launchpad.
+▶️ [Latest Trades for a token on Pumpswap](https://ide.bitquery.io/Latest-Trades-for-a-token-on-Pumpswap)
 
-▶️ [Raydium Launchpad Pool Creation Stream](https://ide.bitquery.io/Raydium-Launchpad-pool-creations_1)
+#### Price of a pump fun token using price index in usd
 
-#### New Pool Creation on Raydium CLMM
+Price of a pump fun token using price index in usd. Uses the `Pairs` cube. Replace the address in the `where` clause to use it.
 
-This stream gives info about the real time liquidity pool creation on Raydium CLMM.
+▶️ [Price of a pump fun token using price index in usd](https://ide.bitquery.io/Price-of-a-pump-fun-token-using-price-index-in-usd)
 
-▶️ [Raydium CLMM Pool Creation Stream](https://ide.bitquery.io/Raydium-CLMM-Pool-Creation-stream)
+### Raydium
 
-#### New Pool Creation on Raydium CPMM
+#### Latest Pools Created on Raydium
 
-This stream gives info about the real time liquidity pool creation on Raydium CPMM.
+This query returns the latest created pools on Raydium. You can set the limit here also.
 
-▶️ [Raydium CPMM Pool Creation Stream](https://ide.bitquery.io/CPMM-pools-creation-stream)
+▶️ [Latest Pools Created on Raydium](https://ide.bitquery.io/Latest-Radiyum-V4-pools-created_1)
 
 #### Latest Trades on Raydium
 
 This stream gives info about the real time trades on Raydium exchange. You can modify this query to monitor trades on Raydium for a particular token or by a particular trader.
 
-▶️ [Raydium Trades](https://ide.bitquery.io/Updated-Real-time-trades-on-Raydium-DEX-on-Solana_1)
+▶️ [Latest Trades on Raydium](https://ide.bitquery.io/Updated-Real-time-trades-on-Raydium-DEX-on-Solana_1)
+
+#### New Pool Creation on Raydium CLMM
+
+This stream gives info about the real time liquidity pool creation on Raydium CLMM.
+
+▶️ [New Pool Creation on Raydium CLMM](https://ide.bitquery.io/Raydium-CLMM-Pool-Creation-stream)
+
+#### New Pool Creation on Raydium CPMM
+
+This stream gives info about the real time liquidity pool creation on Raydium CPMM.
+
+▶️ [New Pool Creation on Raydium CPMM](https://ide.bitquery.io/CPMM-pools-creation-stream)
+
+#### New Pool Creation on Raydium Launchpad
+
+This stream gives info about the real time liquidity pool creation on Raydium Launchpad.
+
+▶️ [New Pool Creation on Raydium Launchpad](https://ide.bitquery.io/Raydium-Launchpad-pool-creations_1)
+
+#### New Pool Creation on Raydium v4
+
+This stream gives info about the real time liquidity pool creation on Raydium exchange.
+
+▶️ [New Pool Creation on Raydium v4](https://ide.bitquery.io/Latest-Radiyum-V4-pools-created_5)
+
+#### Track Raydium Launchpad tokens above 95% Bonding Curve Progress in realtime
+
+Returns Raydium Launchpad tokens which have more than 95% bonding curve progress.
+
+▶️ [Track Raydium Launchpad tokens above 95% Bonding Curve Progress in realtime](https://ide.bitquery.io/LetsBonkfun-Tokens-between-95-and-100-bonding-curve-progress_2)
+
+### Meteora
+
+#### Jup studio token migrations from Meteora DBC to Meteors DEX
+
+Jup studio token migrations from Meteora DBC to Meteors DEX. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Jup studio token migrations from Meteora DBC to Meteors DEX](https://ide.bitquery.io/jup-studio-token-migrations-from-Meteora-DBC-to-Meteors-DEX_1)
+
+#### Liquidity addition for meteora
+
+Liquidity addition for meteora. Uses the `DEXPools` cube.
+
+▶️ [Liquidity addition for meteora](https://ide.bitquery.io/liquidity-addition-for-meteora_1)
+
+#### Liquidity removal for meteora
+
+Liquidity removal for meteora. Uses the `DEXPools` cube.
+
+▶️ [Liquidity removal for meteora](https://ide.bitquery.io/liquidity-removal-for-meteora_1)
+
+#### Meteora DBC token migrations to Meteors DEX
+
+Meteora DBC token migrations to Meteors DEX. Uses the `Instructions` cube.
+
+▶️ [Meteora DBC token migrations to Meteors DEX](https://ide.bitquery.io/meteora-DBC-token-migrations-to-Meteors-DEX)
+
+#### Real time trades on Meteora Dynamic Bonding Curve on Solana
+
+Real time trades on Meteora Dynamic Bonding Curve on Solana. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Real time trades on Meteora Dynamic Bonding Curve on Solana](https://ide.bitquery.io/Real-time-trades-on-Meteora-Dynamic-Bonding-Curve-on-Solana)
+
+#### Real time trades on MeteoraDAMMv2 DEX on Solana
+
+Real time trades on MeteoraDAMMv2 DEX on Solana. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Real time trades on MeteoraDAMMv2 DEX on Solana](https://ide.bitquery.io/Real-time-trades-on-MeteoraDAMMv2-DEX-on-Solana)
+
+### Orca
+
+#### Latest pool created on Orca - Websocket
+
+Latest pool created on Orca - Websocket. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest pool created on Orca - Websocket](https://ide.bitquery.io/Latest-pool-created-on-Orca---Websocket_1)
+
+#### Liquidity addition for orca whirlpool
+
+Liquidity addition for orca whirlpool. Uses the `DEXPools` cube.
+
+▶️ [Liquidity addition for orca whirlpool](https://ide.bitquery.io/liquidity-addition-for-orca-whirlpool_1)
+
+#### Liquidity removal for orca whirlpool
+
+Liquidity removal for orca whirlpool. Uses the `DEXPools` cube.
+
+▶️ [Liquidity removal for orca whirlpool](https://ide.bitquery.io/liquidity-removal-for-orca-whirlpool_1)
+
+#### Orca DEX Trades Websocket
+
+Orca DEX Trades Websocket. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Orca DEX Trades Websocket](https://ide.bitquery.io/Orca-DEX-Trades-Websocket)
+
+#### Orca DEX Trades for a specific currency Websocket
+
+Orca DEX Trades for a specific currency Websocket. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Orca DEX Trades for a specific currency Websocket](https://ide.bitquery.io/Orca-DEX-Trades-for-a-specific-currency-Websocket)
+
+#### Price of a token on Orca
+
+Price of a token on Orca. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Price of a token on Orca](https://ide.bitquery.io/Price-of-a-token-on-Orca)
+
+### Jupiter
+
+#### Latest Cancel Expired Order Transactions on Jupiter in realtime
+
+Latest Cancel Expired Order Transactions on Jupiter in realtime. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest Cancel Expired Order Transactions on Jupiter in realtime](https://ide.bitquery.io/Latest-Cancel-Expired-Order-Transactions-on-Jupiter-in-realtime_1)
+
+#### Latest Cancel Limit Order Transactions on Jupiter in realtime
+
+Latest Cancel Limit Order Transactions on Jupiter in realtime. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest Cancel Limit Order Transactions on Jupiter in realtime](https://ide.bitquery.io/Latest-Cancel-Limit-Order-Transactions-on-Jupiter-in-realtime)
+
+#### Tokens involved in Jupiter swap, source address, destination address, DEX involved
+
+Tokens involved in Jupiter swap, source address, destination address, DEX involved. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Tokens involved in Jupiter swap, source address, destination address, DEX involved](https://ide.bitquery.io/Tokens-involved-in-Jupiter-swap-source-address-destination-address-DEX-involved_2)
+
+## BSC
+
+### Trades
+
+#### Real-time Trades on BSC
+
+This subscription returns the real-time trades happening on BSC Network. You can modify the stream to get real-time trades for a particular token, a particular token pair and even a particular trader.
+
+▶️ [Real-time Trades on BSC](https://ide.bitquery.io/subscribe-to-dex-trades-on-BNB-mainnet)
+
+#### All BNB Trade Stream
+
+All BNB Trade Stream. Uses the `Trades` cube.
+
+▶️ [All BNB Trade Stream](https://ide.bitquery.io/All-BNB-Trade-Stream)
+
+#### Subscribe to bsc dex trades
+
+Subscribe to bsc dex trades.
+
+▶️ [Subscribe to bsc dex trades](https://ide.bitquery.io/subscribe-to-bsc-dex-trades)
+
+### Transfers
+
+#### Transfers where sender is a particular address
+
+Transfers where sender is a particular address. Uses the `Transfers` cube.
+
+▶️ [Transfers where sender is a particular address](https://ide.bitquery.io/Transfers-where-sender-is-a-particular-address)
+
+### Balances & Holders
+
+#### Real-time Transaction Balance Update for a Wallet on BSC
+
+This stream provides real time transaction balance updates for a wallet on BSC.
+
+▶️ [Real-time Transaction Balance Update for a Wallet on BSC](https://ide.bitquery.io/Subscribe-to-Transaction-Balances-for-a-Specific-Address-bsc)
+
+#### Balance update after transfer received from multiple addresses--stream bsc
+
+Balance update after transfer received from multiple addresses--stream bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Balance update after transfer received from multiple addresses--stream bsc](https://ide.bitquery.io/Balance-update-after-transfer-received-from-multiple-addresses--stream-bsc)
+
+#### Balance update after transfer received--stream bsc
+
+Balance update after transfer received--stream bsc. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Balance update after transfer received--stream bsc](https://ide.bitquery.io/Balance-update-after-transfer-received--stream-bsc)
+
+#### Balance update after transfer sent from multiple addresses--stream bsc
+
+Balance update after transfer sent from multiple addresses--stream bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Balance update after transfer sent from multiple addresses--stream bsc](https://ide.bitquery.io/Balance-update-after-transfer-sent-from-multiple-addresses--stream-bsc)
+
+#### Balance update after transfer sent--stream bsc
+
+Balance update after transfer sent--stream bsc. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Balance update after transfer sent--stream bsc](https://ide.bitquery.io/Balance-update-after-transfer-sent--stream-bsc)
+
+#### Balance update from transfer for an address--stream bsc
+
+Balance update from transfer for an address--stream bsc. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Balance update from transfer for an address--stream bsc](https://ide.bitquery.io/balance-update-from-transfer-for-an-address--stream-bsc)
+
+#### Balance update from transfer for multiple addresses--stream bsc
+
+Balance update from transfer for multiple addresses--stream bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Balance update from transfer for multiple addresses--stream bsc](https://ide.bitquery.io/balance-update-from-transfer-for-multiple-addresses--stream-bsc)
+
+#### Monitor balance after unused gas fee returned for an address--stream bsc
+
+Monitor balance after unused gas fee returned for an address--stream bsc. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Monitor balance after unused gas fee returned for an address--stream bsc](https://ide.bitquery.io/Monitor-balance-after-unused-gas-fee-returned--for-an-address--stream-bsc)
+
+#### Monitor balance after unused gas fee returned for multiple addresses--stream bsc
+
+Monitor balance after unused gas fee returned for multiple addresses--stream bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Monitor balance after unused gas fee returned for multiple addresses--stream bsc](https://ide.bitquery.io/Monitor-balance-after-unused-gas-fee-returned--for-multiple-addresses--stream-bsc)
+
+#### Monitor balance and gas fee paid for an address using stream bsc
+
+Monitor balance and gas fee paid for an address using stream bsc. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Monitor balance and gas fee paid for an address using stream bsc](https://ide.bitquery.io/Monitor-balance-and-gas-fee-paid-for-an-address-using-stream-bsc)
+
+### Price & OHLC
+
+#### Realtime price of a ETH in terms of WBNB
+
+Realtime price of a ETH in terms of WBNB. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Realtime price of a ETH in terms of WBNB](https://ide.bitquery.io/realtime-price-of-a-ETH-in-terms-of-WBNB)
+
+#### Stream for latest prices for Flap.sh tokens
+
+Stream for latest prices for Flap.sh tokens. Uses the `Pairs` cube.
+
+▶️ [Stream for latest prices for Flap.sh tokens](https://ide.bitquery.io/Stream-for-latest-prices-for-Flapsh-tokens)
+
+### Supply & Market Cap
+
+#### BSC tokens with market cap above $1 million (Trading API)
+
+Subscribe when **`Token.Id`** matches BSC and **`Supply.MarketCap`** &gt; 1,000,000 USD.
+
+▶️ [BSC tokens with market cap above $1 million (Trading API)](https://ide.bitquery.io/realtime-stream-bsc-tokens-with-marketcap-above-1-million_1)
+
+#### All trades on BSC with Price, Marketcap, supply
+
+All trades on BSC with Price, Marketcap, supply. Uses the `Trades` cube.
+
+▶️ [All trades on BSC with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-BSC-with-Price-Marketcap-supply)
+
+#### Bsc token marketcap stream
+
+Bsc token marketcap stream. Uses the `Tokens` cube.
+
+▶️ [Bsc token marketcap stream](https://ide.bitquery.io/bsc-token-marketcap-stream)
+
+### Liquidity & Pools
+
+#### Realtime Liquidity Stream of a Specific Pool
+
+This subscription query monitors real-time liquidity changes for a specific DEX pool on BSC. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
+
+▶️ [Realtime Liquidity Stream of a Specific Pool](https://ide.bitquery.io/Realtime-Liquidity-Stream-of-a-Specific-Pool_1)
+
+#### Realtime Slippage Monitoring
+
+This subscription query returns real-time slippage data for all DEX pools on BSC. You can monitor price impact and liquidity depth as trades occur.
+
+▶️ [Realtime Slippage Monitoring](https://ide.bitquery.io/realtime-slippage-on-bsc)
+
+#### Realtime Liquidity Stream
+
+Realtime Liquidity Stream.
+
+▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_2)
+
+### Events & Calls
+
+#### Newly Created Tokens on BSC network
+
+Newly Created Tokens on BSC network. Uses the `Calls` cube.
+
+▶️ [Newly Created Tokens on BSC network](https://ide.bitquery.io/Newly-Created-Tokens-on-BSC-network_2)
+
+### Mempool
+
+#### Bsc mempool txs
+
+Bsc mempool txs.
+
+▶️ [Bsc mempool txs](https://ide.bitquery.io/bsc-mempool-txs)
+
+#### Monitor mempool trades bsc
+
+Monitor mempool trades bsc.
+
+▶️ [Monitor mempool trades bsc](https://ide.bitquery.io/monitor-mempool-trades-bsc)
+
+### Blocks & Validators
+
+#### Real-time Validator Rewards for BSC
+
+This stream provides the info on rewards received by validators on BSC in real time.
+
+▶️ [Real-time Validator Rewards for BSC](https://ide.bitquery.io/Track-Validator-Balance-Updates-bsc_1)
+
+#### Track MEV Balance in Real Time for BSC
+
+This stream monitors MEV activities and Balance Updates on BSC in real time.
+
+▶️ [Track MEV Balance in Real Time for BSC](https://ide.bitquery.io/Track-MEV-Related-Balance-Updates-bsc)
+
+#### All Self-Destruct Event Balances Stream bsc
+
+All Self-Destruct Event Balances Stream bsc. Uses the `TransactionBalances` cube.
+
+▶️ [All Self-Destruct Event Balances Stream bsc](https://ide.bitquery.io/All-Self-Destruct-Event-Balances-Stream-bsc)
+
+#### Filter by MEV Bot or Builder Address bsc
+
+Filter by MEV Bot or Builder Address bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Filter by MEV Bot or Builder Address bsc](https://ide.bitquery.io/Filter-by-MEV-Bot-or-Builder-Address-bsc)
+
+#### Filter by Miner Address bsc
+
+Filter by Miner Address bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Filter by Miner Address bsc](https://ide.bitquery.io/Filter-by-Miner-Address-bsc)
+
+#### Filter by Validator Address bsc
+
+Filter by Validator Address bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Filter by Validator Address bsc](https://ide.bitquery.io/Filter-by-Validator-Address-bsc_1)
+
+#### Track Block Mining Rewards bsc
+
+Track Block Mining Rewards bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Track Block Mining Rewards bsc](https://ide.bitquery.io/Track-Block-Mining-Rewards-bsc)
+
+#### Track Ephemeral MEV Contract Balance Changes bsc
+
+Track Ephemeral MEV Contract Balance Changes bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Track Ephemeral MEV Contract Balance Changes bsc](https://ide.bitquery.io/Track-Ephemeral-MEV-Contract-Balance-Changes-bsc)
+
+#### Track Large MEV Transactions bsc
+
+Track Large MEV Transactions bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Track Large MEV Transactions bsc](https://ide.bitquery.io/Track-Large-MEV-Transactions-bsc)
+
+#### Track Large Self-Destruct Transaction Balances bsc
+
+Track Large Self-Destruct Transaction Balances bsc. Uses the `TransactionBalances` cube.
+
+▶️ [Track Large Self-Destruct Transaction Balances bsc](https://ide.bitquery.io/Track-Large-Self-Destruct-Transaction-Balances-bsc)
+
+### Four Meme
+
+#### Four Meme Token Creations Stream
+
+This stream returns the latest token creations on `Four Meme` on BSC Network in real time.
+
+▶️ [Four Meme Token Creations Stream](https://ide.bitquery.io/track-Four-meme-token-creation-using-events_2)
+
+#### Four Meme Trades Stream
+
+This stream returns the latest trades happening on `Four Meme` on BSC Network in real time.
+
+▶️ [Four Meme Trades Stream](https://ide.bitquery.io/Latest-trades-on-fourmeme)
+
+#### Four Meme User Trades
+
+This stream helps in monitoring the trades of a Four Meme user in real time.
+
+▶️ [Four Meme User Trades](https://ide.bitquery.io/monitor-trades-of-a-trader-on-four-meme)
+
+#### Stream Real-time MarketCap of FourMeme Tokens
+
+Real-time market cap stream with OHLC for FourMeme tokens at 1-second intervals. Market cap is calculated from price using fixed 1 billion supply.
+
+▶️ [Stream Real-time MarketCap of FourMeme Tokens](https://ide.bitquery.io/Real-Time-Marektcap-and-price-for-Four-meme-tokens)
+
+#### Four Meme bonding curve completion mempool
+
+Four Meme bonding curve completion mempool. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Four Meme bonding curve completion mempool](https://ide.bitquery.io/Four-Meme-bonding-curve-completion-mempool)
+
+#### Four Meme large buys mempool
+
+Four Meme large buys mempool. Uses the `DEXTrades` cube.
+
+▶️ [Four Meme large buys mempool](https://ide.bitquery.io/Four-Meme-large-buys-mempool)
+
+### PancakeSwap
+
+#### Real-time Mempool Trades on Pancakeswap
+
+Get real time unconfirmed trades on Pancakeswap, using the given stream.
+
+▶️ [Real-time Mempool Trades on Pancakeswap](https://ide.bitquery.io/Mempool---Latest-BSC-PancakeSwap-v3-dextrades---Stream)
+
+#### Track Four Meme Token migrations to PancakeSwap
+
+This query tracks four meme token migrations to Pancakeswap in realtime by monitoring transactions sent to the Four Meme factory address and filtering for `PairCreated` and `PoolCreated` events. These events are emitted when a token graduates from Four Meme and migrates to Pancakeswap.
+
+▶️ [Track Four Meme Token migrations to PancakeSwap](https://ide.bitquery.io/four-meme-migration-to-pancakeswap)
+
+#### Binance meme rush migration to pancakeswap
+
+Binance meme rush migration to pancakeswap. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Binance meme rush migration to pancakeswap](https://ide.bitquery.io/binance-meme-rush-migration-to-pancakeswap)
+
+#### Latest BSC PancakeSwap v3 dextrades - Stream
+
+Latest BSC PancakeSwap v3 dextrades - Stream. Uses the `DEXTrades` cube.
+
+▶️ [Latest BSC PancakeSwap v3 dextrades - Stream](https://ide.bitquery.io/Latest-BSC-PancakeSwap-v3-dextrades---Stream_2)
+
+#### Mempool - Latest BSC PancakeSwap v3 dextrades - Stream
+
+Mempool - Latest BSC PancakeSwap v3 dextrades - Stream. Uses the `DEXTrades` cube.
+
+▶️ [Mempool - Latest BSC PancakeSwap v3 dextrades - Stream](https://ide.bitquery.io/Mempool---Latest-BSC-PancakeSwap-v3-dextrades---Stream_1)
+
+#### Stream - BSC PancakeSwap v3 Trades for a token
+
+Stream - BSC PancakeSwap v3 Trades for a token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Stream - BSC PancakeSwap v3 Trades for a token](https://ide.bitquery.io/Stream---BSC-PancakeSwap-v3-Trades-for-a-token)
+
+### Uniswap
+
+#### Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4
+
+Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4. Uses the `DEXPoolEvents` cube.
+
+▶️ [Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4](https://ide.bitquery.io/Latest-Liquidity-Changes-of-Pools-in-a-Specific-DEX-Protocol---Uniswap-V4)
+
+#### Newly Created Pools on Uniswap v3 on BSC network
+
+Newly Created Pools on Uniswap v3 on BSC network. Uses the `Events` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Newly Created Pools on Uniswap v3 on BSC network](https://ide.bitquery.io/Newly-Created-Pools-on-Uniswap-v3-on-BSC-network_3)
+
+#### Real time trades for uniswap v4 bsc
+
+Real time trades for uniswap v4 bsc. Uses the `DEXTrades` cube.
+
+▶️ [Real time trades for uniswap v4 bsc](https://ide.bitquery.io/Real-time-trades-for-uniswap-v4-bsc)
+
+#### Uniswap v4 pool liquidity bsc
+
+Uniswap v4 pool liquidity bsc. Uses the `DEXPoolEvents` cube.
+
+▶️ [Uniswap v4 pool liquidity bsc](https://ide.bitquery.io/uniswap-v4-pool-liquidity-bsc)
+
+#### Uniswap v4 pool liquidity by poolid bsc
+
+Uniswap v4 pool liquidity by poolid bsc. Uses the `DEXPoolEvents` cube.
+
+▶️ [Uniswap v4 pool liquidity by poolid bsc](https://ide.bitquery.io/uniswap-v4-pool-liquidity-by-poolid-bsc)
 
 ## Base
 
-### Balance APIs
+### Trades
+
+#### Base DEX Trades Stream
+
+This stream returns all the real time DEX trades happening on Base. You can modify this stream to get DEX trades on a particular DEX or trades of a particular token or trades by a particular trader.
+
+▶️ [Base DEX Trades Stream](https://ide.bitquery.io/subscribe-to-dex-trades-on-base_1)
+
+#### All Base Trade Stream
+
+All Base Trade Stream. Uses the `Trades` cube.
+
+▶️ [All Base Trade Stream](https://ide.bitquery.io/All-Base-Trade-Stream)
+
+#### Subscribe to dex trades on base
+
+Subscribe to dex trades on base.
+
+▶️ [Subscribe to dex trades on base](https://ide.bitquery.io/subscribe-to-dex-trades-on-base)
+
+#### Subscription for Latest Trades for AERO
+
+Subscription for Latest Trades for AERO. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Subscription for Latest Trades for AERO](https://ide.bitquery.io/Subscription-for-Latest-Trades-for-AERO_1)
+
+### Transfers
+
+#### Token Transfers Stream
+
+This stream lets you monitor all the token transfers for a particular token. You can modify this subscription to track and monitor token transfers for a particular token from or to a particular address.
+
+▶️ [Token Transfers Stream](https://ide.bitquery.io/Subscribe-to-Latest-USDC-token-transfers)
+
+#### Newly created zora tokens stream
+
+Newly created zora tokens stream. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Newly created zora tokens stream](https://ide.bitquery.io/Newly-created-zora-tokens-stream)
+
+#### Sender is a particular address
+
+Sender is a particular address. Uses the `Transfers` cube.
+
+▶️ [Sender is a particular address](https://ide.bitquery.io/Sender-is-a-particular-address_3)
+
+#### Whale transfers of USDC on base
+
+Whale transfers of USDC on base. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Whale transfers of USDC on base](https://ide.bitquery.io/Whale-transfers-of-USDC-on-base)
+
+### Balances & Holders
+
+#### Stream Token Balance of a Address in Real Time
+
+Subscribe to real-time token balance updates for a specific address and token. This subscription will notify you whenever the token balance changes.
+
+▶️ [Stream Token Balance of a Address in Real Time](https://ide.bitquery.io/Stream-Token-Balance-Updates-in-Real-Time-on-base)
 
 #### Subscribe to All Transaction Balances
 
@@ -389,105 +1302,43 @@ This subscription filters transaction balances for a specific address in real-ti
 
 ▶️ [Subscribe to Transaction Balances for a Specific Address](https://ide.bitquery.io/Subscribe-to-Transaction-Balances-for-a-Specific-Address_1)
 
-#### Stream Token Balance of a Address in Real Time
-
-Subscribe to real-time token balance updates for a specific address and token. This subscription will notify you whenever the token balance changes.
-
-▶️ [Stream Token Balance Updates in Real Time](https://ide.bitquery.io/Stream-Token-Balance-Updates-in-Real-Time-on-base)
-
 #### Track Token Balance Changes
 
 Monitor token balance changes for a specific token across all transactions. This helps track token movements and transfers.
 
-▶️ [Track Token Balance Changes by Transaction](https://ide.bitquery.io/Track-Token-Balance-Changes-by-Transaction-on-base)
+▶️ [Track Token Balance Changes](https://ide.bitquery.io/Track-Token-Balance-Changes-by-Transaction-on-base)
 
-#### Track Validator Balance Updates
+#### Balance update from transfer for an address stream base
 
-Monitor balance changes for Base validators, including staking rewards and withdrawals from the beacon chain.
+Balance update from transfer for an address stream base. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
 
-▶️ [Track Validator Balance Updates](https://ide.bitquery.io/Track-Validator-Balance-Updates)
+▶️ [Balance update from transfer for an address stream base](https://ide.bitquery.io/balance-update-from-transfer-for-an-address--stream-base)
 
-#### Track Validator Rewards
+#### Subscribe to All Transaction Balances base
 
-Track validator rewards and balance increases from staking activities in real-time.
+Subscribe to All Transaction Balances base.
 
-▶️ [Track Validator Rewards](https://ide.bitquery.io/Track-Validator-Balance-Updates-on-base)
+▶️ [Subscribe to All Transaction Balances base](https://ide.bitquery.io/Subscribe-to-All-Transaction-Balances-base)
 
-#### Track Miner Balance Updates
+#### Subscribe to Transaction Balances for a Specific Address base
 
-Monitor balance changes for Base miners, including block rewards, uncle block rewards, and transaction fee rewards.
+Subscribe to Transaction Balances for a Specific Address base. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
 
-▶️ [Track Miner Balance Updates](https://ide.bitquery.io/Track-Miner-Balance-Updates-BASE_1)
+▶️ [Subscribe to Transaction Balances for a Specific Address base](https://ide.bitquery.io/Subscribe-to-Transaction-Balances-for-a-Specific-Address-base)
 
-#### Track Block Mining Rewards
+#### Track Block Builder Rewards base
 
-Track rewards received by miners for successfully mining blocks in real-time.
+Track Block Builder Rewards base. Uses the `TransactionBalances` cube.
 
-▶️ [Track Block Mining Rewards](https://ide.bitquery.io/Track-Block-Mining-Rewards-base_1)
+▶️ [Track Block Builder Rewards base](https://ide.bitquery.io/Track-Block-Builder-Rewards-base)
 
-#### Track MEV-Related Balance Updates
+#### Track Transaction Fee Rewards base
 
-Monitor balance changes related to MEV activities, including transaction fee rewards and block builder rewards.
+Track Transaction Fee Rewards base. Uses the `TransactionBalances` cube.
 
-▶️ [Track MEV-Related Balance Updates](https://ide.bitquery.io/Track-MEV-Related-Balance-Updates-base_1)
+▶️ [Track Transaction Fee Rewards base](https://ide.bitquery.io/Track-Transaction-Fee-Rewards-base)
 
-#### Track All Self-Destruct Event Balances
-
-Monitor all contract self-destruct event balances in real-time.
-
-▶️ [Track All Self-Destruct Event Balances](https://ide.bitquery.io/All-Self-Destruct-Event-Balances-Stream-base_1)
-
-#### Monitoring Balance after Latest Gas Fee Burn
-
-Monitor the balance and gas fee burnt for a particular address in real-time.
-
-▶️ [Monitoring Balance after Latest Gas Fee Burn](https://ide.bitquery.io/Monitor-balance-and-gas-fee-paid-for-an-address-using-stream_2)
-
-### Transfers
-
-#### Token Transfers Stream
-
-This stream lets you monitor all the token transfers for a particular token. You can modify this subscription to track and monitor token transfers for a particular token from or to a particular address.
-
-▶️ [Token Transfers Stream](https://ide.bitquery.io/Subscribe-to-Latest-USDC-token-transfers)
-
-### Trades
-
-#### Base DEX Trades Stream
-
-This stream returns all the real time DEX trades happening on Base. You can modify this stream to get DEX trades on a particular DEX or trades of a particular token or trades by a particular trader.
-
-▶️ [DEX Trades Stream](https://ide.bitquery.io/subscribe-to-dex-trades-on-base_1)
-
-#### Uniswap Trades Stream
-
-This subscription returns the real-time trades happening on Uniswap. You can modify the stream to get real-time trades for a particular token, a particular token pair and even a particular trader.
-
-▶️ [Uniswap Trades Stream](https://ide.bitquery.io/Realtime-Uniswap-v1-Uniswap-v2-Uniswap-V3-Trades_1)
-
-### Slippage Streams
-
-#### Realtime Slippage Monitoring
-
-This subscription query returns real-time slippage data for all DEX pools on Base. You can monitor price impact and liquidity depth as trades occur.
-
-▶️ [Realtime Slippage Monitoring](https://ide.bitquery.io/realtime-slippage-on-base)
-
-### Liquidity Streams
-
-#### Realtime Liquidity Stream
-
-This subscription query returns real-time liquidity data for all DEX pools on Base. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
-
-▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_3#)
-
-#### Realtime Liquidity Stream of a Specific Pool
-
-This subscription query monitors real-time liquidity changes for a specific DEX pool on Base. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
-
-▶️ [Realtime Liquidity Stream of a Specific Pool](https://ide.bitquery.io/Realtime-Liquidity-Stream-of-a-Specific-Pool_3#)
-
-### OHLC & Price Data
+### Price & OHLC
 
 #### Real-time 1 second OHLC
 
@@ -501,149 +1352,391 @@ This stream returns the real time trade price of a token against the token it is
 
 ▶️ [Token Price Stream](https://ide.bitquery.io/token-price-stream_2)
 
-### MarketCap Streams
+#### Aerodrome dex - realtime prices, 1-sec ohlc, trading volumes
 
-Real-time **Trading API `Tokens`** streams for **Base**. Use **lowercase** addresses in **`base:`** ids. More detail: **[Base Token Market Cap API](/docs/blockchain/Base/base-token-marketcap-api)**.
+Aerodrome dex - realtime prices, 1-sec ohlc, trading volumes. Uses the `Pairs` cube.
+
+▶️ [Aerodrome dex - realtime prices, 1-sec ohlc, trading volumes](https://ide.bitquery.io/aerodrome-dex---realtime-prices-1-sec-ohlc-trading-volumes)
+
+#### Get latest price of DAI in USD on Base
+
+Get latest price of DAI in USD on Base. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get latest price of DAI in USD on Base](https://ide.bitquery.io/Get-latest-price-of-DAI-in-USD-on-Base)
+
+#### Price of USDC in terms of DAI on Base network
+
+Price of USDC in terms of DAI on Base network. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Price of USDC in terms of DAI on Base network](https://ide.bitquery.io/Price-of-USDC-in-terms-of-DAI-on-Base-network)
+
+### Supply & Market Cap
 
 #### Base token market cap stream (Trading API)
 
 Subscribe to **`Tokens`** rows for assets whose currency id includes **`base`** (interval duration &gt; 1s).
 
-▶️ [Base Token Market Cap Stream](https://ide.bitquery.io/base-token-marketcap-stream)
+▶️ [Base token market cap stream (Trading API)](https://ide.bitquery.io/base-token-marketcap-stream)
 
 #### Base tokens with market cap above $1 million (Trading API)
 
 Subscribe when **`Token.Id`** matches Base and **`Supply.MarketCap`** &gt; 1,000,000 USD.
 
-▶️ [Base Tokens With Market Cap Above $1M](https://ide.bitquery.io/realtime-stream-base-tokens-with-marketcap-above-1-million)
+▶️ [Base tokens with market cap above $1 million (Trading API)](https://ide.bitquery.io/realtime-stream-base-tokens-with-marketcap-above-1-million)
 
-### Events Streams
+#### All trades on Base with Price, Marketcap, supply
+
+All trades on Base with Price, Marketcap, supply. Uses the `Trades` cube.
+
+▶️ [All trades on Base with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Base-with-Price-Marketcap-supply)
+
+#### Bankr token realtime marketcap OHLC stream
+
+Bankr token realtime marketcap OHLC stream. Uses the `Tokens` cube.
+
+▶️ [Bankr token realtime marketcap OHLC stream](https://ide.bitquery.io/Bankr-token-realtime-marketcap-OHLC-stream)
+
+#### Base tokens above 100k marketcap stream
+
+Base tokens above 100k marketcap stream. Uses the `Tokens` cube.
+
+▶️ [Base tokens above 100k marketcap stream](https://ide.bitquery.io/Base-tokens-above-100k-marketcap-stream)
+
+### Liquidity & Pools
+
+#### Realtime Slippage Monitoring
+
+This subscription query returns real-time slippage data for all DEX pools on Base. You can monitor price impact and liquidity depth as trades occur.
+
+▶️ [Realtime Slippage Monitoring](https://ide.bitquery.io/realtime-slippage-on-base)
+
+#### Realtime Liquidity Stream
+
+Realtime Liquidity Stream.
+
+▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_3)
+
+#### Realtime Liquidity Stream of a Specific Pool
+
+Realtime Liquidity Stream of a Specific Pool. Uses the `DEXPoolEvents` cube.
+
+▶️ [Realtime Liquidity Stream of a Specific Pool](https://ide.bitquery.io/Realtime-Liquidity-Stream-of-a-Specific-Pool_3)
+
+### Events & Calls
+
+#### Realtime stream Bankr launches Base
+
+Realtime stream Bankr launches Base. Uses the `Events` cube.
+
+▶️ [Realtime stream Bankr launches Base](https://ide.bitquery.io/Realtime-stream-Bankr-launches-Base)
+
+### Blocks & Validators
+
+#### Monitoring Balance after Latest Gas Fee Burn
+
+Monitor the balance and gas fee burnt for a particular address in real-time.
+
+▶️ [Monitoring Balance after Latest Gas Fee Burn](https://ide.bitquery.io/Monitor-balance-and-gas-fee-paid-for-an-address-using-stream_2)
+
+#### Track All Self-Destruct Event Balances
+
+Monitor all contract self-destruct event balances in real-time.
+
+▶️ [Track All Self-Destruct Event Balances](https://ide.bitquery.io/All-Self-Destruct-Event-Balances-Stream-base_1)
+
+#### Track Block Mining Rewards
+
+Track rewards received by miners for successfully mining blocks in real-time.
+
+▶️ [Track Block Mining Rewards](https://ide.bitquery.io/Track-Block-Mining-Rewards-base_1)
+
+#### Track MEV-Related Balance Updates
+
+Monitor balance changes related to MEV activities, including transaction fee rewards and block builder rewards.
+
+▶️ [Track MEV-Related Balance Updates](https://ide.bitquery.io/Track-MEV-Related-Balance-Updates-base_1)
+
+#### Track Miner Balance Updates
+
+Monitor balance changes for Base miners, including block rewards, uncle block rewards, and transaction fee rewards.
+
+▶️ [Track Miner Balance Updates](https://ide.bitquery.io/Track-Miner-Balance-Updates-BASE_1)
+
+#### Track Validator Rewards
+
+Track validator rewards and balance increases from staking activities in real-time.
+
+▶️ [Track Validator Rewards](https://ide.bitquery.io/Track-Validator-Balance-Updates-on-base)
+
+#### All Self Destruct Event Balances Stream base
+
+All Self Destruct Event Balances Stream base. Uses the `TransactionBalances` cube.
+
+▶️ [All Self Destruct Event Balances Stream base](https://ide.bitquery.io/All-Self-Destruct-Event-Balances-Stream-base)
+
+#### Filter by MEV Bot or Builder Address base
+
+Filter by MEV Bot or Builder Address base. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Filter by MEV Bot or Builder Address base](https://ide.bitquery.io/Filter-by-MEV-Bot-or-Builder-Address-base)
+
+#### Filter by Miner Address base
+
+Filter by Miner Address base. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Filter by Miner Address base](https://ide.bitquery.io/Filter-by-Miner-Address-base)
+
+#### Track Block Mining Rewards base
+
+Track Block Mining Rewards base. Uses the `TransactionBalances` cube.
+
+▶️ [Track Block Mining Rewards base](https://ide.bitquery.io/Track-Block-Mining-Rewards-base)
+
+### Uniswap
 
 #### Pair Creation on Uniswap
 
 This stream returns the real time liquidity pools/token pairs created on Uniswap V3. You could modify the stream to monitor newly created pools on a different protocol.
 
-▶️ [Pair Creation Stream](https://ide.bitquery.io/Latest-pools-created-Uniswap-v3-Base)
+▶️ [Pair Creation on Uniswap](https://ide.bitquery.io/Latest-pools-created-Uniswap-v3-Base)
 
-## Robinhood Chain
+#### Uniswap v3 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders
 
-### Trades Streams
+1-second OHLC and volume stream for tokens traded on Uniswap v3 (Base). Great for bot trading strategies.
 
-#### Real-Time DEX Trades Stream on Robinhood Chain
+▶️ [Uniswap v3 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders](https://ide.bitquery.io/Uniswap-v3-DEX-tokens-1-second-price-stream-with-OHLC_1)
 
-Stream every DEX trade on Robinhood Chain (chain id 4663) in real time via the Trading API, with price and USD amounts.
+#### Bankr token V4 swaps realtime
 
-▶️ [Real-Time DEX Trades on Robinhood Chain](https://ide.bitquery.io/Robinhood-Trades)
+Bankr token V4 swaps realtime. Uses the `Trades` cube.
 
-### Token Launch Streams
+▶️ [Bankr token V4 swaps realtime](https://ide.bitquery.io/Bankr-token-V4-swaps-realtime)
 
-#### Stream New pools.trade Token Launches
+#### Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4
 
-Websocket subscription streaming every new pools.trade token launch on Robinhood Chain the moment it happens.
+Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4. Uses the `DEXPoolEvents` cube.
 
-▶️ [Stream New pools.trade Launches](https://ide.bitquery.io/Pools-trade-Stream-new-launches)
+▶️ [Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4](https://ide.bitquery.io/Latest-Liquidity-Changes-of-Pools-in-a-Specific-DEX-Protocol---Uniswap-V4_5)
 
-## BSC (Binance Smart Chain)
+#### Real time trades on uniswap v4 base
 
-### Balance APIs
+Real time trades on uniswap v4 base. Uses the `DEXTrades` cube.
 
-#### Real-time Transaction Balance Update for a Wallet on BSC
+▶️ [Real time trades on uniswap v4 base](https://ide.bitquery.io/Real-time-trades-on-uniswap-v4-base)
 
-This stream provides real time transaction balance updates for a wallet on BSC.
+#### Uniswap v4 pool liquidity base
 
-▶️ [Real Time Transaction Balance Update](https://ide.bitquery.io/Subscribe-to-Transaction-Balances-for-a-Specific-Address-bsc)
+Uniswap v4 pool liquidity base. Uses the `DEXPoolEvents` cube.
 
-#### Real-time Validator Rewards for BSC
+▶️ [Uniswap v4 pool liquidity base](https://ide.bitquery.io/uniswap-v4-pool-liquidity-base)
 
-This stream provides the info on rewards received by validators on BSC in real time.
-
-▶️ [Real Time Validator Rewards on BSC](https://ide.bitquery.io/Track-Validator-Balance-Updates-bsc_1)
-
-#### Track MEV Balance in Real Time for BSC
-
-This stream monitors MEV activities and Balance Updates on BSC in real time.
-
-▶️ [Real Time MEV Activities on BSC](https://ide.bitquery.io/Track-MEV-Related-Balance-Updates-bsc)
-
-### MarketCap Streams
-
-Real-time **Trading API `Tokens`** streams for **BNB Smart Chain (BSC)**. Use **lowercase** addresses in **`bsc:`** ids. More detail: **[BSC Token Market Cap API](/docs/blockchain/BSC/bsc-token-marketcap-api)**.
-
-#### BSC token market cap stream (Trading API)
-
-Subscribe to **`Tokens`** rows for assets whose currency id includes **`bsc`** (interval duration &gt; 1s).
-
-▶️ [BSC Token Market Cap Stream](https://ide.bitquery.io/bsc-token-marketcap-stream#)
-
-#### BSC tokens with market cap above $1 million (Trading API)
-
-Subscribe when **`Token.Id`** matches BSC and **`Supply.MarketCap`** &gt; 1,000,000 USD.
-
-▶️ [BSC Tokens With Market Cap Above $1M](https://ide.bitquery.io/realtime-stream-bsc-tokens-with-marketcap-above-1-million_1)
+## Arbitrum
 
 ### Trades
 
-#### Real-time Trades on BSC
+#### Arbitrum Dextrades subscription
 
-This subscription returns the real-time trades happening on BSC Network. You can modify the stream to get real-time trades for a particular token, a particular token pair and even a particular trader.
+Arbitrum Dextrades subscription.
 
-▶️ [BSC Dex Trades](https://ide.bitquery.io/subscribe-to-dex-trades-on-BNB-mainnet)
+▶️ [Arbitrum Dextrades subscription](https://ide.bitquery.io/Arbitrum-Dextrades-subscription)
 
-#### Real-time Trades on Pancakeswap
+### Supply & Market Cap
 
-This subscription returns the real-time trades happening on Pancakeswap. You can modify the stream to get real time trades for a particular token, a particular token pair, and even a particular trader.
+#### Arbitrum token marketcap stream
 
-▶️ [Pancakeswap Trades Stream](https://ide.bitquery.io/Latest-BSC-PancakeSwap-v3-dextrades---Stream)
+Arbitrum token marketcap stream. Uses the `Tokens` cube.
 
-#### Real-time Mempool Trades on Pancakeswap
+▶️ [Arbitrum token marketcap stream](https://ide.bitquery.io/arbitrum-token-marketcap-stream)
 
-Get real time unconfirmed trades on Pancakeswap, using the given stream.
+#### Realtime stream arbitrum tokens with marketcap above 1 million
 
-▶️ [Pancakeswap Mempool Trades](https://ide.bitquery.io/Mempool---Latest-BSC-PancakeSwap-v3-dextrades---Stream)
+Realtime stream arbitrum tokens with marketcap above 1 million. Uses the `Tokens` cube.
 
-### Slippage Streams
+▶️ [Realtime stream arbitrum tokens with marketcap above 1 million](https://ide.bitquery.io/realtime-stream-arbitrum-tokens-with-marketcap-above-1-million)
 
-#### Realtime Slippage Monitoring
+### Liquidity & Pools
 
-This subscription query returns real-time slippage data for all DEX pools on BSC. You can monitor price impact and liquidity depth as trades occur.
+#### Realtime liquidity stream
 
-▶️ [Realtime Slippage Monitoring](https://ide.bitquery.io/realtime-slippage-on-bsc)
+Realtime liquidity stream.
 
-### Liquidity Streams
+▶️ [Realtime liquidity stream](https://ide.bitquery.io/realtime-liquidity-stream_1)
+
+#### Realtime liquidity stream of a specific pool
+
+Realtime liquidity stream of a specific pool. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Realtime liquidity stream of a specific pool](https://ide.bitquery.io/realtime-liquidity-stream-of-a-specific-pool)
+
+#### Realtime slippage on arbitrum
+
+Realtime slippage on arbitrum.
+
+▶️ [Realtime slippage on arbitrum](https://ide.bitquery.io/realtime-slippage-on-arbitrum)
+
+### Transactions
+
+#### Arbitrum: Timeboost Auction Transactions in Realtime
+
+Arbitrum: Timeboost Auction Transactions in Realtime. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Arbitrum: Timeboost Auction Transactions in Realtime](https://ide.bitquery.io/Arbitrum-Timeboost-Auction-Transactions-in-Realtime)
+
+### Uniswap
+
+#### Latest liquidity changes in uniswap v4 pools
+
+Latest liquidity changes in uniswap v4 pools. Uses the `DEXPoolEvents` cube.
+
+▶️ [Latest liquidity changes in uniswap v4 pools](https://ide.bitquery.io/latest-liquidity-changes-in-uniswap-v4-pools)
+
+#### Real time trades for uniswap v4 arbitrum
+
+Real time trades for uniswap v4 arbitrum. Uses the `DEXTrades` cube.
+
+▶️ [Real time trades for uniswap v4 arbitrum](https://ide.bitquery.io/Real-time-trades-for-uniswap-v4-arbitrum)
+
+## Optimism
+
+### Trades
+
+#### Real time trades for uniswap v4 optimism
+
+Real time trades for uniswap v4 optimism. Uses the `DEXTrades` cube.
+
+▶️ [Real time trades for uniswap v4 optimism](https://ide.bitquery.io/Real-time-trades-for-uniswap-v4-optimism)
+
+#### Realtime optimism dex trades websocket
+
+Realtime optimism dex trades websocket.
+
+▶️ [Realtime optimism dex trades websocket](https://ide.bitquery.io/Realtime-optimism-dex-trades-websocket)
+
+### Transfers
+
+#### Sender is a particular address
+
+Sender is a particular address. Uses the `Transfers` cube.
+
+▶️ [Sender is a particular address](https://ide.bitquery.io/Sender-is-a-particular-address)
+
+#### Whale transfers of USDT on optimism
+
+Whale transfers of USDT on optimism. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Whale transfers of USDT on optimism](https://ide.bitquery.io/Whale-transfers-of-USDT-on-optimism)
+
+### Price & OHLC
+
+#### Get latest price of WBTC in USD on optimism
+
+Get latest price of WBTC in USD on optimism. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Get latest price of WBTC in USD on optimism](https://ide.bitquery.io/Get-latest-price-of-WBTC-in-USD-on-optimism)
+
+#### Price of WETH in terms of USDC on Optimism
+
+Price of WETH in terms of USDC on Optimism. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Price of WETH in terms of USDC on Optimism](https://ide.bitquery.io/Price-of-WETH-in-terms-of-USDC-on-Optimism)
+
+## Polygon
+
+### Trades
+
+#### Real time trades for uniswap v4 matic
+
+Real time trades for uniswap v4 matic. Uses the `DEXTrades` cube.
+
+▶️ [Real time trades for uniswap v4 matic](https://ide.bitquery.io/Real-time-trades-for-uniswap-v4-matic)
+
+#### Realtime matic dex trades websocket
+
+Realtime matic dex trades websocket.
+
+▶️ [Realtime matic dex trades websocket](https://ide.bitquery.io/Realtime-matic-dex-trades-websocket)
+
+### Transfers
+
+#### Sender is a particular address
+
+Sender is a particular address. Uses the `Transfers` cube.
+
+▶️ [Sender is a particular address](https://ide.bitquery.io/Sender-is-a-particular-address_2)
+
+#### Whale transfers of USDC on matic
+
+Whale transfers of USDC on matic. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Whale transfers of USDC on matic](https://ide.bitquery.io/Whale-transfers-of-USDC-on-matic)
+
+### Supply & Market Cap
+
+#### All trades on Polygon with Price, Marketcap, supply
+
+All trades on Polygon with Price, Marketcap, supply. Uses the `Trades` cube.
+
+▶️ [All trades on Polygon with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Polygon-with-Price-Marketcap-supply)
+
+#### Matic token marketcap stream
+
+Matic token marketcap stream. Uses the `Tokens` cube.
+
+▶️ [Matic token marketcap stream](https://ide.bitquery.io/matic-token-marketcap-stream)
+
+### Liquidity & Pools
+
+#### Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4
+
+Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4. Uses the `DEXPoolEvents` cube.
+
+▶️ [Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4](https://ide.bitquery.io/Latest-Liquidity-Changes-of-Pools-in-a-Specific-DEX-Protocol---Uniswap-V4_7)
 
 #### Realtime Liquidity Stream
 
-This subscription query returns real-time liquidity data for all DEX pools on BSC. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
+Realtime Liquidity Stream.
 
-▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_2#)
+▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_5)
 
 #### Realtime Liquidity Stream of a Specific Pool
 
-This subscription query monitors real-time liquidity changes for a specific DEX pool on BSC. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
+Realtime Liquidity Stream of a Specific Pool. Uses the `DEXPoolEvents` cube.
 
-▶️ [Realtime Liquidity Stream of a Specific Pool](https://ide.bitquery.io/Realtime-Liquidity-Stream-of-a-Specific-Pool_1)
+▶️ [Realtime Liquidity Stream of a Specific Pool](https://ide.bitquery.io/Realtime-Liquidity-Stream-of-a-Specific-Pool_5)
 
-### Four Meme APIs
+#### Realtime slippage on matic
 
-#### Four Meme Token Creations Stream
+Realtime slippage on matic.
 
-This stream returns the latest token creations on `Four Meme` on BSC Network in real time.
-
-▶️ [Four.meme Token Creations Stream](https://ide.bitquery.io/track-Four-meme-token-creation-using-events_2)
-
-#### Four Meme Trades Stream
-
-This stream returns the latest trades happening on `Four Meme` on BSC Network in real time.
-
-▶️ [Trades on Four Meme](https://ide.bitquery.io/Latest-trades-on-fourmeme)
-
-#### Four Meme User Trades
-
-This stream helps in monitoring the trades of a Four Meme user in real time.
-
-▶️ [Four Meme User Trades](https://ide.bitquery.io/monitor-trades-of-a-trader-on-four-meme)
+▶️ [Realtime slippage on matic](https://ide.bitquery.io/realtime-slippage-on-matic)
 
 ## TRON
+
+### Trades
+
+#### Real-time Trades on Sunpump
+
+This stream returns all the real time DEX trades happening on Sunpump exchange on the Tron network. You can modify this stream to get the trades of a particular token or trades by a particular trader.
+
+▶️ [Real-time Trades on Sunpump](https://ide.bitquery.io/real-time-sunswapTrades)
+
+#### Real-time Trades on Tron
+
+This stream returns all the real time DEX trades happening on the Tron network. You can modify this stream to get DEX trades on a particular DEX or trades of a particular token or trades by a particular trader.
+
+▶️ [Real-time Trades on Tron](https://ide.bitquery.io/Latest-trades-on-Tron)
+
+#### Sunpump trades
+
+Sunpump trades. Uses the `DEXTrades` cube.
+
+▶️ [Sunpump trades](https://ide.bitquery.io/Sunpump-trades)
+
+#### USDT TRC20 DEX Trades
+
+USDT TRC20 DEX Trades. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [USDT TRC20 DEX Trades](https://ide.bitquery.io/USDT-TRC20-DEX-Trades)
 
 ### Transfers
 
@@ -651,33 +1744,671 @@ This stream helps in monitoring the trades of a Four Meme user in real time.
 
 This subscription streams the latest USDT (TRC20) transfers on the TRON network. You can modify the stream to monitor Transfers of USDT from or to a particular address.
 
-▶️ [Token Transfers Stream](https://ide.bitquery.io/usdt-trc20-transfers_1)
+▶️ [Real-time Tether USDT Transfers](https://ide.bitquery.io/usdt-trc20-transfers_1)
+
+#### Sender is particular address
+
+Sender is particular address. Uses the `Transfers` cube.
+
+▶️ [Sender is particular address](https://ide.bitquery.io/Sender-is-particular-address)
+
+#### Whale transfers of USDT on Tron
+
+Whale transfers of USDT on Tron. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Whale transfers of USDT on Tron](https://ide.bitquery.io/Whale-transfers-of-USDT-on-Tron)
+
+### Price & OHLC
+
+#### Track price of a tron token in realtime
+
+Track price of a tron token in realtime. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Track price of a tron token in realtime](https://ide.bitquery.io/Track-price-of-a-tron-token-in-realtime)
+
+### Supply & Market Cap
+
+#### Get All DEX Trades on Tron With Price, Market Cap, and Supply
+
+Get All DEX Trades on Tron With Price, Market Cap, and Supply. Uses the `Trades` cube.
+
+▶️ [Get All DEX Trades on Tron With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Tron-With-Price-Market-Cap-and-Supply)
+
+### Transactions
+
+#### Monitor TRX address transactions
+
+Monitor TRX address transactions. Uses the `Transactions` cube.
+
+▶️ [Monitor TRX address transactions](https://ide.bitquery.io/monitor-TRX-address-transactions)
+
+### Events & Calls
+
+#### Latest Buy on SunPump
+
+Latest Buy on SunPump. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest Buy on SunPump](https://ide.bitquery.io/latest-Buy-on-SunPump)
+
+#### New tokens on sunpump
+
+New tokens on sunpump. Uses the `Events` cube.
+
+▶️ [New tokens on sunpump](https://ide.bitquery.io/New-tokens-on-sunpump_1)
+
+#### Sunpump sell event
+
+Sunpump sell event. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Sunpump sell event](https://ide.bitquery.io/sunpump-sell-event)
+
+#### Tron sunpump first time buy event
+
+Tron sunpump first time buy event. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Tron sunpump first time buy event](https://ide.bitquery.io/Tron-sunpump-first-time-buy-event_1)
+
+### Mempool
+
+#### Events with argumens
+
+Events with argumens. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Events with argumens](https://ide.bitquery.io/Events-with-argumens)
+
+#### Sunpump trades mempool
+
+Sunpump trades mempool. Uses the `DEXTrades` cube.
+
+▶️ [Sunpump trades mempool](https://ide.bitquery.io/Sunpump-trades-mempool)
+
+#### Tron mempool transfers
+
+Tron mempool transfers.
+
+▶️ [Tron mempool transfers](https://ide.bitquery.io/Tron-mempool-transfers)
+
+## Robinhood Chain
 
 ### Trades
 
-#### Real-time Trades on Tron
+#### Latest DEX Trades on Robinhood Chain
 
-This stream returns all the real time DEX trades happening on the Tron network. You can modify this stream to get DEX trades on a particular DEX or trades of a particular token or trades by a particular trader.
+Latest DEX trades on Robinhood Chain (chain id 4663) via the Trading API, with price and USD amounts.
 
-▶️ [DEX Trades Stream](https://ide.bitquery.io/Latest-trades-on-Tron)
+▶️ [Latest DEX Trades on Robinhood Chain](https://ide.bitquery.io/Robinhood-Trades)
 
-#### Real-time Trades on Sunpump
+#### Bags amm trade websocket
 
-This stream returns all the real time DEX trades happening on Sunpump exchange on the Tron network. You can modify this stream to get the trades of a particular token or trades by a particular trader.
+Bags amm trade websocket. Uses the `Trades` cube.
 
-▶️ [Sunpump Trades Stream](https://ide.bitquery.io/real-time-sunswapTrades)
+▶️ [Bags amm trade websocket](https://ide.bitquery.io/bags-amm-trade-websocket)
 
-## NFT Streams
+#### Pools trade Stream new Crowd Launch auctions
 
-### NFT Trades
+Pools trade Stream new Crowd Launch auctions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Pools trade Stream new Crowd Launch auctions](https://ide.bitquery.io/Pools-trade-Stream-new-Crowd-Launch-auctions)
+
+#### Robinhood Chain API - Trades for a Token
+
+Robinhood Chain API - Trades for a Token. Uses the `Trades` cube.
+
+▶️ [Robinhood Chain API - Trades for a Token](https://ide.bitquery.io/Robinhood-Trades-for-a-token)
+
+#### Stream Robinhood Chain Trades in Real Time
+
+Stream Robinhood Chain Trades in Real Time. Uses the `Trades` cube.
+
+▶️ [Stream Robinhood Chain Trades in Real Time](https://ide.bitquery.io/stream-robinhood-chain-trades)
+
+### Transfers
+
+#### Ape.store Newly created tokens - Websocket
+
+Ape.store Newly created tokens - Websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Ape.store Newly created tokens - Websocket](https://ide.bitquery.io/Apestore-Newly-created-tokens---Websocket)
+
+#### Bags.fm Newly created tokens - Websocket
+
+Bags.fm Newly created tokens - Websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Bags.fm Newly created tokens - Websocket](https://ide.bitquery.io/Bagsfm-Newly-created-tokens---Websocket)
+
+#### Bankr Bot Newly created tokens - Websocket
+
+Bankr Bot Newly created tokens - Websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Bankr Bot Newly created tokens - Websocket](https://ide.bitquery.io/Bankr-Bot-Newly-created-tokens---Websocket)
+
+#### Flap Sh Newly created tokens using transfer data - Websocket
+
+Flap Sh Newly created tokens using transfer data - Websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Flap Sh Newly created tokens using transfer data - Websocket](https://ide.bitquery.io/Flap-Sh-Newly-created-tokens-using-transfer-data---Websocket)
+
+#### Hoodfun newly creaed tokens Websocket
+
+Hoodfun newly creaed tokens Websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Hoodfun newly creaed tokens Websocket](https://ide.bitquery.io/hoodfun-newly-creaed-tokens---Websocket)
+
+#### Klik Finance Newly created tokens using transfers websocket
+
+Klik Finance Newly created tokens using transfers websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Klik Finance Newly created tokens using transfers websocket](https://ide.bitquery.io/Klik-Finance-Newly-created-tokens-using-transfers-websocket)
+
+#### Launchpad newly creaed tokens Websocket
+
+Launchpad newly creaed tokens Websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Launchpad newly creaed tokens Websocket](https://ide.bitquery.io/launchpad-newly-creaed-tokens---Websocket)
+
+#### Pools trade Stream launches with token detail
+
+Pools trade Stream launches with token detail. Uses the `Transfers` cube.
+
+▶️ [Pools trade Stream launches with token detail](https://ide.bitquery.io/Pools-trade-Stream-launches-with-token-detail)
+
+#### Real time transfers on robinhood
+
+Real time transfers on robinhood.
+
+▶️ [Real time transfers on robinhood](https://ide.bitquery.io/real-time-transfers-on-robinhood)
+
+### Price & OHLC
+
+#### Robinhood Chain OHLCV / Candlestick API for a Token Pair
+
+Robinhood Chain OHLCV / Candlestick API for a Token Pair. Uses the `Pairs` cube.
+
+▶️ [Robinhood Chain OHLCV / Candlestick API for a Token Pair](https://ide.bitquery.io/OHLCV-stream-for-a-token-pair-on-robinhood)
+
+### Liquidity & Pools
+
+#### Stream New pools.trade Token Launches
+
+Websocket subscription streaming every new pools.trade token launch on Robinhood Chain the moment it happens.
+
+▶️ [Stream New pools.trade Token Launches](https://ide.bitquery.io/Pools-trade-Stream-new-launches)
+
+### Events & Calls
+
+#### Flap sh Newly created tokens using logs (TokenCreated) - Websocket
+
+Flap sh Newly created tokens using logs (TokenCreated) - Websocket. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Flap sh Newly created tokens using logs (TokenCreated) - Websocket](https://ide.bitquery.io/Flap-sh-Newly-created-tokens-using-logs-TokenCreated---Websocket)
+
+#### Stream New Tokens on Robinhood Chain (All Launchpads)
+
+Stream New Tokens on Robinhood Chain (All Launchpads). Uses the `Events` cube.
+
+▶️ [Stream New Tokens on Robinhood Chain (All Launchpads)](https://ide.bitquery.io/stream-new-tokens-robinhood-chain)
+
+## Bitcoin
+
+### Price & OHLC
+
+#### Latest Bitcoin Price
+
+You can stream Bitcoin price at 1-second interval using the [Crypto Price APIs](/docs/trading/crypto-price-api/introduction/).
+
+▶️ [Latest Bitcoin Price](https://ide.bitquery.io/Stream-Bitcoin-Price-Across-Chains)
+
+## Trading API
+
+### Trades
+
+#### All chains New Trades Stream - Solana, eth, bsc ,base , arbitrum, matic
+
+All chains New Trades Stream - Solana, eth, bsc ,base , arbitrum, matic.
+
+▶️ [All chains New Trades Stream - Solana, eth, bsc ,base , arbitrum, matic](https://ide.bitquery.io/all-chains-New-Trades-Stream---Solana-eth-bsc-base--arbitrum-matic_2)
+
+#### All trades of a trader
+
+All trades of a trader. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [All trades of a trader](https://ide.bitquery.io/All-trades-of-a-trader)
+
+#### All wsol Trade Stream
+
+All wsol Trade Stream. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [All wsol Trade Stream](https://ide.bitquery.io/All-wsol-Trade-Stream)
+
+#### How do I get a wallet's trades on a specific pair?
+
+How do I get a wallet's trades on a specific pair?. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [How do I get a wallet's trades on a specific pair?](https://ide.bitquery.io/How-do-I-get-a-wallets-trades-on-a-specific-pair)
+
+#### How do I monitor multiple wallets in one subscription?
+
+How do I monitor multiple wallets in one subscription?. Uses the `Trades` cube.
+
+▶️ [How do I monitor multiple wallets in one subscription?](https://ide.bitquery.io/How-do-I-monitor-multiple-wallets-in-one-subscription)
+
+#### How do I monitor multiple wallets trading a specific token?
+
+How do I monitor multiple wallets trading a specific token?. Uses the `Trades` cube.
+
+▶️ [How do I monitor multiple wallets trading a specific token?](https://ide.bitquery.io/How-do-I-monitor-multiple-wallets-trading-a-specific-token)
+
+#### How do I stream a wallet's trades on a specific DEX?
+
+How do I stream a wallet's trades on a specific DEX?. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [How do I stream a wallet's trades on a specific DEX?](https://ide.bitquery.io/How-do-I-stream-a-wallets-trades-on-a-specific-DEX)
+
+#### How do I stream a wallet's trades on a specific chain?
+
+How do I stream a wallet's trades on a specific chain?. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [How do I stream a wallet's trades on a specific chain?](https://ide.bitquery.io/How-do-I-stream-a-wallets-trades-on-a-specific-chain)
+
+#### How do I stream whale trades for a specific wallet?
+
+How do I stream whale trades for a specific wallet?. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+
+▶️ [How do I stream whale trades for a specific wallet?](https://ide.bitquery.io/How-do-I-stream-whale-trades-for-a-specific-wallet)
+
+#### How do I track trades for multiple tokens in one subscription?
+
+How do I track trades for multiple tokens in one subscription?. Uses the `Trades` cube.
+
+▶️ [How do I track trades for multiple tokens in one subscription?](https://ide.bitquery.io/How-do-I-track-trades-for-multiple-tokens-in-one-subscription)
+
+### Price & OHLC
+
+#### FourMeme 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders
+
+Track token activity (OHLC, price, volume) every 1 second on FourMeme DEX (BSC).
+
+▶️ [FourMeme 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders](https://ide.bitquery.io/FourMeme-DEX-tokens-1-second-price-stream-with-OHLC)
+
+#### PumpAMM 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders
+
+Real-time (1-second interval) price, OHLC, volume, and moving averages for Pump.fun AMM tokens on Solana. Useful for high-frequency trading bots.
+
+▶️ [PumpAMM 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders](https://ide.bitquery.io/PumpAMM-tokens-1-second-price-stream-with-OHLC_1)
+
+#### Raydium Launchlab 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders
+
+Monitor Raydium Launchlab token listings on Solana with 1-second OHLC and volume streams. Perfect for tracking new token launches.
+
+▶️ [Raydium Launchlab 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders](https://ide.bitquery.io/Raydium-Launchpad-DEX-tokens-1-second-price-stream-with-OHLC)
+
+#### 5 minute price change api on solana
+
+5 minute price change api on solana. Uses the `Tokens` cube.
+
+▶️ [5 minute price change api on solana](https://ide.bitquery.io/5-minute-price-change-api-on-solana_6)
+
+#### Bitcoin currency price stream
+
+Bitcoin currency price stream. Uses the `Currencies` cube.
+
+▶️ [Bitcoin currency price stream](https://ide.bitquery.io/bitcoin-currency-price-stream)
+
+#### Heaven DEX tokens 1 second price stream with OHLC
+
+Heaven DEX tokens 1 second price stream with OHLC. Uses the `Pairs` cube.
+
+▶️ [Heaven DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/Heaven-DEX-tokens-1-second-price-stream-with-OHLC)
+
+#### Meteora DBC DEX tokens 1 second price stream with OHLC
+
+Meteora DBC DEX tokens 1 second price stream with OHLC. Uses the `Pairs` cube.
+
+▶️ [Meteora DBC DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/Meteora-DBC-DEX-tokens-1-second-price-stream-with-OHLC)
+
+#### Real Time USD price on solana chain
+
+Real Time USD price on solana chain. Uses the `Pairs` cube.
+
+▶️ [Real Time USD price on solana chain](https://ide.bitquery.io/Real-Time-USD-price-on-solana-chain_2)
+
+### Supply & Market Cap
+
+#### All trades of a specific Ethereum token with Price, Marketcap, supply
+
+All trades of a specific Ethereum token with Price, Marketcap, supply. Uses the `Trades` cube.
+
+▶️ [All trades of a specific Ethereum token with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-of-a-specific-Ethereum-token-with-Price-Marketcap-supply_1)
+
+### Liquidity & Pools
+
+#### Liquidity addition for radium
+
+Liquidity addition for radium. Uses the `DEXPools` cube.
+
+▶️ [Liquidity addition for radium](https://ide.bitquery.io/liquidity-addition-for-radium_1)
+
+#### Liquidity removal for radium
+
+Liquidity removal for radium. Uses the `DEXPools` cube.
+
+▶️ [Liquidity removal for radium](https://ide.bitquery.io/liquidity-removal-for-radium_1)
+
+### Pump.fun
+
+#### All Pumpswap Trade Stream
+
+All Pumpswap Trade Stream. Uses the `Trades` cube.
+
+▶️ [All Pumpswap Trade Stream](https://ide.bitquery.io/All-Pumpswap-Trade-Stream)
+
+#### All pumpfun Trade Stream
+
+All pumpfun Trade Stream. Uses the `Trades` cube.
+
+▶️ [All pumpfun Trade Stream](https://ide.bitquery.io/All-pumpfun-Trade-Stream_2)
+
+#### Pump fun token live prices using trades api
+
+Pump fun token live prices using trades api. Uses the `Trades` cube.
+
+▶️ [Pump fun token live prices using trades api](https://ide.bitquery.io/pump-fun-token-live-prices-using-trades-api_1)
+
+### PancakeSwap
+
+#### Real-time Trades on Pancakeswap
+
+This subscription returns the real-time trades happening on Pancakeswap. You can modify the stream to get real time trades for a particular token, a particular token pair, and even a particular trader.
+
+▶️ [Real-time Trades on Pancakeswap](https://ide.bitquery.io/Latest-BSC-PancakeSwap-v3-dextrades---Stream)
+
+#### PancakeSwap v3 DEX tokens 1 second price stream with OHLC
+
+PancakeSwap v3 DEX tokens 1 second price stream with OHLC. Uses the `Pairs` cube. Replace the address in the `where` clause to use it.
+
+▶️ [PancakeSwap v3 DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/PancakeSwap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
+
+### Uniswap
+
+#### 1-second price, OHLC, volume, SMA and EMA — Uniswap v3
+
+One-second candles with moving averages for Uniswap v3 tokens, built for trading front-ends.
+
+▶️ [1-second price, OHLC, volume, SMA and EMA — Uniswap v3](https://ide.bitquery.io/Uniswap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
+
+#### Stream all Uniswap Seconds OHLC Kline
+
+Stream all Uniswap Seconds OHLC Kline. Uses the `Pairs` cube.
+
+▶️ [Stream all Uniswap Seconds OHLC Kline](https://ide.bitquery.io/Stream-all-Uniswap-Seconds-OHLC-Kline)
+
+#### Uniswap all versions trades stream
+
+Uniswap all versions trades stream. Uses the `DEXTrades` cube.
+
+▶️ [Uniswap all versions trades stream](https://ide.bitquery.io/uniswap-all-versions-trades-stream)
+
+## Stablecoins
+
+### Trades
+
+#### Solana trades subscription
+
+Solana trades subscription. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Solana trades subscription](https://ide.bitquery.io/solana-trades-subscription_10_1)
+
+#### Stablecoin Depeg tracking Stream for evm
+
+Stablecoin Depeg tracking Stream for evm. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Stablecoin Depeg tracking Stream for evm](https://ide.bitquery.io/Stablecoin-Depeg-tracking-Stream-for-evm)
+
+#### Stablecoin Depeg tracking Stream for tron
+
+Stablecoin Depeg tracking Stream for tron. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Stablecoin Depeg tracking Stream for tron](https://ide.bitquery.io/Stablecoin-Depeg-tracking-Stream-for-tron)
+
+#### Stablecoin depeg tracking stream for USDC
+
+Stablecoin depeg tracking stream for USDC. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Stablecoin depeg tracking stream for USDC](https://ide.bitquery.io/stablecoin-depeg-tracking-stream-for-USDC)
+
+#### Stablecoin trades for etheruem
+
+Stablecoin trades for etheruem. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Stablecoin trades for etheruem](https://ide.bitquery.io/Stablecoin-trades-for-etheruem)
+
+#### Stablecoin trades for tron
+
+Stablecoin trades for tron. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Stablecoin trades for tron](https://ide.bitquery.io/Stablecoin-trades-for-tron)
+
+### Transfers
+
+#### Latest Tron USDT Transfers stream
+
+Latest Tron USDT Transfers stream. Uses the `Transfers` cube.
+
+▶️ [Latest Tron USDT Transfers stream](https://ide.bitquery.io/Latest-Tron-USDT-Transfers-stream)
+
+#### Latest USDT/USDC Transfer Stream on BSC
+
+Latest USDT/USDC Transfer Stream on BSC. Uses the `Transfers` cube.
+
+▶️ [Latest USDT/USDC Transfer Stream on BSC](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-Stream-on-BSC)
+
+#### Latest USDT/USDC Transfer stream on base
+
+Latest USDT/USDC Transfer stream on base. Uses the `Transfers` cube.
+
+▶️ [Latest USDT/USDC Transfer stream on base](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-stream-on-base)
+
+#### Latest USDT/USDC Transfer stream on ethereum
+
+Latest USDT/USDC Transfer stream on ethereum. Uses the `Transfers` cube.
+
+▶️ [Latest USDT/USDC Transfer stream on ethereum](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-stream-on-ethereum)
+
+#### Listening to All USDT and USDC Payments on Solana - stream
+
+Listening to All USDT and USDC Payments on Solana - stream. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Listening to All USDT and USDC Payments on Solana - stream](https://ide.bitquery.io/Listening-to-All-USDT-and-USDC-Payments-on-Solana---stream)
+
+#### Listening to stablecoin Transfers for Specific Addresse on tron
+
+Listening to stablecoin Transfers for Specific Addresse on tron. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Listening to stablecoin Transfers for Specific Addresse on tron](https://ide.bitquery.io/Listening-to-stablecoin-Transfers-for-Specific-Addresse-on-tron)
+
+#### Stablecoin Realtime Payments Stream on Eth Mainnet
+
+Stablecoin Realtime Payments Stream on Eth Mainnet. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Stablecoin Realtime Payments Stream on Eth Mainnet](https://ide.bitquery.io/Stablecoin-Realtime-Payments-Stream-on-Eth-Mainnet)
+
+#### Stablecoin Realtime Transfers Stream on tron
+
+Stablecoin Realtime Transfers Stream on tron. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Stablecoin Realtime Transfers Stream on tron](https://ide.bitquery.io/Stablecoin-Realtime-Transfers-Stream-on-tron)
+
+#### Stablecoin transfers websocket
+
+Stablecoin transfers websocket. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Stablecoin transfers websocket](https://ide.bitquery.io/stablecoin-transfers-websocket)
+
+#### USDT and USDC token Transfers stream on solana
+
+USDT and USDC token Transfers stream on solana. Uses the `Transfers` cube.
+
+▶️ [USDT and USDC token Transfers stream on solana](https://ide.bitquery.io/USDT-and-USDC-token-Transfers-stream-on-solana)
+
+### Balances & Holders
+
+#### Real time stablecoin portfolio
+
+Real time stablecoin portfolio. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Real time stablecoin portfolio](https://ide.bitquery.io/real-time-stablecoin-portfolio_2)
+
+### Price & OHLC
+
+#### Stablecoin 1 sec Price Stream
+
+This subscription gives you 1-second OHLC, mean price, averages for all stablecoins including USDC, USDT, DAI, USDS etc.
+
+▶️ [Stablecoin 1 sec Price Stream](https://ide.bitquery.io/stablecoin-1-second-price-stream)
+
+#### Stablecoin price stream of USDT
+
+Stablecoin price stream of USDT. Uses the `Tokens` cube.
+
+▶️ [Stablecoin price stream of USDT](https://ide.bitquery.io/stablecoin-price-stream-of-USDT_2)
+
+### Supply & Market Cap
+
+#### USDT Stablecoin reserves on Solana
+
+USDT Stablecoin reserves on Solana. Uses the `TokenSupplyUpdates` cube. Change the token address in the `where` clause to use it.
+
+▶️ [USDT Stablecoin reserves on Solana](https://ide.bitquery.io/USDT-Stablecoin-reserves-on-Solana)
+
+### Mempool
+
+#### Latest Tron USDT Transfers stream in Mempool
+
+Latest Tron USDT Transfers stream in Mempool. Uses the `Transfers` cube.
+
+▶️ [Latest Tron USDT Transfers stream in Mempool](https://ide.bitquery.io/Latest-Tron-USDT-Transfers-stream-in-Mempool)
+
+#### Latest USDT/USDC Transfer Stream on BSC on Mempool
+
+Latest USDT/USDC Transfer Stream on BSC on Mempool. Uses the `Transfers` cube.
+
+▶️ [Latest USDT/USDC Transfer Stream on BSC on Mempool](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-Stream-on-BSC-on-Mempool)
+
+#### Latest USDT/USDC Transfer stream on ethereum in Mempool
+
+Latest USDT/USDC Transfer stream on ethereum in Mempool. Uses the `Transfers` cube.
+
+▶️ [Latest USDT/USDC Transfer stream on ethereum in Mempool](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-stream-on-ethereum-in-Mempool)
+
+## Perpetuals
+
+### Trades
+
+#### Hyperliquid Real-time Trades Stream (WebSocket)
+
+Hyperliquid Real-time Trades Stream (WebSocket).
+
+▶️ [Hyperliquid Real-time Trades Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-trades-stream)
+
+#### Solana Perps Live Trades Stream (Phoenix Fills)
+
+Solana Perps Live Trades Stream (Phoenix Fills).
+
+▶️ [Solana Perps Live Trades Stream (Phoenix Fills)](https://ide.bitquery.io/solana-perps-live-trades-stream)
+
+### Price & OHLC
+
+#### Hyperliquid Price Updates Stream (WebSocket)
+
+Hyperliquid Price Updates Stream (WebSocket).
+
+▶️ [Hyperliquid Price Updates Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-price-updates-stream)
+
+#### Hyperliquid Real-time Candles Stream (WebSocket)
+
+Hyperliquid Real-time Candles Stream (WebSocket).
+
+▶️ [Hyperliquid Real-time Candles Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-candles-stream)
+
+#### Solana Perpetuals Mark Price Stream (Phoenix)
+
+Solana Perpetuals Mark Price Stream (Phoenix).
+
+▶️ [Solana Perpetuals Mark Price Stream (Phoenix)](https://ide.bitquery.io/solana-perpetuals-mark-price-stream)
+
+## NFTs
+
+### Trades
 
 #### NFT Trades on Opensea
 
 This stream allows you to monitor real time NFT trades on OpenSea. It could also be modified to get trades of a particular NFT collection or NFTs traded by a particular trader.
 
-▶️ [NFT Trades Stream](https://ide.bitquery.io/Latests-OpenSea-Trades--stream)
+▶️ [NFT Trades on Opensea](https://ide.bitquery.io/Latests-OpenSea-Trades--stream)
 
-### Balance APIs
+#### Latest Solana NFT Trades
+
+Latest Solana NFT Trades.
+
+▶️ [Latest Solana NFT Trades](https://ide.bitquery.io/Latest-Solana-NFT-Trades)
+
+### Transfers
+
+#### ERC-721 (NFT) transfers
+
+NFT transfers as they are mined, with token IDs.
+
+▶️ [ERC-721 (NFT) transfers](https://ide.bitquery.io/ERC721-token-transfers)
+
+#### Subscription WebSocket - Latest NFT Transfers
+
+Subscription WebSocket - Latest NFT Transfers.
+
+▶️ [Subscription WebSocket - Latest NFT Transfers](https://ide.bitquery.io/Subscription-WebSocket---Latest-NFT-Transfers)
+
+#### Subscribe to the latest NFT transfers on Solana
+
+Subscribe to the latest NFT transfers on Solana.
+
+▶️ [Subscribe to the latest NFT transfers on Solana](https://ide.bitquery.io/Subscribe-to-the-latest-NFT-transfers-on-Solana)
+
+#### NFT Token Transfers API
+
+NFT Token Transfers API.
+
+▶️ [NFT Token Transfers API](https://ide.bitquery.io/NFT-Token-Transfers-API_4)
+
+#### Transfers of a particular NFT
+
+Transfers of a particular NFT.
+
+▶️ [Transfers of a particular NFT](https://ide.bitquery.io/Transfers-of-a-particular-NFT_1)
+
+#### Track realtime NFT Transfers of a specific NFT on BSC chain
+
+Track realtime NFT Transfers of a specific NFT on BSC chain.
+
+▶️ [Track realtime NFT Transfers of a specific NFT on BSC chain](https://ide.bitquery.io/Track-realtime-NFT-Transfers-of-a-specific-NFT-on-BSC-chain)
+
+#### Track realtime NFT Transfers on BSC chain
+
+Track realtime NFT Transfers on BSC chain.
+
+▶️ [Track realtime NFT Transfers on BSC chain](https://ide.bitquery.io/Track-realtime-NFT-Transfers-on-BSC-chain)
+
+#### Websocket for tracking Transfers of a particular NFT websocket
+
+Websocket for tracking Transfers of a particular NFT websocket.
+
+▶️ [Websocket for tracking Transfers of a particular NFT websocket](https://ide.bitquery.io/Websocket-for-tracking-Transfers-of-a-particular-NFT-websocket)
+
+#### Real-time-transfer-websocket-for-NFT-token on matic
+
+Real-time-transfer-websocket-for-NFT-token on matic.
+
+▶️ [Real-time-transfer-websocket-for-NFT-token on matic](https://ide.bitquery.io/Real-time-transfer-websocket-for-NFT-token-on-matic)
+
+### Balances & Holders
 
 #### Stream NFT Balance Updates in Real Time
 
@@ -691,9 +2422,95 @@ Monitor NFT transfers for a specific collection across all transactions. This he
 
 ▶️ [Track Specific NFT Balance Changes](https://ide.bitquery.io/Track-specific-NFTs-Balance-Changes)
 
-## x402 Streams
+## Polymarket
 
-### Base
+### Trades
+
+#### Real-Time Trades Stream
+
+Subscribe to live prediction market trades as they occur on Polygon (successful transactions only).
+
+▶️ [Real-Time Trades Stream](https://ide.bitquery.io/prediction-market-trades-subscription)
+
+#### Trades for a Specific Market (Stream)
+
+Subscribe to trades for one market only by filtering on Question.MarketId. Replace the market ID in the query with your target market.
+
+▶️ [Trades for a Specific Market (Stream)](https://ide.bitquery.io/subscribe-to-specific-market-trades)
+
+#### Bitcoin Up or Down Trades Stream
+
+Bitcoin Up or Down Trades Stream.
+
+▶️ [Bitcoin Up or Down Trades Stream](https://ide.bitquery.io/Bitcoin-Up-or-Down-Trades-Stream)
+
+#### How do I track high-value or whale trades on Polymarket?
+
+How do I track high-value or whale trades on Polymarket?.
+
+▶️ [How do I track high-value or whale trades on Polymarket?](https://ide.bitquery.io/How-do-I-track-high-value-or-whale-trades-on-Polymarket)
+
+#### Large trades on polymarket
+
+Large trades on polymarket.
+
+▶️ [Large trades on polymarket](https://ide.bitquery.io/large-trades--on-polymarket)
+
+#### Monitoring specific wallets trades in realtime for Ethereum up or down market
+
+Monitoring specific wallets trades in realtime for Ethereum up or down market.
+
+▶️ [Monitoring specific wallets trades in realtime for Ethereum up or down market](https://ide.bitquery.io/monitoring-specific-wallets-trades-in-realtime-for-Ethereum-up-or-down-market)
+
+#### Monitoring specific wallets trades in realtime for XRP up or down market
+
+Monitoring specific wallets trades in realtime for XRP up or down market.
+
+▶️ [Monitoring specific wallets trades in realtime for XRP up or down market](https://ide.bitquery.io/monitoring-specific-wallets-trades-in-realtime-for-XRP-up-or-down-market)
+
+#### Polymarket AI whale trades stream
+
+Polymarket AI whale trades stream.
+
+▶️ [Polymarket AI whale trades stream](https://ide.bitquery.io/Polymarket-AI-whale-trades-stream)
+
+#### Polymarket whale trades alert
+
+Polymarket whale trades alert.
+
+▶️ [Polymarket whale trades alert](https://ide.bitquery.io/polymarket-whale-trades-alert_1)
+
+### Markets
+
+#### Real-Time Management Stream (Creations + Resolutions)
+
+Subscribe to all prediction market lifecycle events (Created and Resolved) as they occur on Polygon.
+
+▶️ [Real-Time Management Stream (Creations + Resolutions)](https://ide.bitquery.io/Prediction-Managements-subscription-resolutions-creations)
+
+#### Real-Time Market Creations
+
+Subscribe only to new market (Created) events.
+
+▶️ [Real-Time Market Creations](https://ide.bitquery.io/track-realtime-new-polymarket-creations)
+
+#### Real-Time Market Resolutions
+
+Subscribe only to Resolved events. Winning outcome is in Prediction.Outcome; token details (e.g. AssetId) in Prediction.OutcomeToken.
+
+▶️ [Real-Time Market Resolutions](https://ide.bitquery.io/track-realtime-polymarket-resolutions)
+
+### Settlements
+
+#### Real-Time Settlement Stream
+
+Subscribe to live Split, Merge, and Redemption events as they occur on Polygon.
+
+▶️ [Real-Time Settlement Stream](https://ide.bitquery.io/realtime-predicion-market-settlements-stream)
+
+## x402
+
+### Transfers
 
 #### Real-Time Payment Monitoring for x402 Server
 
@@ -701,17 +2518,24 @@ Real-time subscription to monitor payments to a specific x402 server on Base net
 
 ▶️ [Real-Time Payment Monitoring for x402 Server](https://ide.bitquery.io/Monitoring-the-latest-payment-to-the-specific-X402-server)
 
-### Solana
-
 #### Real-Time Payment Monitoring for x402 Server on Solana
 
 Real-time subscription to monitor payments to a specific x402 server on Solana network using WebSockets.
 
 ▶️ [Real-Time Payment Monitoring for x402 Server on Solana](https://ide.bitquery.io/Real-Time---Solana-transfers-stream)
 
-## More on Streams
+## Cross-Chain
 
-You will find more detailed information on streams and subscriptions in the relevant sections.
+### Price & OHLC
 
-- [Understanding Subscription](/docs/subscriptions/subscription/)
-- [Streaming via Websocket](/docs/subscriptions/examples/)
+#### Crypto Price Stream
+
+This subscription gives you 1-second OHLC, mean price, averages for all tokens across Solana, Ethereum, BNB, Tron.
+
+▶️ [Crypto Price Stream](https://ide.bitquery.io/1-second-crypto-price-stream-with-mcap)
+
+#### Stablecoin 1 sec Price Stream
+
+This subscription gives you 1-second OHLC, mean price, averages for all stablecoins including USDC, USDT, DAI, USDS etc.
+
+▶️ [Stablecoin 1 sec Price Stream](https://ide.bitquery.io/stablecoin-1-second-price-stream)

--- a/docs/start/starter-subscriptions.md
+++ b/docs/start/starter-subscriptions.md
@@ -46,19 +46,19 @@ Every Ethereum DEX trade as it happens. Add a `where` filter to narrow to a toke
 
 #### All swap events
 
-All swap events. Uses the `Events` cube.
+Returns provides information on the latest real-time swap events on Ethereum. You can run it [here
 
 ▶️ [All swap events](https://ide.bitquery.io/all-swap-events)
 
 #### Get pair trades data just like dexcsreener
 
-Get pair trades data just like dexcsreener. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+The query will subscribe you to real-time trade transactions for a pair, providing a continuous stream of data as new trades are processed and recorded. You can find the query [here
 
 ▶️ [Get pair trades data just like dexcsreener](https://ide.bitquery.io/Get-pair-trades-data-just-like-dexcsreener)
 
 #### Get pair trades data just like geckoterminal
 
-Get pair trades data just like geckoterminal. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+The query will subscribe you to real-time trade transactions for a pair, providing a continuous stream of data as new trades are processed and recorded. You can find the query [here
 
 ▶️ [Get pair trades data just like geckoterminal](https://ide.bitquery.io/Get-pair-trades-data-just-like-geckoterminal)
 
@@ -70,7 +70,7 @@ Latest token trades subscription. Uses the `DEXTrades` cube. Change the token ad
 
 #### Pepe live trades stream
 
-Pepe live trades stream. Uses the `DEXTradeByTokens` cube.
+Every PEPE DEX trade as it is confirmed on-chain in real time using Bitquery subscription.
 
 ▶️ [Pepe live trades stream](https://ide.bitquery.io/pepe-live-trades-stream)
 
@@ -82,19 +82,19 @@ Real time trades of an ethereum address. Uses the `DEXTrades` cube. Replace the 
 
 #### Stream new position mints on Fluid DEX Vault
 
-Stream new position mints on Fluid DEX Vault. Uses the `Events` cube. Change the token address in the `where` clause to use it.
+Track new position mints on the Fluid DEX Vault Factory contract. This query monitors the `NewPositionMinted` event which is emitted when a new position is created on the vault factory.
 
 ▶️ [Stream new position mints on Fluid DEX Vault](https://ide.bitquery.io/stream-new-position-mints-on-Fluid-DEX-Vault)
 
 #### Subscribe to dex trades on ethereum mainnet
 
-Subscribe to dex trades on ethereum mainnet.
+Returns will get you the realtime DEX trades happening on Ethereum Mainnet. Open it in the GraphQL IDE using this [link
 
 ▶️ [Subscribe to dex trades on ethereum mainnet](https://ide.bitquery.io/subscribe-to-dex-trades-on-ethereum-mainnet_2)
 
 #### Trades of a specific trader of a specific token
 
-Trades of a specific trader of a specific token. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+Crypto Trades API: filter `Pair.Market.Network: Ethereum` and `Trader.Address`. More examples: Trades API, [trader + token (IDE)
 
 ▶️ [Trades of a specific trader of a specific token](https://ide.bitquery.io/trades-of-a-specific-trader-of-a-specific-token)
 
@@ -108,19 +108,19 @@ Live ERC-20 transfers. Change the token address to follow a different one.
 
 #### Pepe whale transfer stream
 
-Pepe whale transfer stream. Uses the `Transfers` cube.
+Subscribe to PEPE transfers above 1 billion tokens the moment they hit the chain.
 
 ▶️ [Pepe whale transfer stream](https://ide.bitquery.io/pepe-whale-transfer-stream)
 
 #### Subscribe to Latest WETH token transfers
 
-Subscribe to Latest WETH token transfers. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+Returns subscribes to WETH (Wrapped Ethereum) token transfers. The contract address is 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.
 
 ▶️ [Subscribe to Latest WETH token transfers](https://ide.bitquery.io/Subscribe-to-Latest-WETH-token-transfers)
 
 #### Subscribe to latest Axie infinity token transfers
 
-Subscribe to latest Axie infinity token transfers. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+You can open this API on our GraphQL IDE using this [link
 
 ▶️ [Subscribe to latest Axie infinity token transfers](https://ide.bitquery.io/Subscribe-to-latest-Axie-infinity-token-transfers_1)
 
@@ -202,13 +202,13 @@ Live USD price updates as trades land.
 
 #### 1 second crypto price stream
 
-1 second crypto price stream. Uses the `Tokens` cube.
+For a live ticker, use the Crypto Price API stream.
 
 ▶️ [1 second crypto price stream](https://ide.bitquery.io/1-second-crypto-price-stream)
 
 #### Pepe-ohlcv-stream
 
-Pepe-ohlcv-stream. Uses the `Tokens` cube.
+Stream live PEPE price data with 1-minute candles, moving averages, and USD volume.
 
 ▶️ [Pepe-ohlcv-stream](https://ide.bitquery.io/pepe-ohlcv-stream)
 
@@ -234,7 +234,7 @@ Mints and burns as they change a token's supply.
 
 #### All trades on Ethereum with Price, Marketcap, supply
 
-All trades on Ethereum with Price, Marketcap, supply. Uses the `Trades` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [All trades on Ethereum with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Ethereum-with-Price-Marketcap-supply)
 
@@ -248,13 +248,13 @@ Slippage on every trade as it happens, across all pools.
 
 #### Realtime Liquidity Stream
 
-Realtime Liquidity Stream.
+Returns query returns real-time liquidity data for all DEX pools on Ethereum. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
 
 ▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_4)
 
 #### Realtime Liquidity Stream of a Specific Pool
 
-Realtime Liquidity Stream of a Specific Pool. Uses the `DEXPoolEvents` cube.
+Returns query monitors real-time liquidity changes for a specific DEX pool on Ethereum. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
 
 ▶️ [Realtime Liquidity Stream of a Specific Pool](https://ide.bitquery.io/Realtime-Liquidity-Stream-of-a-Specific-Pool_4)
 
@@ -262,7 +262,7 @@ Realtime Liquidity Stream of a Specific Pool. Uses the `DEXPoolEvents` cube.
 
 #### Get Transaction Hash
 
-Get Transaction Hash.
+In this section we will discuss how we can build eth_getTransactionByHash alternatives using Bitquery APIs.
 
 ▶️ [Get Transaction Hash](https://ide.bitquery.io/Get-Transaction-Hash)
 
@@ -276,7 +276,7 @@ Stream pool and pair creation on ethereum. Uses the `Events` cube.
 
 #### Subscribe to the Same Event Across Multiple Contracts
 
-Subscribe to the Same Event Across Multiple Contracts. Uses the `Events` cube.
+In the below query we listen for a specific event (Approval) across multiple smart contracts on the Ethereum (ETH) network. Run the query [here
 
 ▶️ [Subscribe to the Same Event Across Multiple Contracts](https://ide.bitquery.io/Subscribe-to-the-Same-Event-Across-Multiple-Contracts)
 
@@ -284,19 +284,19 @@ Subscribe to the Same Event Across Multiple Contracts. Uses the `Events` cube.
 
 #### Binance Mempool Transactions
 
-Binance Mempool Transactions. Uses the `Transactions` cube. Replace the address in the `where` clause to use it.
+The example below retrieves mempool transactions from the specified address (Binance / BSC mempool context).
 
 ▶️ [Binance Mempool Transactions](https://ide.bitquery.io/Binance-Mempool-Transactions_1)
 
 #### Eth subscribe("logs")
 
-Eth subscribe("logs"). Uses the `Events` cube.
+You can subscribe to all incoming logs filtered by any of the fields including method signature, tx value,sender , receiver and so on. In the below example we are tracking only logs where the method name is `transfer`. You can run it [here
 
 ▶️ [Eth subscribe("logs")](https://ide.bitquery.io/eth_subscribelogs)
 
 #### Eth subscribe(“pendingTransactions”)
 
-Eth subscribe(“pendingTransactions”).
+To subscribe to incoming pending transactions, use the below subscription. You can run it [here
 
 ▶️ [Eth subscribe(“pendingTransactions”)](https://ide.bitquery.io/eth_subscribependingTransactions)
 
@@ -308,7 +308,7 @@ Gas prices being offered by pending transactions right now.
 
 #### Mempool event stream
 
-Mempool event stream.
+Returns listens to real-time mempool events on the Ethereum (ETH) blockchain. The query is designed to capture details of transactions, logs, events, and arguments from the Ethereum Virtual Machine (EVM) before they are confirmed in a block.
 
 ▶️ [Mempool event stream](https://ide.bitquery.io/Mempool-event-stream)
 
@@ -332,7 +332,7 @@ Catches pool creation at broadcast time rather than after the block.
 
 #### Vrs signature
 
-Vrs signature.
+Returns query retrieves real-time mempool transactions and includes key details such as the block time, block number, transaction hash, transaction cost, and the V, R, S components of the transaction signature. You can run it [here
 
 ▶️ [Vrs signature](https://ide.bitquery.io/vrs-signature)
 
@@ -382,19 +382,19 @@ Rewards paid to validators, block by block.
 
 #### Filter by MEV Bot or Builder Address
 
-Filter by MEV Bot or Builder Address. Uses the `TransactionBalances` cube.
+Track balance changes for specific MEV bots or block builders: Try the API [here
 
 ▶️ [Filter by MEV Bot or Builder Address](https://ide.bitquery.io/Filter-by-MEV-Bot-or-Builder-Address)
 
 #### Filter by Miner Address
 
-Filter by Miner Address. Uses the `TransactionBalances` cube.
+Track balance changes for a specific miner address: Try the API [here
 
 ▶️ [Filter by Miner Address](https://ide.bitquery.io/Filter-by-Miner-Address)
 
 #### Filter by Validator Address
 
-Filter by Validator Address. Uses the `TransactionBalances` cube.
+Track balance changes for a specific validator address: Try the API [here
 
 ▶️ [Filter by Validator Address](https://ide.bitquery.io/Filter-by-Validator-Address)
 
@@ -420,19 +420,19 @@ Live trades on Uniswap only.
 
 #### Currency pair liquidity events stream
 
-Currency pair liquidity events stream. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+If looking to monitor a currency pair across all virtual pools within Uniswap V4, then this subscription works the best.
 
 ▶️ [Currency pair liquidity events stream](https://ide.bitquery.io/currency-pair-liquidity-events-stream)
 
 #### Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4
 
-Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4. Uses the `DEXPoolEvents` cube.
+Returns query monitors real-time liquidity changes for all pools in a specific DEX protocol on Ethereum. Here we have taken example of Uniswap V4.
 
 ▶️ [Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4](https://ide.bitquery.io/Latest-Liquidity-Changes-of-Pools-in-a-Specific-DEX-Protocol---Uniswap-V4_6)
 
 #### Latest pools created Uniswap v3
 
-Latest pools created Uniswap v3. Uses the `Events` cube. Change the token address in the `where` clause to use it.
+Open this query on our GraphQL IDE using this [link
 
 ▶️ [Latest pools created Uniswap v3](https://ide.bitquery.io/Latest-pools-created-Uniswap-v3_9)
 
@@ -466,37 +466,37 @@ This subscription stream uses DexTradeByTokens API to stream real-time specific 
 
 #### All Trade for Bags.fm tokens
 
-All Trade for Bags.fm tokens. Uses the `DEXTrades` cube.
+Get all trades of Bags FM tokens from Meteora and other DEXs. This Bags FM token trades WebSocket provides comprehensive trading data.
 
 ▶️ [All Trade for Bags.fm tokens](https://ide.bitquery.io/All-Trade-for-Bagsfm-tokens)
 
 #### CPMM trades
 
-CPMM trades. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
+Returns subscribes to real-time trades on the Raydium CPMM on the Solana blockchain by filtering using `{Program: {Address: {is: "CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C"}}}:`. You can run the query [here
 
 ▶️ [CPMM trades](https://ide.bitquery.io/CPMM-trades)
 
 #### Get Solana pair trades data
 
-Get Solana pair trades data. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+The query will subscribe you to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded. You can find the query [here
 
 ▶️ [Get Solana pair trades data](https://ide.bitquery.io/Get-Solana-pair-trades-data)
 
 #### Get Solana pair trades data just like dexcsreener
 
-Get Solana pair trades data just like dexcsreener. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+The query will subscribe you to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded. You can find the query [here
 
 ▶️ [Get Solana pair trades data just like dexcsreener](https://ide.bitquery.io/Get-Solana-pair-trades-data-just-like-dexcsreener)
 
 #### Get Solana pair trades data just like geckoTerminal
 
-Get Solana pair trades data just like geckoTerminal. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+The query will subscribe you to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded. You can find the query [here
 
 ▶️ [Get Solana pair trades data just like geckoTerminal](https://ide.bitquery.io/Get-Solana-pair-trades-data-just-like-geckoTerminal_1)
 
 #### Latest Trades of TESLA onchain xStock
 
-Latest Trades of TESLA onchain xStock. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns will give you realtime trades of Tesla xStock (TESLAx). You can run the query [here
 
 ▶️ [Latest Trades of TESLA onchain xStock](https://ide.bitquery.io/Latest-Trades-of-TESLA-onchain-xStock_1)
 
@@ -510,37 +510,37 @@ This stream provides all token transfers on the Solana blockchain, including SOL
 
 #### SPL transfers websocket
 
-SPL transfers websocket. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+One of the most common types of transfers on Solana are SPL token transfers. Let's see an example to get the latest SPL token transfers using our API. Today we are taking an example of JUPITER token transfers.
 
 ▶️ [SPL transfers websocket](https://ide.bitquery.io/SPL-transfers-websocket_1)
 
 #### Solana Websocket - Subscribe to all transfers of specific addresses in realtime
 
-Solana Websocket - Subscribe to all transfers of specific addresses in realtime. Uses the `Transfers` cube.
+Websockets are priced based on their running time, not the amount of data delivered.
 
 ▶️ [Solana Websocket - Subscribe to all transfers of specific addresses in realtime](https://ide.bitquery.io/Solana-Websocket---Subscribe-to-all-transfers-of-specific-addresses-in-realtime)
 
 #### Subscribe to the all transfers on Solana
 
-Subscribe to the all transfers on Solana.
+For monitoring the balance changes that result from these transfers, see our Solana Balance Updates API.
 
 ▶️ [Subscribe to the all transfers on Solana](https://ide.bitquery.io/Subscribe-to-the-all-transfers-on-Solana)
 
 #### Transfers of All Tip Payment Accounts on Solana
 
-Transfers of All Tip Payment Accounts on Solana. Uses the `Transfers` cube.
+Jito foundation has Tip Payment Program that allows users to transfer tips to a set of static public keys (compared to signing the transaction with the next N leaders) and ensure that the incentives are distributed to the correct block leader, while enabling…
 
 ▶️ [Transfers of All Tip Payment Accounts on Solana](https://ide.bitquery.io/Transfers-of-All-Tip-Payment-Accounts-on-Solana)
 
 #### Transfers of Tip Payment Accounts on Solana
 
-Transfers of Tip Payment Accounts on Solana. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+The subscription that provides you the transfer data of one of these addresses is [writen below
 
 ▶️ [Transfers of Tip Payment Accounts on Solana](https://ide.bitquery.io/Transfers-of-Tip-Payment-Accounts-on-Solana_1)
 
 #### Transfers where sender is the specified address
 
-Transfers where sender is the specified address. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+This websocket retrieves transfers where the sender is a particular address `2g9NLWUM6bPm9xq2FBsb3MT3F3G5HDraGqZQEVzcCWTc`.
 
 ▶️ [Transfers where sender is the specified address](https://ide.bitquery.io/transfers-where-sender-is-the-specified-address_1)
 
@@ -574,31 +574,31 @@ This stream delivers real-time token prices on Solana based on the latest trades
 
 #### Byreal token live prices using trades api
 
-Byreal token live prices using trades api. Uses the `Trades` cube.
+Run the subscription [in the Bitquery IDE
 
 ▶️ [Byreal token live prices using trades api](https://ide.bitquery.io/Byreal-token-live-prices-using-trades-api)
 
 #### Get Latest Price of SOL in USD Real-time
 
-Get Latest Price of SOL in USD Real-time. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns retrieves the USD price of a token on Solana by setting `MintAddress: {is: "J5FAZ6bV7CCGHcU4CTXWVG6nnKHcwD9Pn4DntY93pump"}` and `Side: {Currency: {MintAddress: {is: "11111111111111111111111111111111"}}}` .
 
 ▶️ [Get Latest Price of SOL in USD Real-time](https://ide.bitquery.io/Get-Latest-Price-of-SOL-in--USD-Real-time)
 
 #### Get realtime Price of Apple xStock in USD Real-time
 
-Get realtime Price of Apple xStock in USD Real-time. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+You can use the following query to get the latest price of a Apple xStock on Solana.
 
 ▶️ [Get realtime Price of Apple xStock in USD Real-time](https://ide.bitquery.io/Get-realtime-Price-of-Apple-xStock-in--USD-Real-time)
 
 #### GoonFi Realtime OHLC, Price, Volume API - Crypto Price API
 
-GoonFi Realtime OHLC, Price, Volume API - Crypto Price API. Uses the `Pairs` cube.
+Below API will give you realtime prices, OHLC, and volume data for all GoonFi trading pairs. We have selected `1` sec as the interval for the OHLC, volume or moving average calculation.
 
 ▶️ [GoonFi Realtime OHLC, Price, Volume API - Crypto Price API](https://ide.bitquery.io/GoonFi-Realtime-OHLC-Price-Volume-API---Crypto-Price-API_1)
 
 #### Latest price for more than 1 markets on solana
 
-Latest price for more than 1 markets on solana. Uses the `DEXTrades` cube.
+You can retrieve data from multiple Solana DEX markets using our APIs or streams. The [following query
 
 ▶️ [Latest price for more than 1 markets on solana](https://ide.bitquery.io/latest-price-for-more-than-1-markets-on-solana_1)
 
@@ -610,7 +610,7 @@ Latest price for more than 1 markets on solana for specific currencies. Uses the
 
 #### Price of a moonshot token
 
-Price of a moonshot token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns gets real-time price of the specified Token `A1XqfcD1vMEhUNwEKvBVRWFV48ZLDL4oheFVCPEcM3Vk` on the Moonit DEX. You can run the query [here
 
 ▶️ [Price of a moonshot token](https://ide.bitquery.io/Price-of-a-Moonshot-token)
 
@@ -624,37 +624,37 @@ Subscribe when **`Token.Id`** matches Solana and **`Supply.MarketCap`** &gt; 1,0
 
 #### All trades on Solana with Price, Marketcap, supply
 
-All trades on Solana with Price, Marketcap, supply. Uses the `Trades` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [All trades on Solana with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Solana-with-Price-Marketcap-supply)
 
 #### Bags.fm token creation stream using Solana token supply updates
 
-Bags.fm token creation stream using Solana token supply updates. Uses the `TokenSupplyUpdates` cube. Replace the address in the `where` clause to use it.
+Track Bags FM token creation using the Solana TokenSupply API. This endpoint provides Bags FM token data including supply information and creation timestamps. For the same API as a WebSocket stream, [try this
 
 ▶️ [Bags.fm token creation stream using Solana token supply updates](https://ide.bitquery.io/Bagsfm-token-creation-stream-using-Solana-token-supply-updates)
 
 #### Get All DEX Trades on DBC With Price, Market Cap, and Supply
 
-Get All DEX Trades on DBC With Price, Market Cap, and Supply. Uses the `Trades` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [Get All DEX Trades on DBC With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-DBC-With-Price-Market-Cap-and-Supply)
 
 #### Get newly created Moonshot tokens with metadata
 
-Get newly created Moonshot tokens with metadata. Uses the `TokenSupplyUpdates` cube. Replace the address in the `where` clause to use it.
+Now you can track the newly created Moonit Tokens along with their metadata and supply. `PostBalance` will give you the current supply for the token. Check the query [here
 
 ▶️ [Get newly created Moonshot tokens with metadata](https://ide.bitquery.io/Get-newly-created-Moonshot-tokens-with-metadata)
 
 #### Newly created PF token, dev address, metadata
 
-Newly created PF token, dev address, metadata. Uses the `TokenSupplyUpdates` cube. Replace the address in the `where` clause to use it.
+Now you can track the newly created Pump Fun Tokens along with their dev address, metadata and supply. `PostBalance` will give you the current supply for the token. Check the query [here
 
 ▶️ [Newly created PF token, dev address, metadata](https://ide.bitquery.io/newly-created-PF-token-dev-address-metadata)
 
 #### Realtime heaven tokens with marketcap 10k
 
-Realtime heaven tokens with marketcap 10k. Uses the `Pairs` cube.
+Run the subscription [in the Bitquery IDE
 
 ▶️ [Realtime heaven tokens with marketcap 10k](https://ide.bitquery.io/realtime-heaven-tokens-with-marketcap-10k)
 
@@ -686,13 +686,13 @@ Liquidity for a launchpad token pair stream. Uses the `DEXPools` cube. Replace t
 
 #### Search tokens with liquidity over 1 million
 
-Search tokens with liquidity over 1 million. Uses the `DEXPools` cube.
+You can use the below query to get the tokens which are getting traded and have liquidity over 1 million USD. Try out the query [here
 
 ▶️ [Search tokens with liquidity over 1 million](https://ide.bitquery.io/Search-tokens-with-liquidity-over-1-million)
 
 #### Trends fun tokens between 95 and 100 bonding curve progress
 
-Trends fun tokens between 95 and 100 bonding curve progress. Uses the `DEXPools` cube. Replace the address in the `where` clause to use it.
+Track Trends.fun tokens that are approaching graduation with high bonding curve progress percentages. Run the query: [Trends.fun tokens between 95–100% bonding-curve progress ➤
 
 ▶️ [Trends fun tokens between 95 and 100 bonding curve progress](https://ide.bitquery.io/trends-fun-tokens-between-95-and-100-bonding-curve-progress)
 
@@ -700,7 +700,7 @@ Trends fun tokens between 95 and 100 bonding curve progress. Uses the `DEXPools`
 
 #### Realtime Solana Transactions
 
-Realtime Solana Transactions. Uses the `Transactions` cube.
+The subscription query below fetches the most recent transactions on the Solana blockchain You can find the query [here
 
 ▶️ [Realtime Solana Transactions](https://ide.bitquery.io/Realtime-Solana-Transactions)
 
@@ -708,7 +708,7 @@ Realtime Solana Transactions. Uses the `Transactions` cube.
 
 #### ConsumeEvents instruction on OpenBook V2
 
-ConsumeEvents instruction on OpenBook V2. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+We will use this subscription to listen to `consumeEvents` transactions on OpenBook v2. This instruction processes trade events and other activities such as order cancellations.
 
 ▶️ [ConsumeEvents instruction on OpenBook V2](https://ide.bitquery.io/consumeEvents-instruction-on-OpenBook-V2_3)
 
@@ -734,19 +734,19 @@ This stream returns the real time trades on Pumpswap exchange. This stream could
 
 #### Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply
 
-Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply. Uses the `Trades` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Pumpfun-With-Price-Market-Cap-and-Supply)
 
 #### Latest Trades for a token on Pumpswap
 
-Latest Trades for a token on Pumpswap. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Subscribe to `DEXTradeByTokens` with PumpSwap `ProgramAddress` and the token mint. Each update is a new trade involving that token on PumpSwap—use this to stream per-token activity without polling.
 
 ▶️ [Latest Trades for a token on Pumpswap](https://ide.bitquery.io/Latest-Trades-for-a-token-on-Pumpswap)
 
 #### Price of a pump fun token using price index in usd
 
-Price of a pump fun token using price index in usd. Uses the `Pairs` cube. Replace the address in the `where` clause to use it.
+Live stream of token price updates on Pump.fun
 
 ▶️ [Price of a pump fun token using price index in usd](https://ide.bitquery.io/Price-of-a-pump-fun-token-using-price-index-in-usd)
 
@@ -798,13 +798,13 @@ Returns Raydium Launchpad tokens which have more than 95% bonding curve progress
 
 #### Jup studio token migrations from Meteora DBC to Meteors DEX
 
-Jup studio token migrations from Meteora DBC to Meteors DEX. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+We monitor Meteora DBC program address `dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN` for migration instructions including `migrate_meteora_damm` and `migration_damm_v2`.
 
 ▶️ [Jup studio token migrations from Meteora DBC to Meteors DEX](https://ide.bitquery.io/jup-studio-token-migrations-from-Meteora-DBC-to-Meteors-DEX_1)
 
 #### Liquidity addition for meteora
 
-Liquidity addition for meteora. Uses the `DEXPools` cube.
+In this section, we will discover data streams that provides us with the real time events of liquidity addition and liquidity removal for the Meteora DEX, which has `Meteora` as the Protocol Family.
 
 ▶️ [Liquidity addition for meteora](https://ide.bitquery.io/liquidity-addition-for-meteora_1)
 
@@ -816,19 +816,19 @@ Liquidity removal for meteora. Uses the `DEXPools` cube.
 
 #### Meteora DBC token migrations to Meteors DEX
 
-Meteora DBC token migrations to Meteors DEX. Uses the `Instructions` cube.
+Returns will give you the latest migrated tokens Meteora DBC in realtime. You can test the query [here
 
 ▶️ [Meteora DBC token migrations to Meteors DEX](https://ide.bitquery.io/meteora-DBC-token-migrations-to-Meteors-DEX)
 
 #### Real time trades on Meteora Dynamic Bonding Curve on Solana
 
-Real time trades on Meteora Dynamic Bonding Curve on Solana. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
+Returns gets real-time information whenever there's a new trade on the Meteora DBC including detailed information about the trade, including the buy and sell details, the block information, and the transaction specifics. You can run the query [here
 
 ▶️ [Real time trades on Meteora Dynamic Bonding Curve on Solana](https://ide.bitquery.io/Real-time-trades-on-Meteora-Dynamic-Bonding-Curve-on-Solana)
 
 #### Real time trades on MeteoraDAMMv2 DEX on Solana
 
-Real time trades on MeteoraDAMMv2 DEX on Solana. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
+Returns subscribes to real-time trades on the Meteora DAMM v2 (Dynamic Automated Market Maker) on the Solana blockchain by filtering using the program address `cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG`. You can run the query [here
 
 ▶️ [Real time trades on MeteoraDAMMv2 DEX on Solana](https://ide.bitquery.io/Real-time-trades-on-MeteoraDAMMv2-DEX-on-Solana)
 
@@ -836,37 +836,37 @@ Real time trades on MeteoraDAMMv2 DEX on Solana. Uses the `DEXTrades` cube. Repl
 
 #### Latest pool created on Orca - Websocket
 
-Latest pool created on Orca - Websocket. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+For instance, Index 1 and 2 represent the tokens involved in the pool, while Index 4 is for the pool's address. Note that the indexing starts from 0.
 
 ▶️ [Latest pool created on Orca - Websocket](https://ide.bitquery.io/Latest-pool-created-on-Orca---Websocket_1)
 
 #### Liquidity addition for orca whirlpool
 
-Liquidity addition for orca whirlpool. Uses the `DEXPools` cube.
+In this section, we will discover data streams that provides us with the real time events of liquidity addition and liquidity removal for the Orca Whirlpool DEX, which has `whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc` as the Program Address.
 
 ▶️ [Liquidity addition for orca whirlpool](https://ide.bitquery.io/liquidity-addition-for-orca-whirlpool_1)
 
 #### Liquidity removal for orca whirlpool
 
-Liquidity removal for orca whirlpool. Uses the `DEXPools` cube.
+With Orca’s program and negative base change, stream liquidity removals from Whirlpool markets.
 
 ▶️ [Liquidity removal for orca whirlpool](https://ide.bitquery.io/liquidity-removal-for-orca-whirlpool_1)
 
 #### Orca DEX Trades Websocket
 
-Orca DEX Trades Websocket. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
+To access a real-time stream of trades for Solana Orca DEX, [check out this GraphQL subscription (WebSocket)
 
 ▶️ [Orca DEX Trades Websocket](https://ide.bitquery.io/Orca-DEX-Trades-Websocket)
 
 #### Orca DEX Trades for a specific currency Websocket
 
-Orca DEX Trades for a specific currency Websocket. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
+If you want to monitor [trades for a specific currency on Orca DEX
 
 ▶️ [Orca DEX Trades for a specific currency Websocket](https://ide.bitquery.io/Orca-DEX-Trades-for-a-specific-currency-Websocket)
 
 #### Price of a token on Orca
 
-Price of a token on Orca. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+You can use the following query to get the latest price of a token, we have used WSOL address here in the below example. We are getting realtime price of WSOL on Orca DEX on Solana in different pools.
 
 ▶️ [Price of a token on Orca](https://ide.bitquery.io/Price-of-a-token-on-Orca)
 
@@ -874,19 +874,19 @@ Price of a token on Orca. Uses the `DEXTradeByTokens` cube. Change the token add
 
 #### Latest Cancel Expired Order Transactions on Jupiter in realtime
 
-Latest Cancel Expired Order Transactions on Jupiter in realtime. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+We track Jupiter's Limit Order program address `jupoNjAxXgZ4rjzxzPMP4oxduvQsQtZzyknqvzYNrNu` for `cancelExpiredOrder` instructions. The query returns transaction signatures, account details, and program arguments for expired order cancellations.
 
 ▶️ [Latest Cancel Expired Order Transactions on Jupiter in realtime](https://ide.bitquery.io/Latest-Cancel-Expired-Order-Transactions-on-Jupiter-in-realtime_1)
 
 #### Latest Cancel Limit Order Transactions on Jupiter in realtime
 
-Latest Cancel Limit Order Transactions on Jupiter in realtime. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+We track Jupiter's Limit Order program address `jupoNjAxXgZ4rjzxzPMP4oxduvQsQtZzyknqvzYNrNu` for `cancelOrder` instructions. The query returns input mint addresses, maker addresses, reserve addresses, and cancellation details.
 
 ▶️ [Latest Cancel Limit Order Transactions on Jupiter in realtime](https://ide.bitquery.io/Latest-Cancel-Limit-Order-Transactions-on-Jupiter-in-realtime)
 
 #### Tokens involved in Jupiter swap, source address, destination address, DEX involved
 
-Tokens involved in Jupiter swap, source address, destination address, DEX involved. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+We monitor Jupiter's program address `JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4` for `sharedAccountsRoute` instructions to track swap activity. The query returns tokens involved in swaps, source and destination addresses, and routing information.
 
 ▶️ [Tokens involved in Jupiter swap, source address, destination address, DEX involved](https://ide.bitquery.io/Tokens-involved-in-Jupiter-swap-source-address-destination-address-DEX-involved_2)
 
@@ -902,13 +902,13 @@ This subscription returns the real-time trades happening on BSC Network. You can
 
 #### All BNB Trade Stream
 
-All BNB Trade Stream. Uses the `Trades` cube.
+Run this subscription [in the Bitquery IDE
 
 ▶️ [All BNB Trade Stream](https://ide.bitquery.io/All-BNB-Trade-Stream)
 
 #### Subscribe to bsc dex trades
 
-Subscribe to bsc dex trades.
+Returns uses the chain-specific DEXTrades cube via `EVM(network: bsc) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD fields can be empty on thin pools. For swap rows with trader + USD, use the stream at the top of this page.
 
 ▶️ [Subscribe to bsc dex trades](https://ide.bitquery.io/subscribe-to-bsc-dex-trades)
 
@@ -916,7 +916,7 @@ Subscribe to bsc dex trades.
 
 #### Transfers where sender is a particular address
 
-Transfers where sender is a particular address. Uses the `Transfers` cube.
+This websocket retrieves transfers where the sender is a particular address `0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c`.
 
 ▶️ [Transfers where sender is a particular address](https://ide.bitquery.io/Transfers-where-sender-is-a-particular-address)
 
@@ -986,13 +986,13 @@ Monitor balance and gas fee paid for an address using stream bsc. Uses the `Tran
 
 #### Realtime price of a ETH in terms of WBNB
 
-Realtime price of a ETH in terms of WBNB. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Returns provides real-time updates on price of ETH `0x2170Ed0880ac9A755fd29B2688956BD959F933F8` in terms of WBNB `0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c`, including details about the DEX, market, and order specifics. Find the query [here
 
 ▶️ [Realtime price of a ETH in terms of WBNB](https://ide.bitquery.io/realtime-price-of-a-ETH-in-terms-of-WBNB)
 
 #### Stream for latest prices for Flap.sh tokens
 
-Stream for latest prices for Flap.sh tokens. Uses the `Pairs` cube.
+Subscribe to real-time price updates for all Flap.sh tokens.
 
 ▶️ [Stream for latest prices for Flap.sh tokens](https://ide.bitquery.io/Stream-for-latest-prices-for-Flapsh-tokens)
 
@@ -1006,13 +1006,13 @@ Subscribe when **`Token.Id`** matches BSC and **`Supply.MarketCap`** &gt; 1,000,
 
 #### All trades on BSC with Price, Marketcap, supply
 
-All trades on BSC with Price, Marketcap, supply. Uses the `Trades` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [All trades on BSC with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-BSC-with-Price-Marketcap-supply)
 
 #### Bsc token marketcap stream
 
-Bsc token marketcap stream. Uses the `Tokens` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [Bsc token marketcap stream](https://ide.bitquery.io/bsc-token-marketcap-stream)
 
@@ -1032,7 +1032,7 @@ This subscription query returns real-time slippage data for all DEX pools on BSC
 
 #### Realtime Liquidity Stream
 
-Realtime Liquidity Stream.
+Returns query returns real-time liquidity data for all DEX pools on BSC. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
 
 ▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_2)
 
@@ -1040,7 +1040,7 @@ Realtime Liquidity Stream.
 
 #### Newly Created Tokens on BSC network
 
-Newly Created Tokens on BSC network. Uses the `Calls` cube.
+Returns websocket lets you track the newly created tokens on BSC network. You will find the newly created token contract address in the response under `Receipt: ContractAddress` field. You can find the query [here
 
 ▶️ [Newly Created Tokens on BSC network](https://ide.bitquery.io/Newly-Created-Tokens-on-BSC-network_2)
 
@@ -1048,13 +1048,13 @@ Newly Created Tokens on BSC network. Uses the `Calls` cube.
 
 #### Bsc mempool txs
 
-Bsc mempool txs.
+Try it in the IDE: [BSC mempool transactions
 
 ▶️ [Bsc mempool txs](https://ide.bitquery.io/bsc-mempool-txs)
 
 #### Monitor mempool trades bsc
 
-Monitor mempool trades bsc.
+Stream all DEX trades happening in the BSC mempool in real-time. Monitor buy/sell activity, prices, volumes, and trading pairs across all DEXs before transactions are confirmed.
 
 ▶️ [Monitor mempool trades bsc](https://ide.bitquery.io/monitor-mempool-trades-bsc)
 
@@ -1074,49 +1074,49 @@ This stream monitors MEV activities and Balance Updates on BSC in real time.
 
 #### All Self-Destruct Event Balances Stream bsc
 
-All Self-Destruct Event Balances Stream bsc. Uses the `TransactionBalances` cube.
+Monitor all contract self-destruct event balances in real-time using this GraphQL subscription. [Run Stream
 
 ▶️ [All Self-Destruct Event Balances Stream bsc](https://ide.bitquery.io/All-Self-Destruct-Event-Balances-Stream-bsc)
 
 #### Filter by MEV Bot or Builder Address bsc
 
-Filter by MEV Bot or Builder Address bsc. Uses the `TransactionBalances` cube.
+Track balance changes for specific MEV bots or block builders: Try the API [here
 
 ▶️ [Filter by MEV Bot or Builder Address bsc](https://ide.bitquery.io/Filter-by-MEV-Bot-or-Builder-Address-bsc)
 
 #### Filter by Miner Address bsc
 
-Filter by Miner Address bsc. Uses the `TransactionBalances` cube.
+Track balance changes for a specific miner address: Try the API [here
 
 ▶️ [Filter by Miner Address bsc](https://ide.bitquery.io/Filter-by-Miner-Address-bsc)
 
 #### Filter by Validator Address bsc
 
-Filter by Validator Address bsc. Uses the `TransactionBalances` cube.
+Track balance changes for a specific validator address: Try the API [here
 
 ▶️ [Filter by Validator Address bsc](https://ide.bitquery.io/Filter-by-Validator-Address-bsc_1)
 
 #### Track Block Mining Rewards bsc
 
-Track Block Mining Rewards bsc. Uses the `TransactionBalances` cube.
+Track rewards received by miners for successfully mining blocks: Try the API [here
 
 ▶️ [Track Block Mining Rewards bsc](https://ide.bitquery.io/Track-Block-Mining-Rewards-bsc)
 
 #### Track Ephemeral MEV Contract Balance Changes bsc
 
-Track Ephemeral MEV Contract Balance Changes bsc. Uses the `TransactionBalances` cube.
+Monitor balance changes for short-lived contracts that are created and destroyed in the same transaction (typical pattern for MEV bots) using this subscription: Try the API [here
 
 ▶️ [Track Ephemeral MEV Contract Balance Changes bsc](https://ide.bitquery.io/Track-Ephemeral-MEV-Contract-Balance-Changes-bsc)
 
 #### Track Large MEV Transactions bsc
 
-Track Large MEV Transactions bsc. Uses the `TransactionBalances` cube.
+Monitor large transaction fee rewards that may indicate significant MEV extraction: Try the API [here
 
 ▶️ [Track Large MEV Transactions bsc](https://ide.bitquery.io/Track-Large-MEV-Transactions-bsc)
 
 #### Track Large Self-Destruct Transaction Balances bsc
 
-Track Large Self-Destruct Transaction Balances bsc. Uses the `TransactionBalances` cube.
+Monitor significant self-destruct balance changes (e.g., > $1000 USD) using this subscription: Try the API [here
 
 ▶️ [Track Large Self-Destruct Transaction Balances bsc](https://ide.bitquery.io/Track-Large-Self-Destruct-Transaction-Balances-bsc)
 
@@ -1148,13 +1148,13 @@ Real-time market cap stream with OHLC for FourMeme tokens at 1-second intervals.
 
 #### Four Meme bonding curve completion mempool
 
-Four Meme bonding curve completion mempool. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Monitor tokens that are about to complete their bonding curve (near graduation) in the mempool.
 
 ▶️ [Four Meme bonding curve completion mempool](https://ide.bitquery.io/Four-Meme-bonding-curve-completion-mempool)
 
 #### Four Meme large buys mempool
 
-Four Meme large buys mempool. Uses the `DEXTrades` cube.
+Monitor large buy orders in the mempool to detect whale activity and potential price pumps.
 
 ▶️ [Four Meme large buys mempool](https://ide.bitquery.io/Four-Meme-large-buys-mempool)
 
@@ -1174,7 +1174,7 @@ This query tracks four meme token migrations to Pancakeswap in realtime by monit
 
 #### Binance meme rush migration to pancakeswap
 
-Binance meme rush migration to pancakeswap. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Returns tracks Binance Meme Rush token migrations to Pancakeswap in realtime by monitoring transactions sent to the Four Meme factory address (`0x5c952063c7fc8610ffdb798152d69f0b9550762b`) and filtering for `PairCreated` and `PoolCreated` events.
 
 ▶️ [Binance meme rush migration to pancakeswap](https://ide.bitquery.io/binance-meme-rush-migration-to-pancakeswap)
 
@@ -1200,31 +1200,31 @@ Stream - BSC PancakeSwap v3 Trades for a token. Uses the `DEXTradeByTokens` cube
 
 #### Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4
 
-Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4. Uses the `DEXPoolEvents` cube.
+Returns query monitors real-time liquidity changes for all pools in a specific DEX protocol on BSC. Here we have taken example of Uniswap V4.
 
 ▶️ [Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4](https://ide.bitquery.io/Latest-Liquidity-Changes-of-Pools-in-a-Specific-DEX-Protocol---Uniswap-V4)
 
 #### Newly Created Pools on Uniswap v3 on BSC network
 
-Newly Created Pools on Uniswap v3 on BSC network. Uses the `Events` cube. Change the token address in the `where` clause to use it.
+Returns websocket lets you track the newly created pools on Uniswap V3 `0xdB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7`.
 
 ▶️ [Newly Created Pools on Uniswap v3 on BSC network](https://ide.bitquery.io/Newly-Created-Pools-on-Uniswap-v3-on-BSC-network_3)
 
 #### Real time trades for uniswap v4 bsc
 
-Real time trades for uniswap v4 bsc. Uses the `DEXTrades` cube.
+The Uniswap v4 PoolManager contract emits all pool-related events, including pool initialization, swaps, and liquidity modifications, and serves as the single on-chain source of truth for Uniswap v4 activity on BSC.
 
 ▶️ [Real time trades for uniswap v4 bsc](https://ide.bitquery.io/Real-time-trades-for-uniswap-v4-bsc)
 
 #### Uniswap v4 pool liquidity bsc
 
-Uniswap v4 pool liquidity bsc. Uses the `DEXPoolEvents` cube.
+Stream live liquidity for all Uniswap v4 pools on BSC. [Run in the Bitquery IDE
 
 ▶️ [Uniswap v4 pool liquidity bsc](https://ide.bitquery.io/uniswap-v4-pool-liquidity-bsc)
 
 #### Uniswap v4 pool liquidity by poolid bsc
 
-Uniswap v4 pool liquidity by poolid bsc. Uses the `DEXPoolEvents` cube.
+Filter to a specific pool by `PoolId`. [Run in the Bitquery IDE
 
 ▶️ [Uniswap v4 pool liquidity by poolid bsc](https://ide.bitquery.io/uniswap-v4-pool-liquidity-by-poolid-bsc)
 
@@ -1240,19 +1240,19 @@ This stream returns all the real time DEX trades happening on Base. You can modi
 
 #### All Base Trade Stream
 
-All Base Trade Stream. Uses the `Trades` cube.
+Run this subscription [in the Bitquery IDE
 
 ▶️ [All Base Trade Stream](https://ide.bitquery.io/All-Base-Trade-Stream)
 
 #### Subscribe to dex trades on base
 
-Subscribe to dex trades on base.
+Read DEXTrades vs DEXTradeByTokens vs Trades cube to get a better understanding on when to use which cube. You can find the query [here
 
 ▶️ [Subscribe to dex trades on base](https://ide.bitquery.io/subscribe-to-dex-trades-on-base)
 
 #### Subscription for Latest Trades for AERO
 
-Subscription for Latest Trades for AERO. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+For this part, we have chosen AERO token as the token is currently trending and have high trade volume.
 
 ▶️ [Subscription for Latest Trades for AERO](https://ide.bitquery.io/Subscription-for-Latest-Trades-for-AERO_1)
 
@@ -1266,19 +1266,19 @@ This stream lets you monitor all the token transfers for a particular token. You
 
 #### Newly created zora tokens stream
 
-Newly created zora tokens stream. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+You can also stream the latest tokens created in real-time using [this subscription
 
 ▶️ [Newly created zora tokens stream](https://ide.bitquery.io/Newly-created-zora-tokens-stream)
 
 #### Sender is a particular address
 
-Sender is a particular address. Uses the `Transfers` cube.
+This websocket retrieves transfers where the sender is a particular address `0x3304E22DDaa22bCdC5fCa2269b418046aE7b566A`.
 
 ▶️ [Sender is a particular address](https://ide.bitquery.io/Sender-is-a-particular-address_3)
 
 #### Whale transfers of USDC on base
 
-Whale transfers of USDC on base. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+The subscription query below fetches the whale transactions on the Base network. We have used USDC address `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`. You can find the query [here
 
 ▶️ [Whale transfers of USDC on base](https://ide.bitquery.io/Whale-transfers-of-USDC-on-base)
 
@@ -1316,25 +1316,25 @@ Balance update from transfer for an address stream base. Uses the `TransactionBa
 
 #### Subscribe to All Transaction Balances base
 
-Subscribe to All Transaction Balances base.
+Returns provides real-time balance updates for all addresses involved in transactions on the Base network. Try the API [here
 
 ▶️ [Subscribe to All Transaction Balances base](https://ide.bitquery.io/Subscribe-to-All-Transaction-Balances-base)
 
 #### Subscribe to Transaction Balances for a Specific Address base
 
-Subscribe to Transaction Balances for a Specific Address base. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+Returns filters transaction balances for a specific address. Try the API [here
 
 ▶️ [Subscribe to Transaction Balances for a Specific Address base](https://ide.bitquery.io/Subscribe-to-Transaction-Balances-for-a-Specific-Address-base)
 
 #### Track Block Builder Rewards base
 
-Track Block Builder Rewards base. Uses the `TransactionBalances` cube.
+Monitor transaction fee rewards received by block builders (MEV extractors): Try the API [here
 
 ▶️ [Track Block Builder Rewards base](https://ide.bitquery.io/Track-Block-Builder-Rewards-base)
 
 #### Track Transaction Fee Rewards base
 
-Track Transaction Fee Rewards base. Uses the `TransactionBalances` cube.
+Monitor transaction fee rewards received by miners: Try the API [here
 
 ▶️ [Track Transaction Fee Rewards base](https://ide.bitquery.io/Track-Transaction-Fee-Rewards-base)
 
@@ -1354,19 +1354,19 @@ This stream returns the real time trade price of a token against the token it is
 
 #### Aerodrome dex - realtime prices, 1-sec ohlc, trading volumes
 
-Aerodrome dex - realtime prices, 1-sec ohlc, trading volumes. Uses the `Pairs` cube.
+Below API gives you instant access to live Aerodrome market data with pre-calculated OHLC, moving averages, and trading volumes updating every second—no complex calculations needed, just plug and play for your trading bots or analytics platform.
 
 ▶️ [Aerodrome dex - realtime prices, 1-sec ohlc, trading volumes](https://ide.bitquery.io/aerodrome-dex---realtime-prices-1-sec-ohlc-trading-volumes)
 
 #### Get latest price of DAI in USD on Base
 
-Get latest price of DAI in USD on Base. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns retrieves the USD price of a token on Base chain by setting `SmartContract: {is: "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb"}` . Check the field `PriceInUSD` for the USD value. You can access the query [here
 
 ▶️ [Get latest price of DAI in USD on Base](https://ide.bitquery.io/Get-latest-price-of-DAI-in-USD-on-Base)
 
 #### Price of USDC in terms of DAI on Base network
 
-Price of USDC in terms of DAI on Base network. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Returns provides real-time updates on price of USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` in terms of DAI `0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb`, including details about the DEX, market, and order specifics. Find the query [here
 
 ▶️ [Price of USDC in terms of DAI on Base network](https://ide.bitquery.io/Price-of-USDC-in-terms-of-DAI-on-Base-network)
 
@@ -1386,19 +1386,19 @@ Subscribe when **`Token.Id`** matches Base and **`Supply.MarketCap`** &gt; 1,000
 
 #### All trades on Base with Price, Marketcap, supply
 
-All trades on Base with Price, Marketcap, supply. Uses the `Trades` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [All trades on Base with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Base-with-Price-Marketcap-supply)
 
 #### Bankr token realtime marketcap OHLC stream
 
-Bankr token realtime marketcap OHLC stream. Uses the `Tokens` cube.
+Subscribe to live 1-second OHLC + market cap updates for a specific Bankr token.
 
 ▶️ [Bankr token realtime marketcap OHLC stream](https://ide.bitquery.io/Bankr-token-realtime-marketcap-OHLC-stream)
 
 #### Base tokens above 100k marketcap stream
 
-Base tokens above 100k marketcap stream. Uses the `Tokens` cube.
+Stream every Base token currently above $100k FDV. Useful as a high-mcap or "graduated by mcap" alert.
 
 ▶️ [Base tokens above 100k marketcap stream](https://ide.bitquery.io/Base-tokens-above-100k-marketcap-stream)
 
@@ -1412,13 +1412,13 @@ This subscription query returns real-time slippage data for all DEX pools on Bas
 
 #### Realtime Liquidity Stream
 
-Realtime Liquidity Stream.
+Returns query returns real-time liquidity data for all DEX pools on Base. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
 
 ▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_3)
 
 #### Realtime Liquidity Stream of a Specific Pool
 
-Realtime Liquidity Stream of a Specific Pool. Uses the `DEXPoolEvents` cube.
+Returns query monitors real-time liquidity changes for a specific DEX pool on Base. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
 
 ▶️ [Realtime Liquidity Stream of a Specific Pool](https://ide.bitquery.io/Realtime-Liquidity-Stream-of-a-Specific-Pool_3)
 
@@ -1426,7 +1426,7 @@ Realtime Liquidity Stream of a Specific Pool. Uses the `DEXPoolEvents` cube.
 
 #### Realtime stream Bankr launches Base
 
-Realtime stream Bankr launches Base. Uses the `Events` cube.
+Convert the above query into a subscription to be notified of every new token the moment it lands on Base.
 
 ▶️ [Realtime stream Bankr launches Base](https://ide.bitquery.io/Realtime-stream-Bankr-launches-Base)
 
@@ -1470,25 +1470,25 @@ Track validator rewards and balance increases from staking activities in real-ti
 
 #### All Self Destruct Event Balances Stream base
 
-All Self Destruct Event Balances Stream base. Uses the `TransactionBalances` cube.
+Monitor all contract self-destruct event balances in real-time using this GraphQL subscription. [Run Stream
 
 ▶️ [All Self Destruct Event Balances Stream base](https://ide.bitquery.io/All-Self-Destruct-Event-Balances-Stream-base)
 
 #### Filter by MEV Bot or Builder Address base
 
-Filter by MEV Bot or Builder Address base. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+Track balance changes for specific MEV bots or block builders: Try the API [here
 
 ▶️ [Filter by MEV Bot or Builder Address base](https://ide.bitquery.io/Filter-by-MEV-Bot-or-Builder-Address-base)
 
 #### Filter by Miner Address base
 
-Filter by Miner Address base. Uses the `TransactionBalances` cube. Replace the address in the `where` clause to use it.
+Track balance changes for a specific miner address: Try the API [here
 
 ▶️ [Filter by Miner Address base](https://ide.bitquery.io/Filter-by-Miner-Address-base)
 
 #### Track Block Mining Rewards base
 
-Track Block Mining Rewards base. Uses the `TransactionBalances` cube.
+Track rewards received by miners for successfully mining blocks: Try the API [here
 
 ▶️ [Track Block Mining Rewards base](https://ide.bitquery.io/Track-Block-Mining-Rewards-base)
 
@@ -1508,25 +1508,25 @@ This stream returns the real time liquidity pools/token pairs created on Uniswap
 
 #### Bankr token V4 swaps realtime
 
-Bankr token V4 swaps realtime. Uses the `Trades` cube.
+Bankr trades clear on the Uniswap V4 singleton. Use the Crypto Trades API (`Trading.Trades`) to stream swap-level rows with USD price, market cap, supply, trader, and V4 pool id.
 
 ▶️ [Bankr token V4 swaps realtime](https://ide.bitquery.io/Bankr-token-V4-swaps-realtime)
 
 #### Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4
 
-Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4. Uses the `DEXPoolEvents` cube.
+Returns query monitors real-time liquidity changes for all pools in a specific DEX protocol on Base. Here we have taken example of Uniswap V4.
 
 ▶️ [Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4](https://ide.bitquery.io/Latest-Liquidity-Changes-of-Pools-in-a-Specific-DEX-Protocol---Uniswap-V4_5)
 
 #### Real time trades on uniswap v4 base
 
-Real time trades on uniswap v4 base. Uses the `DEXTrades` cube.
+The Uniswap v4 PoolManager contract emits all pool-related events, including pool initialization, swaps, and liquidity modifications, and serves as the single on-chain source of truth for Uniswap v4 activity on Base.
 
 ▶️ [Real time trades on uniswap v4 base](https://ide.bitquery.io/Real-time-trades-on-uniswap-v4-base)
 
 #### Uniswap v4 pool liquidity base
 
-Uniswap v4 pool liquidity base. Uses the `DEXPoolEvents` cube.
+Stream live liquidity for all Uniswap v4 pools on Base. [Run in the Bitquery IDE
 
 ▶️ [Uniswap v4 pool liquidity base](https://ide.bitquery.io/uniswap-v4-pool-liquidity-base)
 
@@ -1536,7 +1536,7 @@ Uniswap v4 pool liquidity base. Uses the `DEXPoolEvents` cube.
 
 #### Arbitrum Dextrades subscription
 
-Arbitrum Dextrades subscription.
+Returns uses the chain-specific DEXTrades cube via `EVM(network: arbitrum) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD can be weak on thin pools. For trader + USD swap rows, use the stream at the top.
 
 ▶️ [Arbitrum Dextrades subscription](https://ide.bitquery.io/Arbitrum-Dextrades-subscription)
 
@@ -1544,13 +1544,13 @@ Arbitrum Dextrades subscription.
 
 #### Arbitrum token marketcap stream
 
-Arbitrum token marketcap stream. Uses the `Tokens` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [Arbitrum token marketcap stream](https://ide.bitquery.io/arbitrum-token-marketcap-stream)
 
 #### Realtime stream arbitrum tokens with marketcap above 1 million
 
-Realtime stream arbitrum tokens with marketcap above 1 million. Uses the `Tokens` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [Realtime stream arbitrum tokens with marketcap above 1 million](https://ide.bitquery.io/realtime-stream-arbitrum-tokens-with-marketcap-above-1-million)
 
@@ -1558,19 +1558,19 @@ Realtime stream arbitrum tokens with marketcap above 1 million. Uses the `Tokens
 
 #### Realtime liquidity stream
 
-Realtime liquidity stream.
+Returns query returns real-time liquidity data for all DEX pools on Arbitrum. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
 
 ▶️ [Realtime liquidity stream](https://ide.bitquery.io/realtime-liquidity-stream_1)
 
 #### Realtime liquidity stream of a specific pool
 
-Realtime liquidity stream of a specific pool. Uses the `DEXPoolEvents` cube. Change the token address in the `where` clause to use it.
+Returns query monitors real-time liquidity changes for a specific DEX pool on Arbitrum. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
 
 ▶️ [Realtime liquidity stream of a specific pool](https://ide.bitquery.io/realtime-liquidity-stream-of-a-specific-pool)
 
 #### Realtime slippage on arbitrum
 
-Realtime slippage on arbitrum.
+Returns query returns real-time slippage data for all DEX pools on Arbitrum. You can monitor price impact and liquidity depth as trades occur.
 
 ▶️ [Realtime slippage on arbitrum](https://ide.bitquery.io/realtime-slippage-on-arbitrum)
 
@@ -1578,7 +1578,7 @@ Realtime slippage on arbitrum.
 
 #### Arbitrum: Timeboost Auction Transactions in Realtime
 
-Arbitrum: Timeboost Auction Transactions in Realtime. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Use the following subscription in the Bitquery IDE to watch every TimeBoost auction interaction. The query filters on the auction contract address and surfaces both transaction context and decoded ABI arguments.
 
 ▶️ [Arbitrum: Timeboost Auction Transactions in Realtime](https://ide.bitquery.io/Arbitrum-Timeboost-Auction-Transactions-in-Realtime)
 
@@ -1586,13 +1586,13 @@ Arbitrum: Timeboost Auction Transactions in Realtime. Uses the `Events` cube. Re
 
 #### Latest liquidity changes in uniswap v4 pools
 
-Latest liquidity changes in uniswap v4 pools. Uses the `DEXPoolEvents` cube.
+Returns query monitors real-time liquidity changes for all pools in a specific DEX protocol on Arbitrum. Here we have taken example of Uniswap V4.
 
 ▶️ [Latest liquidity changes in uniswap v4 pools](https://ide.bitquery.io/latest-liquidity-changes-in-uniswap-v4-pools)
 
 #### Real time trades for uniswap v4 arbitrum
 
-Real time trades for uniswap v4 arbitrum. Uses the `DEXTrades` cube.
+The Uniswap v4 PoolManager contract emits all pool-related events, including pool initialization, swaps, and liquidity modifications, and serves as the single on-chain source of truth for Uniswap v4 activity on Arbitrum.
 
 ▶️ [Real time trades for uniswap v4 arbitrum](https://ide.bitquery.io/Real-time-trades-for-uniswap-v4-arbitrum)
 
@@ -1602,13 +1602,13 @@ Real time trades for uniswap v4 arbitrum. Uses the `DEXTrades` cube.
 
 #### Real time trades for uniswap v4 optimism
 
-Real time trades for uniswap v4 optimism. Uses the `DEXTrades` cube.
+The Uniswap v4 PoolManager contract emits all pool-related events, including pool initialization, swaps, and liquidity modifications, and serves as the single on-chain source of truth for Uniswap v4 activity on Optimism.
 
 ▶️ [Real time trades for uniswap v4 optimism](https://ide.bitquery.io/Real-time-trades-for-uniswap-v4-optimism)
 
 #### Realtime optimism dex trades websocket
 
-Realtime optimism dex trades websocket.
+Returns uses the chain-specific DEXTrades cube via `EVM(network: optimism) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD can be weak on thin pools. For trader + USD swap rows, use the stream at the top.
 
 ▶️ [Realtime optimism dex trades websocket](https://ide.bitquery.io/Realtime-optimism-dex-trades-websocket)
 
@@ -1616,13 +1616,13 @@ Realtime optimism dex trades websocket.
 
 #### Sender is a particular address
 
-Sender is a particular address. Uses the `Transfers` cube.
+This websocket retrieves transfers where the sender is a particular address `0xEbe80f029b1c02862B9E8a70a7e5317C06F62Cae`.
 
 ▶️ [Sender is a particular address](https://ide.bitquery.io/Sender-is-a-particular-address)
 
 #### Whale transfers of USDT on optimism
 
-Whale transfers of USDT on optimism. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+The subscription query below fetches the whale transactions on the Optimism network. We have used USDT address `0x94b008aA00579c1307B0EF2c499aD98a8ce58e58` You can find the query [here
 
 ▶️ [Whale transfers of USDT on optimism](https://ide.bitquery.io/Whale-transfers-of-USDT-on-optimism)
 
@@ -1630,13 +1630,13 @@ Whale transfers of USDT on optimism. Uses the `Transfers` cube. Change the token
 
 #### Get latest price of WBTC in USD on optimism
 
-Get latest price of WBTC in USD on optimism. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns retrieves the USD price of a token on Optimism by setting `SmartContract: {is: "0x68f180fcCe6836688e9084f035309E29Bf0A2095"}` . Check the field `PriceInUSD` for the USD value. You can access the query [here
 
 ▶️ [Get latest price of WBTC in USD on optimism](https://ide.bitquery.io/Get-latest-price-of-WBTC-in-USD-on-optimism)
 
 #### Price of WETH in terms of USDC on Optimism
 
-Price of WETH in terms of USDC on Optimism. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Returns provides real-time updates on price of WETH `0x4200000000000000000000000000000000000006` in terms of USD Coin `0x7f5c764cbc14f9669b88837ca1490cca17c31607`, including details about the DEX, market, and order specifics. Find the query [here
 
 ▶️ [Price of WETH in terms of USDC on Optimism](https://ide.bitquery.io/Price-of-WETH-in-terms-of-USDC-on-Optimism)
 
@@ -1646,13 +1646,13 @@ Price of WETH in terms of USDC on Optimism. Uses the `DEXTrades` cube. Change th
 
 #### Real time trades for uniswap v4 matic
 
-Real time trades for uniswap v4 matic. Uses the `DEXTrades` cube.
+The Uniswap v4 PoolManager contract emits all pool-related events, including pool initialization, swaps, and liquidity modifications, and serves as the single on-chain source of truth for Uniswap v4 activity on Matic.
 
 ▶️ [Real time trades for uniswap v4 matic](https://ide.bitquery.io/Real-time-trades-for-uniswap-v4-matic)
 
 #### Realtime matic dex trades websocket
 
-Realtime matic dex trades websocket.
+Read DEXTrades vs DEXTradeByTokens vs Trades cube to understand when to use which cube. You can find the query [here
 
 ▶️ [Realtime matic dex trades websocket](https://ide.bitquery.io/Realtime-matic-dex-trades-websocket)
 
@@ -1660,13 +1660,13 @@ Realtime matic dex trades websocket.
 
 #### Sender is a particular address
 
-Sender is a particular address. Uses the `Transfers` cube.
+This websocket retrieves transfers where the sender is a particular address `0x1A8f43e01B78979EB4Ef7feBEC60F32c9A72f58E`.
 
 ▶️ [Sender is a particular address](https://ide.bitquery.io/Sender-is-a-particular-address_2)
 
 #### Whale transfers of USDC on matic
 
-Whale transfers of USDC on matic. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+The subscription query below fetches the whale transactions on the MATIC network. We have used USDC address `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359`. You can find the query [here
 
 ▶️ [Whale transfers of USDC on matic](https://ide.bitquery.io/Whale-transfers-of-USDC-on-matic)
 
@@ -1674,13 +1674,13 @@ Whale transfers of USDC on matic. Uses the `Transfers` cube. Change the token ad
 
 #### All trades on Polygon with Price, Marketcap, supply
 
-All trades on Polygon with Price, Marketcap, supply. Uses the `Trades` cube.
+Run this subscription [in the Bitquery IDE
 
 ▶️ [All trades on Polygon with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Polygon-with-Price-Marketcap-supply)
 
 #### Matic token marketcap stream
 
-Matic token marketcap stream. Uses the `Tokens` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [Matic token marketcap stream](https://ide.bitquery.io/matic-token-marketcap-stream)
 
@@ -1688,25 +1688,25 @@ Matic token marketcap stream. Uses the `Tokens` cube.
 
 #### Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4
 
-Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4. Uses the `DEXPoolEvents` cube.
+Returns query monitors real-time liquidity changes for all pools in a specific DEX protocol on Matic. Here we have taken example of Uniswap V4.
 
 ▶️ [Latest Liquidity Changes of Pools in a Specific DEX Protocol - Uniswap V4](https://ide.bitquery.io/Latest-Liquidity-Changes-of-Pools-in-a-Specific-DEX-Protocol---Uniswap-V4_7)
 
 #### Realtime Liquidity Stream
 
-Realtime Liquidity Stream.
+Returns query returns real-time liquidity data for all DEX pools on Matic. You can monitor liquidity changes, pool reserves, and spot prices as trades and liquidity modifications occur across all pools.
 
 ▶️ [Realtime Liquidity Stream](https://ide.bitquery.io/Realtime-Liquidity-Stream_5)
 
 #### Realtime Liquidity Stream of a Specific Pool
 
-Realtime Liquidity Stream of a Specific Pool. Uses the `DEXPoolEvents` cube.
+Returns query monitors real-time liquidity changes for a specific DEX pool on Matic. Use this to track liquidity events, pool reserves, and spot prices for a particular pool as they occur.
 
 ▶️ [Realtime Liquidity Stream of a Specific Pool](https://ide.bitquery.io/Realtime-Liquidity-Stream-of-a-Specific-Pool_5)
 
 #### Realtime slippage on matic
 
-Realtime slippage on matic.
+Returns query returns real-time slippage data for all DEX pools on Matic. You can monitor price impact and liquidity depth as trades occur.
 
 ▶️ [Realtime slippage on matic](https://ide.bitquery.io/realtime-slippage-on-matic)
 
@@ -1728,13 +1728,13 @@ This stream returns all the real time DEX trades happening on the Tron network. 
 
 #### Sunpump trades
 
-Sunpump trades. Uses the `DEXTrades` cube.
+To subscribe to latest Sunpump trades you can use [the following stream
 
 ▶️ [Sunpump trades](https://ide.bitquery.io/Sunpump-trades)
 
 #### USDT TRC20 DEX Trades
 
-USDT TRC20 DEX Trades. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Real-time DEX trades where USDT is the bought currency on Tron — protocol, buyer and seller, amounts and order IDs.
 
 ▶️ [USDT TRC20 DEX Trades](https://ide.bitquery.io/USDT-TRC20-DEX-Trades)
 
@@ -1748,13 +1748,13 @@ This subscription streams the latest USDT (TRC20) transfers on the TRON network.
 
 #### Sender is particular address
 
-Sender is particular address. Uses the `Transfers` cube.
+This websocket retrieves transfers where the sender is a particular address `TDqSquXBgUCLYvYC4XZgrprLK589dkhSCf`.
 
 ▶️ [Sender is particular address](https://ide.bitquery.io/Sender-is-particular-address)
 
 #### Whale transfers of USDT on Tron
 
-Whale transfers of USDT on Tron. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+The subscription query below fetches the whale transactions on the Tron network. We have used USDT address `TThzxNRLrW2Brp9DcTQU8i4Wd9udCWEdZ3`. You can find the query [here
 
 ▶️ [Whale transfers of USDT on Tron](https://ide.bitquery.io/Whale-transfers-of-USDT-on-Tron)
 
@@ -1762,7 +1762,7 @@ Whale transfers of USDT on Tron. Uses the `Transfers` cube. Change the token add
 
 #### Track price of a tron token in realtime
 
-Track price of a tron token in realtime. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Returns provides real-time updates on price of token `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` in terms of USDT `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`, including details about the DEX. Try the query [here
 
 ▶️ [Track price of a tron token in realtime](https://ide.bitquery.io/Track-price-of-a-tron-token-in-realtime)
 
@@ -1770,7 +1770,7 @@ Track price of a tron token in realtime. Uses the `DEXTradeByTokens` cube. Chang
 
 #### Get All DEX Trades on Tron With Price, Market Cap, and Supply
 
-Get All DEX Trades on Tron With Price, Market Cap, and Supply. Uses the `Trades` cube.
+Run this subscription [in the Bitquery IDE
 
 ▶️ [Get All DEX Trades on Tron With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Tron-With-Price-Market-Cap-and-Supply)
 
@@ -1778,7 +1778,7 @@ Get All DEX Trades on Tron With Price, Market Cap, and Supply. Uses the `Trades`
 
 #### Monitor TRX address transactions
 
-Monitor TRX address transactions. Uses the `Transactions` cube.
+The subscription query below fetches the transactions on the Tron network for the wallet address `TDqSquXBgUCLYvYC4XZgrprLK589dkhSCf`.
 
 ▶️ [Monitor TRX address transactions](https://ide.bitquery.io/monitor-TRX-address-transactions)
 
@@ -1786,25 +1786,25 @@ Monitor TRX address transactions. Uses the `Transactions` cube.
 
 #### Latest Buy on SunPump
 
-Latest Buy on SunPump. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+You can use following stream to get latest buys on Sunpump. You can try [this stream on IDE
 
 ▶️ [Latest Buy on SunPump](https://ide.bitquery.io/latest-Buy-on-SunPump)
 
 #### New tokens on sunpump
 
-New tokens on sunpump. Uses the `Events` cube.
+Returns will subscribe you to the latest created sun pump tokens. You will find the newly created token address in `Log { SmartContract }`.
 
 ▶️ [New tokens on sunpump](https://ide.bitquery.io/New-tokens-on-sunpump_1)
 
 #### Sunpump sell event
 
-Sunpump sell event. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+You can use following stream to get latest sells on Sunpump. You can try [this stream on IDE
 
 ▶️ [Sunpump sell event](https://ide.bitquery.io/sunpump-sell-event)
 
 #### Tron sunpump first time buy event
 
-Tron sunpump first time buy event. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+You can use follow stream to get stream of first time buy event for any new token.
 
 ▶️ [Tron sunpump first time buy event](https://ide.bitquery.io/Tron-sunpump-first-time-buy-event_1)
 
@@ -1818,13 +1818,13 @@ Events with argumens. Uses the `Events` cube. Replace the address in the `where`
 
 #### Sunpump trades mempool
 
-Sunpump trades mempool. Uses the `DEXTrades` cube.
+We simulate transactions in mempool, therefore you can also get trades directly from mempool using [following stream
 
 ▶️ [Sunpump trades mempool](https://ide.bitquery.io/Sunpump-trades-mempool)
 
 #### Tron mempool transfers
 
-Tron mempool transfers.
+Returns provides real-time data on token transfers happening in the TRON mempool including the value of the transferred amount in USD.
 
 ▶️ [Tron mempool transfers](https://ide.bitquery.io/Tron-mempool-transfers)
 
@@ -1840,25 +1840,25 @@ Latest DEX trades on Robinhood Chain (chain id 4663) via the Trading API, with p
 
 #### Bags amm trade websocket
 
-Bags amm trade websocket. Uses the `Trades` cube.
+Stream every Bags trade as it is indexed via a GraphQL `subscription` on `Trading.Trades`, scoped to the Bags protocol family on Robinhood. Includes side (buy/sell), trader, base/quote amounts (native and USD), market cap, and full transaction header.
 
 ▶️ [Bags amm trade websocket](https://ide.bitquery.io/bags-amm-trade-websocket)
 
 #### Pools trade Stream new Crowd Launch auctions
 
-Pools trade Stream new Crowd Launch auctions. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Every Crowd Launch deploys its auction through the auction factory `0x000000001f26a0044baa66024e7b6599c61963f8`, which emits `AuctionCreated(address,address,uint256,bytes)`.
 
 ▶️ [Pools trade Stream new Crowd Launch auctions](https://ide.bitquery.io/Pools-trade-Stream-new-Crowd-Launch-auctions)
 
 #### Robinhood Chain API - Trades for a Token
 
-Robinhood Chain API - Trades for a Token. Uses the `Trades` cube.
+Using this GraphQL stream you can get real-time trades for a specific token (example: AssetHood, `ASSETH`) with details such as trader address, token details, marketcap, FDV and transaction hash.
 
 ▶️ [Robinhood Chain API - Trades for a Token](https://ide.bitquery.io/Robinhood-Trades-for-a-token)
 
 #### Stream Robinhood Chain Trades in Real Time
 
-Stream Robinhood Chain Trades in Real Time. Uses the `Trades` cube.
+These are live examples — meme tokens go quiet over time, so swap in any token, pool, or trader you care about.
 
 ▶️ [Stream Robinhood Chain Trades in Real Time](https://ide.bitquery.io/stream-robinhood-chain-trades)
 
@@ -1866,55 +1866,55 @@ Stream Robinhood Chain Trades in Real Time. Uses the `Trades` cube.
 
 #### Ape.store Newly created tokens - Websocket
 
-Ape.store Newly created tokens - Websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
 
 ▶️ [Ape.store Newly created tokens - Websocket](https://ide.bitquery.io/Apestore-Newly-created-tokens---Websocket)
 
 #### Bags.fm Newly created tokens - Websocket
 
-Bags.fm Newly created tokens - Websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
 
 ▶️ [Bags.fm Newly created tokens - Websocket](https://ide.bitquery.io/Bagsfm-Newly-created-tokens---Websocket)
 
 #### Bankr Bot Newly created tokens - Websocket
 
-Bankr Bot Newly created tokens - Websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
 
 ▶️ [Bankr Bot Newly created tokens - Websocket](https://ide.bitquery.io/Bankr-Bot-Newly-created-tokens---Websocket)
 
 #### Flap Sh Newly created tokens using transfer data - Websocket
 
-Flap Sh Newly created tokens using transfer data - Websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Track Flap.sh mints as transfers from the zero address with amount `1000000000` in transactions sent to the Flap.sh contract.
 
 ▶️ [Flap Sh Newly created tokens using transfer data - Websocket](https://ide.bitquery.io/Flap-Sh-Newly-created-tokens-using-transfer-data---Websocket)
 
 #### Hoodfun newly creaed tokens Websocket
 
-Hoodfun newly creaed tokens Websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
 
 ▶️ [Hoodfun newly creaed tokens Websocket](https://ide.bitquery.io/hoodfun-newly-creaed-tokens---Websocket)
 
 #### Klik Finance Newly created tokens using transfers websocket
 
-Klik Finance Newly created tokens using transfers websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
 
 ▶️ [Klik Finance Newly created tokens using transfers websocket](https://ide.bitquery.io/Klik-Finance-Newly-created-tokens-using-transfers-websocket)
 
 #### Launchpad newly creaed tokens Websocket
 
-Launchpad newly creaed tokens Websocket. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
 
 ▶️ [Launchpad newly creaed tokens Websocket](https://ide.bitquery.io/launchpad-newly-creaed-tokens---Websocket)
 
 #### Pools trade Stream launches with token detail
 
-Pools trade Stream launches with token detail. Uses the `Transfers` cube.
+The transfer-based stream returns the token's name, symbol, decimals, and contract in the same payload — everything a sniping bot or listings feed needs, with no follow-up metadata call. It also carries the transaction's gas economics and success flag:
 
 ▶️ [Pools trade Stream launches with token detail](https://ide.bitquery.io/Pools-trade-Stream-launches-with-token-detail)
 
 #### Real time transfers on robinhood
 
-Real time transfers on robinhood.
+Stream live transfers for dashboards, bots, and alerting.
 
 ▶️ [Real time transfers on robinhood](https://ide.bitquery.io/real-time-transfers-on-robinhood)
 
@@ -1922,7 +1922,7 @@ Real time transfers on robinhood.
 
 #### Robinhood Chain OHLCV / Candlestick API for a Token Pair
 
-Robinhood Chain OHLCV / Candlestick API for a Token Pair. Uses the `Pairs` cube.
+This GraphQL stream for 1 second OHLCV streams the USD normalised OHLC/K-line data for a token pair, and also contains info such as interval start and end time, marketcap, volume and token details for both base and quote tokens.
 
 ▶️ [Robinhood Chain OHLCV / Candlestick API for a Token Pair](https://ide.bitquery.io/OHLCV-stream-for-a-token-pair-on-robinhood)
 
@@ -1938,13 +1938,13 @@ Websocket subscription streaming every new pools.trade token launch on Robinhood
 
 #### Flap sh Newly created tokens using logs (TokenCreated) - Websocket
 
-Flap sh Newly created tokens using logs (TokenCreated) - Websocket. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+Filter Flap.sh `TokenCreated` events and decode argument values (token address, metadata fields, and related parameters).
 
 ▶️ [Flap sh Newly created tokens using logs (TokenCreated) - Websocket](https://ide.bitquery.io/Flap-sh-Newly-created-tokens-using-logs-TokenCreated---Websocket)
 
 #### Stream New Tokens on Robinhood Chain (All Launchpads)
 
-Stream New Tokens on Robinhood Chain (All Launchpads). Uses the `Events` cube.
+Follow the steps here: How to generate Bitquery API token ➤ :::
 
 ▶️ [Stream New Tokens on Robinhood Chain (All Launchpads)](https://ide.bitquery.io/stream-new-tokens-robinhood-chain)
 
@@ -1964,61 +1964,61 @@ You can stream Bitcoin price at 1-second interval using the [Crypto Price APIs](
 
 #### All chains New Trades Stream - Solana, eth, bsc ,base , arbitrum, matic
 
-All chains New Trades Stream - Solana, eth, bsc ,base , arbitrum, matic.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [All chains New Trades Stream - Solana, eth, bsc ,base , arbitrum, matic](https://ide.bitquery.io/all-chains-New-Trades-Stream---Solana-eth-bsc-base--arbitrum-matic_2)
 
 #### All trades of a trader
 
-All trades of a trader. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [All trades of a trader](https://ide.bitquery.io/All-trades-of-a-trader)
 
 #### All wsol Trade Stream
 
-All wsol Trade Stream. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [All wsol Trade Stream](https://ide.bitquery.io/All-wsol-Trade-Stream)
 
 #### How do I get a wallet's trades on a specific pair?
 
-How do I get a wallet's trades on a specific pair?. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [How do I get a wallet's trades on a specific pair?](https://ide.bitquery.io/How-do-I-get-a-wallets-trades-on-a-specific-pair)
 
 #### How do I monitor multiple wallets in one subscription?
 
-How do I monitor multiple wallets in one subscription?. Uses the `Trades` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [How do I monitor multiple wallets in one subscription?](https://ide.bitquery.io/How-do-I-monitor-multiple-wallets-in-one-subscription)
 
 #### How do I monitor multiple wallets trading a specific token?
 
-How do I monitor multiple wallets trading a specific token?. Uses the `Trades` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [How do I monitor multiple wallets trading a specific token?](https://ide.bitquery.io/How-do-I-monitor-multiple-wallets-trading-a-specific-token)
 
 #### How do I stream a wallet's trades on a specific DEX?
 
-How do I stream a wallet's trades on a specific DEX?. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [How do I stream a wallet's trades on a specific DEX?](https://ide.bitquery.io/How-do-I-stream-a-wallets-trades-on-a-specific-DEX)
 
 #### How do I stream a wallet's trades on a specific chain?
 
-How do I stream a wallet's trades on a specific chain?. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [How do I stream a wallet's trades on a specific chain?](https://ide.bitquery.io/How-do-I-stream-a-wallets-trades-on-a-specific-chain)
 
 #### How do I stream whale trades for a specific wallet?
 
-How do I stream whale trades for a specific wallet?. Uses the `Trades` cube. Replace the address in the `where` clause to use it.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [How do I stream whale trades for a specific wallet?](https://ide.bitquery.io/How-do-I-stream-whale-trades-for-a-specific-wallet)
 
 #### How do I track trades for multiple tokens in one subscription?
 
-How do I track trades for multiple tokens in one subscription?. Uses the `Trades` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [How do I track trades for multiple tokens in one subscription?](https://ide.bitquery.io/How-do-I-track-trades-for-multiple-tokens-in-one-subscription)
 
@@ -2044,31 +2044,31 @@ Monitor Raydium Launchlab token listings on Solana with 1-second OHLC and volume
 
 #### 5 minute price change api on solana
 
-5 minute price change api on solana. Uses the `Tokens` cube.
+Here we have selected the filter `Price: {IsQuotedInUsd: true}`, this means that any price values such as OHLC or Average indicators will be in USD. If you want them in quote currency, change the filter to `Price: {IsQuotedInUsd: false}`.
 
 ▶️ [5 minute price change api on solana](https://ide.bitquery.io/5-minute-price-change-api-on-solana_6)
 
 #### Bitcoin currency price stream
 
-Bitcoin currency price stream. Uses the `Currencies` cube.
+Get real-time Bitcoin OHLC data across all chains:
 
 ▶️ [Bitcoin currency price stream](https://ide.bitquery.io/bitcoin-currency-price-stream)
 
 #### Heaven DEX tokens 1 second price stream with OHLC
 
-Heaven DEX tokens 1 second price stream with OHLC. Uses the `Pairs` cube.
+Here we have selected the filter `Price: {IsQuotedInUsd: true}`, this means that any price values such as OHLC or Average indicators will be in USD. If you want them in quote currency, change the filter to `Price: {IsQuotedInUsd: false}`.
 
 ▶️ [Heaven DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/Heaven-DEX-tokens-1-second-price-stream-with-OHLC)
 
 #### Meteora DBC DEX tokens 1 second price stream with OHLC
 
-Meteora DBC DEX tokens 1 second price stream with OHLC. Uses the `Pairs` cube.
+Here we have selected the filter `Price: {IsQuotedInUsd: true}`, this means that any price values such as OHLC or Average indicators will be in USD. If you want them in quote currency, change the filter to `Price: {IsQuotedInUsd: false}`.
 
 ▶️ [Meteora DBC DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/Meteora-DBC-DEX-tokens-1-second-price-stream-with-OHLC)
 
 #### Real Time USD price on solana chain
 
-Real Time USD price on solana chain. Uses the `Pairs` cube.
+Here we have selected the filter `Price: {IsQuotedInUsd: true}`, this means that any price values such as OHLC or Average indicators will be in USD. If you want them denominated in quote currency, change the filter to `Price: {IsQuotedInUsd: false}`.
 
 ▶️ [Real Time USD price on solana chain](https://ide.bitquery.io/Real-Time-USD-price-on-solana-chain_2)
 
@@ -2076,7 +2076,7 @@ Real Time USD price on solana chain. Uses the `Pairs` cube.
 
 #### All trades of a specific Ethereum token with Price, Marketcap, supply
 
-All trades of a specific Ethereum token with Price, Marketcap, supply. Uses the `Trades` cube.
+You can run this subscription [in the Bitquery IDE
 
 ▶️ [All trades of a specific Ethereum token with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-of-a-specific-Ethereum-token-with-Price-Marketcap-supply_1)
 
@@ -2084,35 +2084,15 @@ All trades of a specific Ethereum token with Price, Marketcap, supply. Uses the 
 
 #### Liquidity addition for radium
 
-Liquidity addition for radium. Uses the `DEXPools` cube.
+Subscribe to `Solana.DEXPools` with Raydium’s program and positive base change to detect new liquidity deposited into Raydium pools.
 
 ▶️ [Liquidity addition for radium](https://ide.bitquery.io/liquidity-addition-for-radium_1)
 
 #### Liquidity removal for radium
 
-Liquidity removal for radium. Uses the `DEXPools` cube.
+Use the same Raydium program filter with negative `ChangeAmount` on the base side to stream liquidity withdrawals.
 
 ▶️ [Liquidity removal for radium](https://ide.bitquery.io/liquidity-removal-for-radium_1)
-
-### Pump.fun
-
-#### All Pumpswap Trade Stream
-
-All Pumpswap Trade Stream. Uses the `Trades` cube.
-
-▶️ [All Pumpswap Trade Stream](https://ide.bitquery.io/All-Pumpswap-Trade-Stream)
-
-#### All pumpfun Trade Stream
-
-All pumpfun Trade Stream. Uses the `Trades` cube.
-
-▶️ [All pumpfun Trade Stream](https://ide.bitquery.io/All-pumpfun-Trade-Stream_2)
-
-#### Pump fun token live prices using trades api
-
-Pump fun token live prices using trades api. Uses the `Trades` cube.
-
-▶️ [Pump fun token live prices using trades api](https://ide.bitquery.io/pump-fun-token-live-prices-using-trades-api_1)
 
 ### PancakeSwap
 
@@ -2128,6 +2108,26 @@ PancakeSwap v3 DEX tokens 1 second price stream with OHLC. Uses the `Pairs` cube
 
 ▶️ [PancakeSwap v3 DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/PancakeSwap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
 
+### Pump.fun
+
+#### All Pumpswap Trade Stream
+
+You can run this subscription [in the Bitquery IDE
+
+▶️ [All Pumpswap Trade Stream](https://ide.bitquery.io/All-Pumpswap-Trade-Stream)
+
+#### All pumpfun Trade Stream
+
+You can run this subscription [in the Bitquery IDE
+
+▶️ [All pumpfun Trade Stream](https://ide.bitquery.io/All-pumpfun-Trade-Stream_2)
+
+#### Pump fun token live prices using trades api
+
+You can run this subscription [in the Bitquery IDE
+
+▶️ [Pump fun token live prices using trades api](https://ide.bitquery.io/pump-fun-token-live-prices-using-trades-api_1)
+
 ### Uniswap
 
 #### 1-second price, OHLC, volume, SMA and EMA — Uniswap v3
@@ -2138,13 +2138,13 @@ One-second candles with moving averages for Uniswap v3 tokens, built for trading
 
 #### Stream all Uniswap Seconds OHLC Kline
 
-Stream all Uniswap Seconds OHLC Kline. Uses the `Pairs` cube.
+Subscribe to `Trading.Pairs` filtered by Uniswap protocols and 1s interval to power sub-minute charts and HFT analytics.
 
 ▶️ [Stream all Uniswap Seconds OHLC Kline](https://ide.bitquery.io/Stream-all-Uniswap-Seconds-OHLC-Kline)
 
 #### Uniswap all versions trades stream
 
-Uniswap all versions trades stream. Uses the `DEXTrades` cube.
+Filter `DEXTrades` with `ProtocolName` in `uniswap_v3`, `uniswap_v2`, `uniswap_v1` to stream only Uniswap family pools on mainnet.
 
 ▶️ [Uniswap all versions trades stream](https://ide.bitquery.io/uniswap-all-versions-trades-stream)
 
@@ -2154,37 +2154,37 @@ Uniswap all versions trades stream. Uses the `DEXTrades` cube.
 
 #### Solana trades subscription
 
-Solana trades subscription. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Below stream will give you realtime trades of `USDT` on Solana. Test the stream [here
 
 ▶️ [Solana trades subscription](https://ide.bitquery.io/solana-trades-subscription_10_1)
 
 #### Stablecoin Depeg tracking Stream for evm
 
-Stablecoin Depeg tracking Stream for evm. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Below stream tracks USDT on Ethereum when PriceInUSD is outside 0.95–1.05 (depeg-style band). Test the query [here
 
 ▶️ [Stablecoin Depeg tracking Stream for evm](https://ide.bitquery.io/Stablecoin-Depeg-tracking-Stream-for-evm)
 
 #### Stablecoin Depeg tracking Stream for tron
 
-Stablecoin Depeg tracking Stream for tron. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Below stream tracks USDT on Tron when PriceInUSD is outside 0.95–1.05 (depeg-style band). Test the query [here
 
 ▶️ [Stablecoin Depeg tracking Stream for tron](https://ide.bitquery.io/Stablecoin-Depeg-tracking-Stream-for-tron)
 
 #### Stablecoin depeg tracking stream for USDC
 
-Stablecoin depeg tracking stream for USDC. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Below stream will be able to track specific Stablecoin depeg. In this query example, we are tracking depeg for the stablecoin `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` which has a symbol `USDC`. Test the query [here
 
 ▶️ [Stablecoin depeg tracking stream for USDC](https://ide.bitquery.io/stablecoin-depeg-tracking-stream-for-USDC)
 
 #### Stablecoin trades for etheruem
 
-Stablecoin trades for etheruem. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Below stream will give you realtime USDT DEX trades on Ethereum. Test the stream [here
 
 ▶️ [Stablecoin trades for etheruem](https://ide.bitquery.io/Stablecoin-trades-for-etheruem)
 
 #### Stablecoin trades for tron
 
-Stablecoin trades for tron. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Below stream will give you realtime USDT DEX trades on Tron. Test the stream [here
 
 ▶️ [Stablecoin trades for tron](https://ide.bitquery.io/Stablecoin-trades-for-tron)
 
@@ -2192,61 +2192,61 @@ Stablecoin trades for tron. Uses the `DEXTrades` cube. Change the token address 
 
 #### Latest Tron USDT Transfers stream
 
-Latest Tron USDT Transfers stream. Uses the `Transfers` cube.
+Listen to stablecoin payments across all major blockchains. The Mempool option lets you detect a payment *before* it is confirmed — useful for instant merchant UX.
 
 ▶️ [Latest Tron USDT Transfers stream](https://ide.bitquery.io/Latest-Tron-USDT-Transfers-stream)
 
 #### Latest USDT/USDC Transfer Stream on BSC
 
-Latest USDT/USDC Transfer Stream on BSC. Uses the `Transfers` cube.
+Listen to stablecoin payments across all major blockchains. The Mempool option lets you detect a payment *before* it is confirmed — useful for instant merchant UX.
 
 ▶️ [Latest USDT/USDC Transfer Stream on BSC](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-Stream-on-BSC)
 
 #### Latest USDT/USDC Transfer stream on base
 
-Latest USDT/USDC Transfer stream on base. Uses the `Transfers` cube.
+Listen to stablecoin payments across all major blockchains. The Mempool option lets you detect a payment *before* it is confirmed — useful for instant merchant UX.
 
 ▶️ [Latest USDT/USDC Transfer stream on base](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-stream-on-base)
 
 #### Latest USDT/USDC Transfer stream on ethereum
 
-Latest USDT/USDC Transfer stream on ethereum. Uses the `Transfers` cube.
+Listen to stablecoin payments across all major blockchains. The Mempool option lets you detect a payment *before* it is confirmed — useful for instant merchant UX.
 
 ▶️ [Latest USDT/USDC Transfer stream on ethereum](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-stream-on-ethereum)
 
 #### Listening to All USDT and USDC Payments on Solana - stream
 
-Listening to All USDT and USDC Payments on Solana - stream. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+Returns streams USDT (`TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`) transfers on Tron — the highest-volume stablecoin payments network globally.
 
 ▶️ [Listening to All USDT and USDC Payments on Solana - stream](https://ide.bitquery.io/Listening-to-All-USDT-and-USDC-Payments-on-Solana---stream)
 
 #### Listening to stablecoin Transfers for Specific Addresse on tron
 
-Listening to stablecoin Transfers for Specific Addresse on tron. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+Listen to USDT sent or received by address `TUTQj7VJ1QjR3t2GJByvrP25yZNFcj38VJ`. This is the canonical "merchant/treasury wallet monitor" pattern — fan-out one subscription per wallet and route hits to your payments backend.
 
 ▶️ [Listening to stablecoin Transfers for Specific Addresse on tron](https://ide.bitquery.io/Listening-to-stablecoin-Transfers-for-Specific-Addresse-on-tron)
 
 #### Stablecoin Realtime Payments Stream on Eth Mainnet
 
-Stablecoin Realtime Payments Stream on Eth Mainnet. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+A single-contract USDC payments stream on Ethereum mainnet. Swap the `SmartContract` for `0xdAC17F958D2ee523a2206206994597C13D831ec7` to get USDT, or extend with an `in: [...]` list to multiplex stablecoins.
 
 ▶️ [Stablecoin Realtime Payments Stream on Eth Mainnet](https://ide.bitquery.io/Stablecoin-Realtime-Payments-Stream-on-Eth-Mainnet)
 
 #### Stablecoin Realtime Transfers Stream on tron
 
-Stablecoin Realtime Transfers Stream on tron. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+Below stream will give you realtime transfers of `USDT` on Tron. Test the stream [here
 
 ▶️ [Stablecoin Realtime Transfers Stream on tron](https://ide.bitquery.io/Stablecoin-Realtime-Transfers-Stream-on-tron)
 
 #### Stablecoin transfers websocket
 
-Stablecoin transfers websocket. Uses the `Transfers` cube. Change the token address in the `where` clause to use it.
+Below stream will give you realtime transfers of `USDC` on Solana. Test the stream [here
 
 ▶️ [Stablecoin transfers websocket](https://ide.bitquery.io/stablecoin-transfers-websocket)
 
 #### USDT and USDC token Transfers stream on solana
 
-USDT and USDC token Transfers stream on solana. Uses the `Transfers` cube.
+This GraphQL stream provides live USDT and USDC stablecoin transfers on Solana.
 
 ▶️ [USDT and USDC token Transfers stream on solana](https://ide.bitquery.io/USDT-and-USDC-token-Transfers-stream-on-solana)
 
@@ -2254,7 +2254,7 @@ USDT and USDC token Transfers stream on solana. Uses the `Transfers` cube.
 
 #### Real time stablecoin portfolio
 
-Real time stablecoin portfolio. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Below stream will provide you the realtime portfolio updates for a particular address for a specific Stablecoin. In this query example, we are tracking portfolio updates for the address `3i51cKbLbaKAqvRJdCUaq9hsnvf9kqCfMujNgFj7nRKt` and for stablecoin `USDC`.
 
 ▶️ [Real time stablecoin portfolio](https://ide.bitquery.io/real-time-stablecoin-portfolio_2)
 
@@ -2268,7 +2268,7 @@ This subscription gives you 1-second OHLC, mean price, averages for all stableco
 
 #### Stablecoin price stream of USDT
 
-Stablecoin price stream of USDT. Uses the `Tokens` cube.
+Get real-time and historical USDT prices, OHLCV, and moving averages across supported networks and markets.
 
 ▶️ [Stablecoin price stream of USDT](https://ide.bitquery.io/stablecoin-price-stream-of-USDT_2)
 
@@ -2276,7 +2276,7 @@ Stablecoin price stream of USDT. Uses the `Tokens` cube.
 
 #### USDT Stablecoin reserves on Solana
 
-USDT Stablecoin reserves on Solana. Uses the `TokenSupplyUpdates` cube. Change the token address in the `where` clause to use it.
+Monitor USDT reserve or get lateast reserve value on Solana using below Stream/API.
 
 ▶️ [USDT Stablecoin reserves on Solana](https://ide.bitquery.io/USDT-Stablecoin-reserves-on-Solana)
 
@@ -2284,19 +2284,19 @@ USDT Stablecoin reserves on Solana. Uses the `TokenSupplyUpdates` cube. Change t
 
 #### Latest Tron USDT Transfers stream in Mempool
 
-Latest Tron USDT Transfers stream in Mempool. Uses the `Transfers` cube.
+Listen to stablecoin payments across all major blockchains. The Mempool option lets you detect a payment *before* it is confirmed — useful for instant merchant UX.
 
 ▶️ [Latest Tron USDT Transfers stream in Mempool](https://ide.bitquery.io/Latest-Tron-USDT-Transfers-stream-in-Mempool)
 
 #### Latest USDT/USDC Transfer Stream on BSC on Mempool
 
-Latest USDT/USDC Transfer Stream on BSC on Mempool. Uses the `Transfers` cube.
+Listen to stablecoin payments across all major blockchains. The Mempool option lets you detect a payment *before* it is confirmed — useful for instant merchant UX.
 
 ▶️ [Latest USDT/USDC Transfer Stream on BSC on Mempool](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-Stream-on-BSC-on-Mempool)
 
 #### Latest USDT/USDC Transfer stream on ethereum in Mempool
 
-Latest USDT/USDC Transfer stream on ethereum in Mempool. Uses the `Transfers` cube.
+Listen to stablecoin payments across all major blockchains. The Mempool option lets you detect a payment *before* it is confirmed — useful for instant merchant UX.
 
 ▶️ [Latest USDT/USDC Transfer stream on ethereum in Mempool](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-stream-on-ethereum-in-Mempool)
 
@@ -2306,13 +2306,13 @@ Latest USDT/USDC Transfer stream on ethereum in Mempool. Uses the `Transfers` cu
 
 #### Hyperliquid Real-time Trades Stream (WebSocket)
 
-Hyperliquid Real-time Trades Stream (WebSocket).
+Run it in the IDE: [Hyperliquid Trades Stream ➤
 
 ▶️ [Hyperliquid Real-time Trades Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-trades-stream)
 
 #### Solana Perps Live Trades Stream (Phoenix Fills)
 
-Solana Perps Live Trades Stream (Phoenix Fills).
+You can run a live fills stream [in the Bitquery IDE
 
 ▶️ [Solana Perps Live Trades Stream (Phoenix Fills)](https://ide.bitquery.io/solana-perps-live-trades-stream)
 
@@ -2320,19 +2320,19 @@ Solana Perps Live Trades Stream (Phoenix Fills).
 
 #### Hyperliquid Price Updates Stream (WebSocket)
 
-Hyperliquid Price Updates Stream (WebSocket).
+Run it in the IDE: [Hyperliquid Price Updates Stream ➤
 
 ▶️ [Hyperliquid Price Updates Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-price-updates-stream)
 
 #### Hyperliquid Real-time Candles Stream (WebSocket)
 
-Hyperliquid Real-time Candles Stream (WebSocket).
+Run it in the IDE: [Hyperliquid Candles Stream ➤
 
 ▶️ [Hyperliquid Real-time Candles Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-candles-stream)
 
 #### Solana Perpetuals Mark Price Stream (Phoenix)
 
-Solana Perpetuals Mark Price Stream (Phoenix).
+You can run this stream [in the Bitquery IDE
 
 ▶️ [Solana Perpetuals Mark Price Stream (Phoenix)](https://ide.bitquery.io/solana-perpetuals-mark-price-stream)
 
@@ -2348,7 +2348,7 @@ This stream allows you to monitor real time NFT trades on OpenSea. It could also
 
 #### Latest Solana NFT Trades
 
-Latest Solana NFT Trades.
+The subscription query provided below fetches the most recent NFT trades on the Solana blockchain. You can find the query [here
 
 ▶️ [Latest Solana NFT Trades](https://ide.bitquery.io/Latest-Solana-NFT-Trades)
 
@@ -2362,49 +2362,49 @@ NFT transfers as they are mined, with token IDs.
 
 #### Subscription WebSocket - Latest NFT Transfers
 
-Subscription WebSocket - Latest NFT Transfers.
+Using Streaming APIs, you can subscribe to real-time changes on blockchains. We use a GraphQL subscription,which function similarly to WebSockets.
 
 ▶️ [Subscription WebSocket - Latest NFT Transfers](https://ide.bitquery.io/Subscription-WebSocket---Latest-NFT-Transfers)
 
 #### Subscribe to the latest NFT transfers on Solana
 
-Subscribe to the latest NFT transfers on Solana.
+Let's see an example of NFT token transfers using GraphQL Subscription (Webhook). In the following API, we will be subscribing to all NFT token transfers. You can run the query [here
 
 ▶️ [Subscribe to the latest NFT transfers on Solana](https://ide.bitquery.io/Subscribe-to-the-latest-NFT-transfers-on-Solana)
 
 #### NFT Token Transfers API
 
-NFT Token Transfers API.
+Let's see an example of NFT token transfers using GraphQL Subscription (Webhook). In the following NFT Token Transfers API, we will be subscribing to all NFT token transfers on Base network. You can run the query [here
 
 ▶️ [NFT Token Transfers API](https://ide.bitquery.io/NFT-Token-Transfers-API_4)
 
 #### Transfers of a particular NFT
 
-Transfers of a particular NFT.
+Returns subscribes you to the real time transfers of a specific non-fungible token (NFT) on the Base network. You can find the query [here
 
 ▶️ [Transfers of a particular NFT](https://ide.bitquery.io/Transfers-of-a-particular-NFT_1)
 
 #### Track realtime NFT Transfers of a specific NFT on BSC chain
 
-Track realtime NFT Transfers of a specific NFT on BSC chain.
+Returns subscribes you to the real time non-fungible token (NFT) transfers of a specific nft contract on the BSC network. You can find the query [here
 
 ▶️ [Track realtime NFT Transfers of a specific NFT on BSC chain](https://ide.bitquery.io/Track-realtime-NFT-Transfers-of-a-specific-NFT-on-BSC-chain)
 
 #### Track realtime NFT Transfers on BSC chain
 
-Track realtime NFT Transfers on BSC chain.
+Let's see an example of NFT token transfers using GraphQL Subscription (Webhook). In the following NFT Token Transfers API, we will be subscribing to all NFT token transfers on BSC network. You can run the query [here
 
 ▶️ [Track realtime NFT Transfers on BSC chain](https://ide.bitquery.io/Track-realtime-NFT-Transfers-on-BSC-chain)
 
 #### Websocket for tracking Transfers of a particular NFT websocket
 
-Websocket for tracking Transfers of a particular NFT websocket.
+Returns subscribes you to the real time transfers of a specific non-fungible token (NFT) on the Tron network. You can find the query [here
 
 ▶️ [Websocket for tracking Transfers of a particular NFT websocket](https://ide.bitquery.io/Websocket-for-tracking-Transfers-of-a-particular-NFT-websocket)
 
 #### Real-time-transfer-websocket-for-NFT-token on matic
 
-Real-time-transfer-websocket-for-NFT-token on matic.
+Returns subscribes you to the real time transfers of a specific non-fungible token (NFT) on the Matic network. You can find the query [here
 
 ▶️ [Real-time-transfer-websocket-for-NFT-token on matic](https://ide.bitquery.io/Real-time-transfer-websocket-for-NFT-token-on-matic)
 
@@ -2440,43 +2440,43 @@ Subscribe to trades for one market only by filtering on Question.MarketId. Repla
 
 #### Bitcoin Up or Down Trades Stream
 
-Bitcoin Up or Down Trades Stream.
+Subscribe to live Polymarket trades for markets whose question title includes "Bitcoin Up or Down".
 
 ▶️ [Bitcoin Up or Down Trades Stream](https://ide.bitquery.io/Bitcoin-Up-or-Down-Trades-Stream)
 
 #### How do I track high-value or whale trades on Polymarket?
 
-How do I track high-value or whale trades on Polymarket?.
+Use a GraphQL subscription on `PredictionTrades` filtered by `CollateralAmountInUSD: { gt: "10000" }` and `ProtocolName: "polymarket"` to monitor trades exceeding $10,000 USD in real time. Ideal for detecting whale activity and large market movements.
 
 ▶️ [How do I track high-value or whale trades on Polymarket?](https://ide.bitquery.io/How-do-I-track-high-value-or-whale-trades-on-Polymarket)
 
 #### Large trades on polymarket
 
-Large trades on polymarket.
+Start by streaming large Polymarket trades. Each event gives you a buyer address to investigate. Change `subscription` to `query` for historical results.
 
 ▶️ [Large trades on polymarket](https://ide.bitquery.io/large-trades--on-polymarket)
 
 #### Monitoring specific wallets trades in realtime for Ethereum up or down market
 
-Monitoring specific wallets trades in realtime for Ethereum up or down market.
+The same wallet-monitoring pattern works for every Polymarket Up or Down market — only the `Question.Title` filter changes. Open any of the pre-built IDE queries below to stream trades for the chain you care about:
 
 ▶️ [Monitoring specific wallets trades in realtime for Ethereum up or down market](https://ide.bitquery.io/monitoring-specific-wallets-trades-in-realtime-for-Ethereum-up-or-down-market)
 
 #### Monitoring specific wallets trades in realtime for XRP up or down market
 
-Monitoring specific wallets trades in realtime for XRP up or down market.
+The same wallet-monitoring pattern works for every Polymarket Up or Down market — only the `Question.Title` filter changes. Open any of the pre-built IDE queries below to stream trades for the chain you care about:
 
 ▶️ [Monitoring specific wallets trades in realtime for XRP up or down market](https://ide.bitquery.io/monitoring-specific-wallets-trades-in-realtime-for-XRP-up-or-down-market)
 
 #### Polymarket AI whale trades stream
 
-Polymarket AI whale trades stream.
+Streams live AI-market trades above a USD threshold (here `$5,000`). This is ideal for whale-alert bots and detecting large, conviction bets. Filter with a `Question.Title` keyword, or swap it for a single-market `MarketId`.
 
 ▶️ [Polymarket AI whale trades stream](https://ide.bitquery.io/Polymarket-AI-whale-trades-stream)
 
 #### Polymarket whale trades alert
 
-Polymarket whale trades alert.
+Stream successful Polymarket trades whose collateral exceeds $10,000 USD. Adjust the threshold string as needed.
 
 ▶️ [Polymarket whale trades alert](https://ide.bitquery.io/polymarket-whale-trades-alert_1)
 


### PR DESCRIPTION
The IDE's **Queries** and **Streams** panels render directly from `docs/start/starter-queries.md` and `docs/start/starter-subscriptions.md` — the parser reads only `##`/`###`/`####`, three levels, and the paragraph under each `####` becomes the hover tooltip. Those two files had drifted badly. This rebuilds them.

**Nothing here is live until this merges** — the IDE fetches `refs/heads/main`.

## What changed

**323 → 1,025 entries.** 644 queries across 28 groups, 381 streams across 17.

One canonical section vocabulary applied identically to every group — Trades, Transfers, Balances & Holders, Price & OHLC, Supply & Market Cap, Liquidity & Pools, Transactions, Events & Calls, Mempool, Blocks & Validators — with a venue section (Uniswap, PancakeSwap, Raydium, Pump.fun, Four Meme…) promoted where a venue has 3+ queries.

Newly visible in the IDE, from zero: **Arbitrum, Optimism, Algorand, Trading API, Stablecoins, Perpetuals, Futures DEXs, Avalanche, Celo, Dogecoin, Litecoin, Bitcoin Cash, Dash, Zcash.** Robinhood 4 → 50, TRON 11 → 42, Polygon 2 → 27.

The Real Time / Historical section split is gone — it was decorative (`Current Balance of an address` sat under "Real Time Balance APIs" running `dataset: combined`). `Blocks & Validators` now holds the validator/miner/MEV/self-destruct entries that were buried under "Balance APIs". `Mempool` is a section for the first time.

## Verification

Every entry was executed against the live API before inclusion — queries over HTTP, subscriptions over WebSocket. Anything that errored was dropped rather than shipped. The full audit suite passes:

| gate | result |
|---|---|
| play-link slug + tooltip on every entry | pass |
| every slug resolves, not deleted, not unpublished | pass |
| zero `BalanceUpdates` (cube being retired) | pass |
| every entry on the chain its group claims | pass |
| stored endpoint matches query dialect (V1 vs V2) | pass |
| no duplicate titles within a group + tab | pass |
| every entry executed successfully, live | pass |
| Docusaurus production build | success, no warnings |
| 254 of 298 original entries retained | every drop explained |

The 44 dropped originals: 27 fail live, 11 use `BalanceUpdates`, 4 are dead slugs, 1 was on the wrong chain, 1 subscription rejected.

## Defects fixed along the way

- **14 links were unreachable** because of a trailing `#` or `?` inside the markdown URL, which the IDE folds into the slug via `split("/").pop()`.
- **8 links opened a different query than their title claimed** — e.g. "Bonding Curve Progress of a **Raydium Launchpad** Token" opened the **LetsBonk.fun** query; "NFTs a **contract** holds" opened the **wallet** query.
- **5 queries filed under one chain actually targeted another.**
- One **V2 subscription was stored against the V1 endpoint**.
- A broken inbound anchor from `learning-path.md` (also fixed here).
- `docs/ide/paid.md` said archive/combined were Enterprise-only; they are available to self-serve plans via the historical data add-on.

## Removed

**Cosmos** and **Bitcoin SV**. Cosmos's only query times out server-side. Bitcoin SV's index stopped at block 934549 on 2026-02-02 — nearly seven months stale, while every other UTXO chain is current to the minute.

**Celo ships without DEX queries**: its `dexTrades` cube stopped at block 31124914 on 2025-03-26, though its other cubes are live.

## Known gaps

- Tooltips are 80% human-written (harvested from each query's own docs page); the remaining ~196 are generated from cube and filter shape and would benefit from a pass.
- Four Solana balance entries still rely on `InstructionBalanceUpdates` / `joinBalanceUpdates` — siblings of the cube being retired. Solana has no `Balances` cube, so they need a decision.
- Backend, not docs: the Trading API market-cap queries die on a ~17s server deadline, and parts of the legacy NFT set request archive tables that are not deployed. Both are excluded here.
- Stellar, Fantom, Cronos, Klaytn and Moonbeam are still unbuilt (Moonbeam was 16 days stale when checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)