### PR TITLE
docs: lead with the Trading cube, and add a one-page API reference for AI assistants

### DIFF
--- a/docs/start/bitquery-for-ai.md
+++ b/docs/start/bitquery-for-ai.md
@@ -1,0 +1,390 @@
+---
+title: "Bitquery in One Page — Complete Context for AI Assistants"
+description: "A single self-contained page describing the Bitquery API: endpoints, chains, cubes, datasets, query rules and worked examples. Paste it into an AI assistant and it can write correct Bitquery queries without reading anything else."
+keywords:
+  [
+    "Bitquery for AI",
+    "Bitquery LLM context",
+    "blockchain API for AI agents",
+    "GraphQL blockchain schema",
+    "Bitquery cheat sheet"
+  ]
+sidebar_position: 2
+---
+
+# Bitquery in One Page
+
+This page is written to be handed to an AI assistant. It is deliberately self-contained: no
+navigation, no links to click through, every query written out in full. Paste the whole page
+into a model's context and it has enough to write correct Bitquery queries, pick the right
+endpoint, and avoid the mistakes that produce silently wrong answers.
+
+If you are a human, this also works as a one-screen reference.
+
+---
+
+## 1. What Bitquery is
+
+Bitquery indexes blockchain data — trades, transfers, balances, holders, transactions, events,
+contract calls, mempool — and serves it as GraphQL. You do not run nodes. You send a GraphQL
+document over HTTP for historical questions, or over WebSocket for a live stream.
+
+There are two generations of the API and **they are different products with different schemas**.
+Choosing the wrong one is the single most common mistake.
+
+---
+
+## 2. Endpoints and authentication
+
+| Purpose | Endpoint |
+| --- | --- |
+| V2 queries | `https://streaming.bitquery.io/graphql` |
+| V2 subscriptions | `wss://streaming.bitquery.io/graphql` |
+| V1 queries | `https://graphql.bitquery.io` |
+
+Authentication is the same token on both:
+
+```
+Authorization: Bearer ory_at_YOUR_TOKEN
+Content-Type: application/json
+```
+
+For WebSocket, use the `graphql-transport-ws` (or `graphql-ws`) subprotocol and pass the token
+either as an `Authorization` header or as `?token=...` on the URL. Send `connection_init`, wait
+for `connection_ack`, then send `subscribe`.
+
+**Subscriptions only work over WebSocket.** Posting a `subscription` document to the HTTP
+endpoint returns `subscriptions must be sent over a websocket connection, not HTTP`.
+
+---
+
+## 3. Which chain lives on which API
+
+**V2 covers exactly these chains and no others.**
+
+- EVM root, `network:` argument — `eth`, `bsc`, `base`, `arbitrum`, `optimism`, `matic`, `robinhood`
+- `Solana` root — Solana
+- `Tron` root — Tron
+- `Hyperliquid` root — Hyperliquid perpetuals
+- `Trading` root — cross-chain prices and trades, no `network` argument
+
+**Everything else is V1 only**: Bitcoin, Litecoin, Bitcoin Cash, Dogecoin, Dash, Zcash,
+Cardano, Ripple, Stellar, Algorand, Avalanche, Celo, Fantom, Cronos, Klaytn, Moonbeam.
+
+V1 groups chains under a shared root with a `network` argument:
+
+- `bitcoin(network: bitcoin | litecoin | bitcash | dogecoin | dash | zcash)`
+- `ethereum(network: avalanche | celo_mainnet | fantom | cronos | klaytn | moonbeam | ...)`
+- `cardano(network: cardano)`, `ripple(network: ripple)`, `stellar(network: stellar)`,
+  `algorand(network: algorand)`, `solana(network: solana)`
+
+**V1 has no subscriptions.** If a chain is V1-only, it has no live stream over GraphQL.
+
+---
+
+## 4. The cubes — which one answers which question
+
+A "cube" is a top-level dataset. Picking the right cube matters more than writing clever filters.
+
+**`Trading` (cross-chain, no `network` argument)** — the primary source for prices and trades:
+
+- `Trading.Pairs` — OHLC and volume for one trading pair on one market. **Use this to price a
+  single token**, with a rank filter (see §6).
+- `Trading.Tokens` — OHLC and volume for a token, blended across every pool it trades in.
+- `Trading.Currencies` — a currency across all of its token representations and chains.
+- `Trading.Trades` — individual normalised trades across chains.
+
+**`EVM(network: ...)`** — `Balances`, `Blocks`, `Calls`, `DEXPoolEvents`, `DEXPoolSlippages`,
+`DEXTradeByTokens`, `DEXTrades`, `Events`, `Holders`, `MinerRewards`, `PredictionManagements`,
+`PredictionSettlements`, `PredictionTrades`, `TransactionBalances`, `Transactions`, `Transfers`,
+`Uncles`.
+
+**`Solana`** — `Blocks`, `DEXOrders`, `DEXPools`, `DEXTradeByTokens`, `DEXTrades`, `Instructions`,
+`PerpetualFills`, `PerpetualMarketSummaries`, `PerpetualOrders`, `PerpetualPositions`,
+`PerpetualPrices`, `Rewards`, `TokenSupplyUpdates`, `Transactions`, `Transfers`.
+
+Note: **Solana has no `Balances` cube.** Solana balances are derived from `Transfers`.
+
+Quick map from question to cube:
+
+| Question | Cube |
+| --- | --- |
+| What is this token worth right now? | `Trading.Pairs` with rank 1 |
+| Candles for a chart | `Trading.Pairs` (recent) or `DEXTradeByTokens` (older) |
+| Every swap on a chain | `EVM.DEXTrades` / `Solana.DEXTrades` |
+| Swaps grouped per token | `DEXTradeByTokens` |
+| Who holds this token | `EVM.Holders` |
+| What does this wallet hold | `EVM.Balances` |
+| Token movements | `Transfers` |
+| Raw transactions | `Transactions` |
+| Decoded logs / contract calls | `Events` / `Calls` |
+| Pool reserves, liquidity events | `DEXPoolEvents`, `DEXPools` |
+| Pending, not yet mined | any EVM cube with `mempool: true` |
+
+---
+
+## 5. Datasets and how far back data goes
+
+Every V2 root takes a `dataset` argument:
+
+- `realtime` — the recent window. This is the **default** if you omit `dataset`.
+- `archive` — deep history.
+- `combined` — archive and realtime stitched together.
+
+Retention on `realtime` is short and differs per cube: roughly 12 hours on Solana `DEXTrades`,
+about 7 days on Solana `DEXTradeByTokens`, a few days on EVM DEX and transfer cubes, and about
+30 days on the `Trading` cubes.
+
+Two things about this cause most "the data is wrong" reports:
+
+1. **`realtime` does not error when you ask beyond its window. It silently returns fewer rows.**
+   A chart just starts late. Always check whether the window you asked for is inside retention.
+2. **`archive` and `combined` are not deployed for every cube on every chain.** When they are
+   not, you get a ClickHouse error like
+   `no table can query <Cube> ... consider use realtime dataset`. That is not a bug in your
+   query, it means that table does not exist for that chain.
+
+Self-serve plans query `realtime`. Querying `archive` or `combined` needs the historical data
+add-on on the plan.
+
+---
+
+## 6. Rules that keep answers correct
+
+These are the mistakes that produce a plausible-looking wrong number rather than an error.
+
+**Price one token with `Pairs` and rank 1, not with `Tokens`.** The `Tokens` price is
+volume-weighted across every pool, so a thin pool drags it away from the real market. Add
+`Ranking: {Position: {eq: 1}}` to take the token's top market only. Always pair it with
+`Price: {IsQuotedInUsd: true}` — the rank filter picks the market, not the denomination.
+
+**In the `Trading` cube, token addresses are stored lowercase and the filter is
+case-sensitive.** A checksummed EVM address returns **zero rows and no error**. Lowercase every
+address you put in a `Trading` filter.
+
+**Balances are cumulative, so they cannot be answered from `realtime` alone.** A balance read
+from the realtime window is the change over the last few hours, not the balance. Use `archive`
+or `combined` for anything balance- or holder-shaped. The same applies to holder counts, token
+ownership and net worth.
+
+**Use the `Trading` cube for recent data and `DEXTradeByTokens` for older.** The `Trading` cubes
+cover roughly the last 30 days. Beyond that, rebuild the same numbers from raw trades with
+`DEXTradeByTokens`.
+
+**A bare `EVM` root means Ethereum.** `EVM { ... }` without a `network` argument returns
+Ethereum data. Be explicit.
+
+**On V1, always bound a list query by date.** V1 sorts the whole table otherwise and the query
+dies with ClickHouse `Code: 241, memory limit exceeded`. V1 has no relative-date filter, so pass
+the date as a variable and move it as needed.
+
+**Solana `combined` is currently broken** — every Solana cube returns a 500 on
+`dataset: combined`. Use `realtime` for recent and `archive` for history.
+
+**`BalanceUpdates` is being retired.** Do not write new queries against it.
+
+---
+
+## 7. Worked examples
+
+Every query below was executed against the live API before being written down.
+
+### Price of one token, from its top market
+
+```graphql
+query ($token: String!, $network: String!) {
+  Trading {
+    Pairs(
+      where: {
+        Token: { Address: { is: $token }, Network: { is: $network } }
+        Ranking: { Position: { eq: 1 } }
+        Interval: { Time: { Duration: { eq: 60 } } }
+        Price: { IsQuotedInUsd: true }
+      }
+      orderBy: { descending: Block_Time }
+      limit: { count: 1 }
+    ) {
+      Token { Symbol Name Address Network }
+      QuoteToken { Symbol Address }
+      Market { Name Address }
+      Price { Ohlc { Open High Low Close } Average { Mean } IsQuotedInUsd }
+      Volume { Usd Base Quote }
+      Block { Time }
+    }
+  }
+}
+```
+
+Variables — note the lowercase address:
+
+```json
+{ "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "network": "Ethereum" }
+```
+
+`Network` accepts `Ethereum`, `Base`, `Binance Smart Chain`, `Arbitrum`, `Optimism`, `Solana`.
+
+### Latest DEX trades for a token on an EVM chain
+
+```graphql
+{
+  EVM(network: eth) {
+    DEXTrades(
+      limit: { count: 10 }
+      orderBy: { descending: Block_Time }
+      where: { Trade: { Buy: { Currency: { SmartContract: { is: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2" } } } } }
+    ) {
+      Block { Time }
+      Transaction { Hash }
+      Trade {
+        Dex { ProtocolName ProtocolFamily }
+        Buy { Amount Currency { Symbol SmartContract } Buyer }
+        Sell { Amount Currency { Symbol SmartContract } }
+      }
+    }
+  }
+}
+```
+
+### What a wallet holds
+
+Balances are cumulative, so this uses `combined`:
+
+```graphql
+query ($address: String!) {
+  EVM(network: eth, dataset: combined) {
+    Balances(where: { Balance: { Address: { is: $address } } }) {
+      Currency { Symbol Name SmartContract }
+      Balance { Amount(selectWhere: { gt: "0" }) AmountInUSD }
+    }
+  }
+}
+```
+
+### Token transfers for a wallet
+
+```graphql
+{
+  EVM(network: eth) {
+    Transfers(
+      limit: { count: 25 }
+      orderBy: { descending: Block_Time }
+      where: { Transfer: { Sender: { is: "0x21a31ee1afc51d94c2efccaa2092ad1028285549" } } }
+    ) {
+      Block { Time }
+      Transaction { Hash }
+      Transfer { Amount Currency { Symbol SmartContract } Sender Receiver }
+    }
+  }
+}
+```
+
+### Solana trades for a token
+
+```graphql
+{
+  Solana {
+    DEXTradeByTokens(
+      limit: { count: 10 }
+      orderBy: { descending: Block_Time }
+      where: { Trade: { Currency: { MintAddress: { is: "So11111111111111111111111111111111111111112" } } } }
+    ) {
+      Block { Time }
+      Trade {
+        Currency { Symbol MintAddress }
+        Side { Currency { Symbol MintAddress } }
+        Dex { ProtocolName }
+        Price
+        PriceInUSD
+        Amount
+      }
+    }
+  }
+}
+```
+
+### A live stream
+
+Same document shape, `subscription` instead of `query`, sent over WebSocket:
+
+```graphql
+subscription {
+  EVM(network: eth) {
+    DEXTrades {
+      Block { Time }
+      Trade {
+        Dex { ProtocolName }
+        Buy { Amount Currency { Symbol } }
+        Sell { Amount Currency { Symbol } }
+      }
+    }
+  }
+}
+```
+
+### A V1 chain — Bitcoin and its relatives
+
+```graphql
+{
+  bitcoin(network: dogecoin) {
+    blocks(options: { limit: 10, desc: "height" }) {
+      height
+      timestamp { time(format: "%Y-%m-%d %H:%M:%S") }
+      transactionCount
+    }
+  }
+}
+```
+
+Balance of a V1 UTXO address as of a date — received minus spent:
+
+```graphql
+query ($address: String!, $asof: ISO8601DateTime) {
+  bitcoin(network: bitcoin) {
+    received: outputs(outputAddress: { is: $address }, date: { till: $asof }) {
+      value(calculate: sum)
+      count
+    }
+    spent: inputs(inputAddress: { is: $address }, date: { till: $asof }) {
+      value(calculate: sum)
+      count
+    }
+  }
+}
+```
+
+### Pending transactions, before they are mined
+
+```graphql
+{
+  EVM(mempool: true, network: eth) {
+    Transfers(limit: { count: 10 }) {
+      Transaction { Hash From To }
+      Transfer { Amount Currency { Symbol } Sender Receiver }
+    }
+  }
+}
+```
+
+---
+
+## 8. Errors and what they actually mean
+
+| Message | Meaning |
+| --- | --- |
+| `subscriptions must be sent over a websocket connection, not HTTP` | Send the document to `wss://streaming.bitquery.io/graphql` instead. |
+| `no table can query <Cube> ... consider use realtime dataset` | `archive`/`combined` is not deployed for that cube on that chain. |
+| `access restricted: your plan only allows "realtime"` | The query asked for `archive` or `combined`; the plan needs the historical data add-on. |
+| `402 No active billing period` | No active plan or points on the account. |
+| `Code: 241 ... memory limit exceeded` | A V1 list query with no date bound. Add one. |
+| `context deadline exceeded` | The server gave up. Narrow the filter or the time window. |
+| Zero rows, no error | Either the window is outside `realtime` retention, or a `Trading` address filter was not lowercase. |
+
+---
+
+## 9. Choosing quickly
+
+1. Is the chain on V2? If not, use V1 and expect no subscriptions.
+2. Is the question about price? Use `Trading.Pairs` with rank 1.
+3. Is it about balances, holders or ownership? Use `archive`/`combined` — never `realtime`.
+4. Is it older than about 30 days? Use `DEXTradeByTokens`, not the `Trading` cubes.
+5. Does it need to be live? Same document, `subscription`, over WebSocket.

--- a/docs/start/bitquery-for-ai.md
+++ b/docs/start/bitquery-for-ai.md
@@ -78,7 +78,17 @@ V1 groups chains under a shared root with a `network` argument:
 - `cardano(network: cardano)`, `ripple(network: ripple)`, `stellar(network: stellar)`,
   `algorand(network: algorand)`, `solana(network: solana)`
 
-**V1 has no subscriptions.** If a chain is V1-only, it has no live stream over GraphQL.
+**Ethereum, BSC, Tron and Polygon are being migrated off V1. Always query them on V2**, even
+though the V1 schema still accepts them.
+
+**Root names carry the version.** V1 roots are lowercase — `ethereum(`, `tron(`, `solana(`,
+`bitcoin(`. V2 roots are capitalised — `EVM(`, `Tron(`, `Solana(`, `Trading`. If you see a
+lowercase root, it is a V1 document and belongs on the V1 endpoint.
+
+**Streaming is a V2 feature.** V1's schema does expose a subscription root, but only
+`ethereum(network: ...)`, and there is no documented V1 WebSocket endpoint — use V2 for
+anything live. Chains that exist only on V1 and are not in the V1 EVM family — Bitcoin and its
+relatives, Cardano, Ripple, Stellar, Algorand — have no GraphQL stream at all.
 
 ---
 

--- a/docs/start/starter-queries.md
+++ b/docs/start/starter-queries.md
@@ -1199,19 +1199,17 @@ Stream every stop-loss and take-profit placement as it happens.
 
 ▶️ [Phoenix Perps Fills by Trader Wallet - Solana](https://ide.bitquery.io/sol_perps_filled_orders_by_signer)
 
-#### Whale Trades on Solana Perps (Phoenix)
-
-Positive = received, negative = paid. Replace the field list with `total: sum(of: Position_Funding)` for the net carry cost of holding their positions.
-
-▶️ [Whale Trades on Solana Perps (Phoenix)](https://ide.bitquery.io/solana-perps-whale-trades)
-
-### Other venues
-
 #### Trader Realized PnL on Solana Perps
 
 Rows with `Size: 0` are markets they've fully closed — drop them and the rest is the live book, with entry prices.
 
 ▶️ [Trader Realized PnL on Solana Perps](https://ide.bitquery.io/solana-perps-trader-pnl)
+
+#### Whale Trades on Solana Perps (Phoenix)
+
+Positive = received, negative = paid. Replace the field list with `total: sum(of: Position_Funding)` for the net carry cost of holding their positions.
+
+▶️ [Whale Trades on Solana Perps (Phoenix)](https://ide.bitquery.io/solana-perps-whale-trades)
 
 #### Solana Perps OHLC Candles from Mark Price
 

--- a/docs/start/starter-queries.md
+++ b/docs/start/starter-queries.md
@@ -16,18 +16,21 @@ Every query below is saved in the [Bitquery IDE](https://ide.bitquery.io) and wa
 
 ## Table of Contents
 
-- [Ethereum](#ethereum)
+- [Bitcoin](#bitcoin)
 - [Solana](#solana)
+- [Robinhood Chain](#robinhood-chain)
+- [Polymarket](#polymarket)
+- [Perpetuals](#perpetuals)
+- [TRON](#tron)
+- [Cross-Chain](#cross-chain)
+- [Ethereum](#ethereum)
 - [BSC](#bsc)
 - [Base](#base)
 - [Arbitrum](#arbitrum)
 - [Optimism](#optimism)
 - [Polygon](#polygon)
-- [TRON](#tron)
-- [Robinhood Chain](#robinhood-chain)
 - [Avalanche](#avalanche)
 - [Celo](#celo)
-- [Bitcoin](#bitcoin)
 - [Litecoin](#litecoin)
 - [Bitcoin Cash](#bitcoin-cash)
 - [Dogecoin](#dogecoin)
@@ -38,12 +41,1429 @@ Every query below is saved in the [Bitquery IDE](https://ide.bitquery.io) and wa
 - [Algorand](#algorand)
 - [Trading API](#trading-api)
 - [Stablecoins](#stablecoins)
-- [Perpetuals](#perpetuals)
 - [NFTs](#nfts)
-- [Polymarket](#polymarket)
 - [Futures DEXs](#futures-dexs)
 - [x402](#x402)
-- [Cross-Chain](#cross-chain)
+
+## Bitcoin
+
+### Transfers
+
+#### Inflows and Outflows of a wallet
+
+This API returns all incoming and outgoing transactions for a specific Bitcoin wallet address.
+
+▶️ [Inflows and Outflows of a wallet](https://ide.bitquery.io/Inflows-and-Outflow-of-a-bitcoin-wallet)
+
+### Balances & Holders
+
+#### Balance of an address at a past date
+
+What one Bitcoin address held as of a chosen date. Move the date in the Variables pane.
+
+▶️ [Balance of an address at a past date](https://ide.bitquery.io/Bitcoin-Balance-of-an-address-at-a-past-date)
+
+#### Bitcoin Balance for multiple addresses
+
+This query calculates the combined balance of multiple Bitcoin wallet addresses by summing their total inflows and outflows: Balance = Total Output - Total Input. You can also set a date to get balances as of a specific point in time.
+
+▶️ [Bitcoin Balance for multiple addresses](https://ide.bitquery.io/BTC-balance-api-for-multiple-addresses)
+
+#### BTC balance api for multiple addresses
+
+Pass an array of addresses to `inputAddress` and `outputAddress` with `{in: [...]}` to get per-wallet totals in a single request. Useful for exchanges, custodians, and portfolio dashboards that monitor many wallets at once.
+
+▶️ [BTC balance api for multiple addresses](https://ide.bitquery.io/BTC-balance-API-for-multiple-addresses)
+
+#### Bitcoin balance
+
+Returns total BTC sent (inputs) and received (outputs) for an address, along with USD-equivalent values and first / last activity dates. Subtract `inputs.value` from `outputs.value` to get the current balance.
+
+▶️ [Bitcoin balance](https://ide.bitquery.io/Bitcoin-balance_5)
+
+#### Bitcoin balance at a given height
+
+Need to know what a wallet held at a particular point in time? The `height` filter caps inputs and outputs at a given block number, which is exactly what you need for audits, tax reporting, and point-in-time portfolio snapshots.
+
+▶️ [Bitcoin balance at a given height](https://ide.bitquery.io/bitcoin-balance-at-a-given-height)
+
+#### Bitcoin balance on a given block height
+
+Sum outputs and subtract inputs with a `height: {lteq: N}` cap to get the wallet's balance at a specific point on-chain. Useful for audits, tax snapshots, and point-in-time portfolio reporting.
+
+▶️ [Bitcoin balance on a given block height](https://ide.bitquery.io/bitcoin-balance-on-a-given-block-height)
+
+### Price & OHLC
+
+#### Btc price in 2016
+
+Pulls the BTC/USD price implied by any output on a given date — Bitquery stores the spot value at the time of each transaction, so you can derive a historical price by dividing USD value by BTC value.
+
+▶️ [Btc price in 2016](https://ide.bitquery.io/btc-price-in-2016)
+
+### Transactions
+
+#### Details of Bitcoin Transaction
+
+This API provides comprehensive details of a specific Bitcoin transaction in a single query.
+
+▶️ [Details of Bitcoin Transaction](https://ide.bitquery.io/Details-of-Bitcoin-Transaction)
+
+### Blocks & Validators
+
+#### Bitcoin miners rewards
+
+Mining rewards live in coinbase outputs (the first transaction in every block, `txIndex: 0`) with `outputDirection: mining`.
+
+▶️ [Bitcoin miners rewards](https://ide.bitquery.io/bitcoin-miners-rewards)
+
+#### Get miners activity in a specific timeframe
+
+Pulls the activity count per miner address inside a date range. Drop or extend the date window to size the cohort however you need.
+
+▶️ [Get miners activity in a specific timeframe](https://ide.bitquery.io/get-miners-activity-in-a-specific-timeframe)
+
+#### Get miners first activity
+
+For a specific set of miner addresses, this query returns the first block each one mined. Useful for cohort analysis, miner onboarding studies, or building "first seen" timelines.
+
+▶️ [Get miners first activity](https://ide.bitquery.io/get-miners-first-activity)
+
+## Solana
+
+### Trades
+
+#### Get Swaps by Pair Address
+
+Get all trades related transactions for a specific pair address. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Get Swaps by Pair Address](https://ide.bitquery.io/swaps-for-a-market-address-on-Solana)
+
+#### Get Trades by Wallet Address
+
+Get all trades related transactions (buy, sell) for a specific wallet address. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Get Trades by Wallet Address](https://ide.bitquery.io/Solana-dextrades-by-a-trader_2)
+
+#### Get Volume Stats for Solana Chain — historical (beyond 30 days)
+
+Returns volume statistics, active wallets, and total transactions for Solana. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get Volume Stats for Solana Chain — historical (beyond 30 days)](https://ide.bitquery.io/Chain-stats-like-total-volume-traded-total-transactions-active-wallets_1)
+
+#### Get Multiple Token Analytics — historical (beyond 30 days)
+
+Returns analytics data for multiple token addresses. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get Multiple Token Analytics — historical (beyond 30 days)](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-multiple-solana-tokens)
+
+#### Get Token Metadata — historical (beyond 30 days)
+
+Get the token metadata for contract (mint, standard, name, symbol). Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get Token Metadata — historical (beyond 30 days)](https://ide.bitquery.io/Solana-currency-details)
+
+#### Get Token Pair Stats — historical (beyond 30 days)
+
+Get the pair stats by using pair address. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get Token Pair Stats — historical (beyond 30 days)](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-solana-token-pair)
+
+#### Get Token Pairs by Address — historical (beyond 30 days)
+
+Get the supported pairs for a specific token address. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get Token Pairs by Address — historical (beyond 30 days)](https://ide.bitquery.io/traded-pairs-of-a-token_2)
+
+#### Realised PnL, avg buy price, buy volume, sell volume of a Trader for specific token — historical (beyond 30 days)
+
+Get realised PnL, average buy price, buy volume, and sell volume for a token on Solana of a trader for over a time window. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Realised PnL, avg buy price, buy volume, sell volume of a Trader for specific token — historical (beyond 30 days)](https://ide.bitquery.io/Realised-Pnl-avg-buy-price-Buy-volume-Sell-Volume-Solana_2)
+
+#### Search tokens by name, symbol, mint address — historical (beyond 30 days)
+
+Search for tokens based on contract address, token name or token symbol. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Search tokens by name, symbol, mint address — historical (beyond 30 days)](https://ide.bitquery.io/Token-Search-API---trump-symbol)
+
+#### Buys Sells BuyVolume SellVolume Makers TotalTradedVolume PriceinUSD for solana token pair — historical (beyond 30 days)
+
+Returns the essential stats for a token such as buy volume, sell volume, total buys, total sells, makers, total trade volume, buyers, sellers (in last 5 min, 1 hour) of a specific token. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Buys Sells BuyVolume SellVolume Makers TotalTradedVolume PriceinUSD for solana token pair — historical (beyond 30 days)](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-solana-token-pair00_2)
+
+### Transfers
+
+#### Simple SOL transfers (Transactions not trades)
+
+This API returns simple SOL transfers; in other words, it contains transactions that are simple token transfers, not trades.
+
+▶️ [Simple SOL transfers (Transactions not trades)](https://ide.bitquery.io/Simple-SOL-transfers-Transactions-not-trades)
+
+#### Solana Token Transfers for a Specific Address
+
+This API retrieves the history of token transfers (both sent and received) for a specific Solana address within a defined time period.
+
+▶️ [Solana Token Transfers for a Specific Address](https://ide.bitquery.io/Solana-historical-token-transfers-of-an-address-between-a-time)
+
+#### Solana Transfers
+
+This query gets the latest 10 transfers on Solana. You can increase the limit to get more transfers. This query only uses real-time data.
+
+▶️ [Solana Transfers](https://ide.bitquery.io/Solana-transfers0_5)
+
+#### Solana Historical Transfers
+
+Solana Historical Transfers.
+
+▶️ [Solana Historical Transfers](https://ide.bitquery.io/solana-historical-transfers_1)
+
+#### Currency with elon inclusion
+
+You can search tokens on Solana using names or symbols case insensitively also using our APIs and get prices and other details.
+
+▶️ [Currency with elon inclusion](https://ide.bitquery.io/Currency-with-elon-inclusion)
+
+#### Solana token transfers of Bags fm tokens
+
+Track all transfers of Bags FM tokens across wallets. This Bags FM token transfers endpoint provides complete transfer history. 🔗.
+
+▶️ [Solana token transfers of Bags fm tokens](https://ide.bitquery.io/Solana-token-transfers-of-Bags-fm-tokens)
+
+#### Total txn fees paid by the Account
+
+Get the total fees (in SOL and USD) paid by a specific Solana account across all transfers.
+
+▶️ [Total txn fees paid by the Account](https://ide.bitquery.io/total-txn-fees-paid-by-the-Account)
+
+#### Transaction fees paid by Account aggregated by currency
+
+Get total fees paid by a Solana account for transferring each type of token.
+
+▶️ [Transaction fees paid by Account aggregated by currency](https://ide.bitquery.io/Transaction-fees-paid-by-Account-aggregated-by-currency)
+
+#### Transfers of a wallet
+
+Fetches the recent 10 transfers of a specific wallet address `9nnLbotNTcUhvbrsA6Mdkx45Sm82G35zo28AqUvjExn8`.
+
+▶️ [Transfers of a wallet](https://ide.bitquery.io/Transfers-of-a-wallet_1)
+
+#### Wallet transfers with transaction fees paid
+
+Track wallet token transfers and get the fees paid for each by the address.
+
+▶️ [Wallet transfers with transaction fees paid](https://ide.bitquery.io/wallet-transfers-with-transaction-fees-paid)
+
+### Balances & Holders
+
+#### Solana Instruction Balance Updates
+
+This query returns Solana balance update info for any balance update event, including the address, amount, currency details, and the details of the program responsible for this update.
+
+▶️ [Solana Instruction Balance Updates](https://ide.bitquery.io/Solana-InstructionBalanceUpdates)
+
+#### Balance updates
+
+Returns balance update associated with a instruction invocation.
+
+▶️ [Balance updates](https://ide.bitquery.io/balance-updates)
+
+#### Solana balance updates executing burn instruction
+
+The query below uses the InstructionBalanceUpdates API to fetch balance updates that occur when token burn instructions execute.
+
+▶️ [Solana balance updates executing burn instruction](https://ide.bitquery.io/solana-balance-updates-executing-burn-instruction)
+
+#### Trades of wallets with balance Updates in that trades
+
+Below query will give you the trades of the wallets present in `addressList` along with the balance updates happened in those trades..
+
+▶️ [Trades of wallets with balance Updates in that trades](https://ide.bitquery.io/Trades-of-wallets-with-balance-Updates-in-that-trades)
+
+### Price & OHLC
+
+#### Token price from top market (rank 1)
+
+Prices SOL from its single top market rather than blending every pool — the recommended way to price one specific token. Replace `token` in the Variables pane, lowercase.
+
+▶️ [Token price from top market (rank 1)](https://ide.bitquery.io/Solana-Token-price-from-top-market-rank-1)
+
+#### Get OHLCV by Pair Address
+
+You can get charting data easily with this query. Adjust the intervals as necessary. This query supports historical data. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Get OHLCV by Pair Address](https://ide.bitquery.io/OHLC-for-a-token_8)
+
+#### Get Latest Price of a Token in USD
+
+Get Latest Price of a Token in USD. Uses the `Pairs` cube. Replace the address in the `where` clause to use it. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Get Latest Price of a Token in USD](https://ide.bitquery.io/Pumpfun-token-latest-price-USD)
+
+#### Historical Price and Volume Data (Volume & Price, Last 24h using Trading API)
+
+Use this API to get historical price and volume for a specific token over the past 24 hours. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Historical Price and Volume Data (Volume & Price, Last 24h using Trading API)](https://ide.bitquery.io/24h-historical-price-and-historical-volume-on-Solana)
+
+#### Get Token Prices on Solana — historical (beyond 30 days)
+
+Returns price information for multiple Solana tokens in a single request. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get Token Prices on Solana — historical (beyond 30 days)](https://ide.bitquery.io/Get-multiple-Token-Prices)
+
+#### Price change 5min, 1hr, 6hr precentage of a specific token — historical (beyond 30 days)
+
+With this, you can get the price change 5min, 1hr, 6hr precentage of a specific token. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Price change 5min, 1hr, 6hr precentage of a specific token — historical (beyond 30 days)](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_5)
+
+#### Top 10 solana tokens by price change in last 1 hr — historical (beyond 30 days)
+
+With this, you can get top 10 solana tokens by price change in last 1 hr. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Top 10 solana tokens by price change in last 1 hr — historical (beyond 30 days)](https://ide.bitquery.io/Top-10-solana-tokens-by-price-change-in-last-1-hr_4)
+
+#### ATH of multiple tokens quantile Solana — historical (beyond 30 days)
+
+ATH of multiple tokens quantile Solana. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [ATH of multiple tokens quantile Solana — historical (beyond 30 days)](https://ide.bitquery.io/ATH-of-multiple-tokens-quantile-Solana)
+
+#### ATH with price delta Solana — historical (beyond 30 days)
+
+Fetches a Solana token’s ATH price, ATH date, and price change percentages over the past 24h, 7d, and 30d using Bitquery Solana APIs. Try the. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [ATH with price delta Solana — historical (beyond 30 days)](https://ide.bitquery.io/ATH-with-price-delta-Solana)
+
+#### AldrinAmm OHLC for specific pair — historical (beyond 30 days)
+
+If you want to get OHLC data for any specific currency pair on AldrinAmm, you can use this api. Only use. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [AldrinAmm OHLC for specific pair — historical (beyond 30 days)](https://ide.bitquery.io/AldrinAmm-OHLC-for-specific-pair)
+
+#### Get Latest Price of Apple xStock in USD Real-time — historical (beyond 30 days)
+
+You can use the following query to get the latest price of a Apple xStock on Solana. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get Latest Price of Apple xStock in USD Real-time — historical (beyond 30 days)](https://ide.bitquery.io/Get-Latest-Price-of-Apple-xStock-in--USD-Real-time)
+
+### Supply & Market Cap
+
+#### Sandisk - Backpack Securities MCAP
+
+See the Pairs cube for full field reference. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Sandisk - Backpack Securities MCAP](https://ide.bitquery.io/Sandisk---Backpack-Securities-MCAP)
+
+#### Top Tokens by Market Cap on solana
+
+Ranks tokens on Solana by `Supply.MarketCap`, with 24h window, 1s interval, $1,000+ USD volume, `limitBy` per `Token_Id`, up to 50 rows. `Token.Network` is Solana. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Top Tokens by Market Cap on solana](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-solana)
+
+#### Bags.fm token creation using Solana token supply updates
+
+Bags.fm token creation using Solana token supply updates. Uses the `TokenSupplyUpdates` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Bags.fm token creation using Solana token supply updates](https://ide.bitquery.io/Bagsfm-token-creation-using-Solana-token-supply-updates)
+
+#### Market cap of token
+
+You can fetch Marketcap of a token using below query.
+
+▶️ [Market cap of token](https://ide.bitquery.io/market-cap-of-token_1)
+
+#### Token burn example solana
+
+You can also track real-time token burn using the TokenSupplyUpdates API. Check out the.
+
+▶️ [Token burn example solana](https://ide.bitquery.io/token-burn-example-solana)
+
+#### Token supply
+
+Will return the latest token supply of a specific token. We are getting here supply for this `6D7NaB2xsLd7cauWu1wKk6KBsJohJmP2qZH9GEfVi5Ui` token `PostBalance` will give you the current supply for this token.
+
+▶️ [Token supply](https://ide.bitquery.io/token-supply_2)
+
+#### Tokens with market cap range
+
+Lets say we need to get the tokens whose marketcap has crossed the `1M USD` mark but is less than `2M USD` for various reasons like automated trading. We can get the token details that have crossed a particular marketcap using.
+
+▶️ [Tokens with market cap range](https://ide.bitquery.io/tokens-with-market-cap-range)
+
+#### Top 10 marketcap jump tokens in last 1hr
+
+Use below query to get top 10 marketcap jump tokens in last 1hr.
+
+▶️ [Top 10 marketcap jump tokens in last 1hr](https://ide.bitquery.io/top-10-marketcap-jump-tokens-in-last-1hr)
+
+#### Top Solana tokens based on market cap
+
+Top Solana tokens based on market cap. Uses the `TokenSupplyUpdates` cube.
+
+▶️ [Top Solana tokens based on market cap](https://ide.bitquery.io/top-Solana-tokens-based-on-market-cap)
+
+#### Marketcap of tokens — historical (beyond 30 days)
+
+Returns the ATH (All-Time High) market cap, starting market cap, and related price metrics for multiple tokens. It calculates market cap using a 1 billion token supply and uses quantile to find the ATH price. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Marketcap of tokens — historical (beyond 30 days)](https://ide.bitquery.io/Marketcap-of-tokens)
+
+### Liquidity & Pools
+
+#### All Token Pairs Across DEXs with Current Liquidity
+
+This query retrieves all instances of a specific token pair across decentralized exchanges (DEXs) on Solana, along with their current liquidity.
+
+▶️ [All Token Pairs Across DEXs with Current Liquidity](https://ide.bitquery.io/All-Liquidity-pairs-of-a-token-and-current-liquidity-on-solana)
+
+#### Latest Pools Created on Launchpad
+
+This query returns the latest created pools on Raydium launchpad. You can set the limit here also.
+
+▶️ [Latest Pools Created on Launchpad](https://ide.bitquery.io/Launchpad-latest-pool-created)
+
+#### Liquidity of All Pools of a Token on Solana
+
+Get latest liquidity snapshots for all pools where a token is either base or quote currency.
+
+▶️ [Liquidity of All Pools of a Token on Solana](https://ide.bitquery.io/liqidity-of-all-pools-of-a-token)
+
+#### Solana Pool Liquidity Changes
+
+This query retrieves the latest changes to liquidity pools on Solana, including the change amount and the price at which the change happened. This query also uses only the real-time data set.
+
+▶️ [Solana Pool Liquidity Changes](https://ide.bitquery.io/Solana-DEXPools)
+
+#### All liquidity add instructions track on Solana
+
+Tracks liquidity addition events on Solana DEX pools by monitoring specific instructions.
+
+▶️ [All liquidity add instructions track on Solana](https://ide.bitquery.io/All-liquidity-add-instructions-track-on-Solana)
+
+#### CPMM pools created
+
+The mint addresses for the tokens being used in the pool are listed for example `tokenMint1` and `tokenMint0` , indicating which tokens the CPMM will support.
+
+▶️ [CPMM pools created](https://ide.bitquery.io/CPMM-pools-created_1)
+
+#### Get LP Latest liqudity on Solana
+
+Get LP Latest liqudity on Solana. Uses the `DEXPools` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Get LP Latest liqudity on Solana](https://ide.bitquery.io/Get-LP-Latest-liqudity-on-Solana)
+
+#### Get all the liquidity pools info for a particular token
+
+Will give the information on all the liquidity pools of a particular token `EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm`.
+
+▶️ [Get all the liquidity pools info for a particular token](https://ide.bitquery.io/get-all-the-liquidity-pools-info-for-a-particular-token_1)
+
+#### Liquidity change in recent month
+
+Liquidity change in recent month. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Liquidity change in recent month](https://ide.bitquery.io/liquidity-change-in-recent-month)
+
+#### Liquidity lock using instructions balance update
+
+Using the below query, you can retrieve latest liquidity locks made using streamflow.
+
+▶️ [Liquidity lock using instructions balance update](https://ide.bitquery.io/Liquidity-lock-using-instructions-balance-update)
+
+### Events & Calls
+
+#### Not Anchor Error Solana Logs
+
+To exclude instructions containing specific log phrases such as 'AnchorError' you can use the `notLike` filter.
+
+▶️ [Not Anchor Error Solana Logs](https://ide.bitquery.io/Not-Anchor-Error-Solana-Logs)
+
+#### Solana Zeta Market logs
+
+If you need to filter out the instructions from Solana logs that involve a particular exchange but you don’t have any information, like address and protocol, then you can use the “includes” keyword on Logs.
+
+▶️ [Solana Zeta Market logs](https://ide.bitquery.io/Solana-Zeta-Market-logs)
+
+### Pump.fun
+
+#### Top 10 pump fun tokens by Marketcap change in last 5mins
+
+This query returns the top 10 pump fun tokens by Marketcap change in last 5mins. You can increase the limit to get more tokens.
+
+▶️ [Top 10 pump fun tokens by Marketcap change in last 5mins](https://ide.bitquery.io/Top-10-pump-fun-tokens-by-Marketcap-change-in-last-5mins_1)
+
+#### Top PumpFun Tokens by Marketcap
+
+This query returns the top 10 PumpFun tokens based on market cap. You can increase the limit to get more tokens.
+
+▶️ [Top PumpFun Tokens by Marketcap](https://ide.bitquery.io/top-tokens-by-mktcap-on-pump-fun-in-last-15-min)
+
+#### Get Bonding Curve Progress of a Token on Pump Fun
+
+Returns Bonding Curve Percentage of a Token on the Pump Fun.
+
+▶️ [Get Bonding Curve Progress of a Token on Pump Fun](https://ide.bitquery.io/get-the-bonding-curve-progress-percentage_1)
+
+#### ATH Market Cap of Pump Fun Tokens in a Specific Timeframe
+
+Use Bitquery's `DEXTradeByTokens` with `dataset: combined`, `Trade.PriceInUSD(maximum: Trade_PriceInUSD)`, and `quantile(of: Trade_PriceInUSD, level: 0.98)` to get ATH price. Market cap = ATH price × 1 billion (Pump.fun tokens have 1B supply).
+
+▶️ [ATH Market Cap of Pump Fun Tokens in a Specific Timeframe](https://ide.bitquery.io/ATH-Market-Cap-of-Pump-Fun-Tokens-in-a-Specific-Timeframe)
+
+#### All tokens traded on Pump.fun in the last 1 hour
+
+To get all tokens traded on Pump.fun in the last 1 hour, use a query that filters trades by the Pump.fun protocol and a block time within the past hour.
+
+▶️ [All tokens traded on Pump.fun in the last 1 hour](https://ide.bitquery.io/all-tokens-traded-on-Pumpfun-in-the-last-1-hour_1)
+
+#### How do I get tokens that reached a specific market cap on Pump.fun?
+
+To find tokens on Pump.fun that have reached a specific market capitalization threshold, you can use the following Bitquery GraphQL example.
+
+▶️ [How do I get tokens that reached a specific market cap on Pump.fun?](https://ide.bitquery.io/How-do-I-get-tokens-that-reached-a-specific-market-cap-on-Pumpfun)
+
+### Meteora
+
+#### Get the Top Traders of a specific Token on Meteora DAMM v2 DEX
+
+The below query gets the Top Traders of the specified Token on Meteora DAMM v2. This provides insights into the most active traders and their trading patterns.
+
+▶️ [Get the Top Traders of a specific Token on Meteora DAMM v2 DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DAMM-v2-DEX_1)
+
+#### Get the Top Traders of a specific Token on Meteora DLMM DEX
+
+The below query gets the Top Traders of the specified Token on Meteora DLMM. This provides insights into the most active traders and their trading patterns.
+
+▶️ [Get the Top Traders of a specific Token on Meteora DLMM DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DLMM-DEX)
+
+#### Get the Top Traders of a specific Token on Meteora DYN DEX
+
+The below query gets the Top Traders of the specified Token `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` on Meteora DYN.
+
+▶️ [Get the Top Traders of a specific Token on Meteora DYN DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DYN-DEX)
+
+#### Meteora DAMM v2 OHLC API
+
+If you want to get OHLC (Open, High, Low, Close) data for any specific currency pair on Meteora DAMM v2, you can use this API. This provides technical analysis data for charting and trading strategies.
+
+▶️ [Meteora DAMM v2 OHLC API](https://ide.bitquery.io/Meteora-DAMM-v2-OHLC-API)
+
+#### Meteora DLMM OHLC API
+
+If you want to get OHLC (Open, High, Low, Close) data for any specific currency pair on Meteora DLMM, you can use this API. This provides technical analysis data for charting and trading strategies.
+
+▶️ [Meteora DLMM OHLC API](https://ide.bitquery.io/Meteora-DLMM-OHLC-API)
+
+#### Meteora DYN OHLC API
+
+If you want to get OHLC data for any specific currency pair on Meteora DYN, you can use this api. Only use.
+
+▶️ [Meteora DYN OHLC API](https://ide.bitquery.io/Meteora-DYN-OHLC-API)
+
+### Raydium
+
+#### Top 100 About to Graduate Raydium Launchpad Tokens
+
+Returns top 100 About to Graduate Raydium Launchpadn Tokens.
+
+▶️ [Top 100 About to Graduate Raydium Launchpad Tokens](https://ide.bitquery.io/Top-100-graduating-raydium-launchlab-tokens-in-last-5-minutes)
+
+#### Historical PumpFun Migrated Token on Raydium and Pumpswap.
+
+Historical PumpFun Migrated Token on Raydium and Pumpswap. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Historical PumpFun Migrated Token on Raydium and Pumpswap.](https://ide.bitquery.io/all-pumpfun-migrated-token-query_4)
+
+#### Get Bonding Curve Progress of a Raydium Launchpad Token
+
+Returns Bonding Curve Percentage of a Raydium Launchpad Token.
+
+▶️ [Get Bonding Curve Progress of a Raydium Launchpad Token](https://ide.bitquery.io/bonding-curve-progress-percentage-of-a-letsbonkfun-token)
+
+#### Latest Price of a Token on Raydium Launchpad
+
+This query returns the latest price of a token on the Raydium launchpad.
+
+▶️ [Latest Price of a Token on Raydium Launchpad](https://ide.bitquery.io/Latest-Price-of-a-Token-on-Launchpad)
+
+#### Latest Trades for a specific currency on Raydium
+
+This query returns the latest trades for a token on Raydium. You can set the limit here also.
+
+▶️ [Latest Trades for a specific currency on Raydium](https://ide.bitquery.io/Trades-for-a-token-on-Raydium-on-Solana)
+
+#### DecreaseLiquidityV2 latest raydium clmm
+
+DecreaseLiquidityV2 latest raydium clmm. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+
+▶️ [DecreaseLiquidityV2 latest raydium clmm](https://ide.bitquery.io/decreaseLiquidityV2-latest-raydium-clmm_1)
+
+### LetsBonk.fun
+
+#### Latest Price of a LetsBonk.fun Token on Launchpad
+
+Provides the most recent price data for a specific LetsBonk.fun token `token Mint Address` launched on Raydium Launchpad. You can filter by the token’s `MintAddress`, and the query will return the last recorded trade price.
+
+▶️ [Latest Price of a LetsBonk.fun Token on Launchpad](https://ide.bitquery.io/Latest-Price-of-a-LetsBonkfun-Token-on-Launchpad)
+
+#### Latest Trades of a letsbonk.fun token on Launchpad
+
+Fetches the most recent trades of a LetsBonk.fun Token `token Mint Address` on the Raydium Launchpad. Run the query.
+
+▶️ [Latest Trades of a letsbonk.fun token on Launchpad](https://ide.bitquery.io/Latest-Trades-of-a-letsbonkfun-token-on-Launchpad)
+
+#### Liquidity for a Letsbonk.fun token pair
+
+Liquidity for a Letsbonk.fun token pair. Uses the `DEXPools` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Liquidity for a Letsbonk.fun token pair](https://ide.bitquery.io/liquidity-for-a-Letsbonkfun-token-pair_2)
+
+#### Ohlc for letsbonk.fun token
+
+Ohlc for letsbonk.fun token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Ohlc for letsbonk.fun token](https://ide.bitquery.io/ohlc-for-letsbonkfun-token)
+
+#### Pool address for letsbonk.fun token
+
+Pool address for letsbonk.fun token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Pool address for letsbonk.fun token](https://ide.bitquery.io/pool-address-for-letsbonkfun-token_1)
+
+#### Top buyers of a letsbonk.fun token on launchpad
+
+Top buyers of a letsbonk.fun token on launchpad. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top buyers of a letsbonk.fun token on launchpad](https://ide.bitquery.io/top-buyers-of-a-letsbonkfun-token-on-launchpad)
+
+## Robinhood Chain
+
+### Trades
+
+#### Largest Trades on Robinhood Chain (24h, USD)
+
+Largest Trades on Robinhood Chain (24h, USD). Uses the `Trades` cube.
+
+▶️ [Largest Trades on Robinhood Chain (24h, USD)](https://ide.bitquery.io/largest-swaps-robinhood-chain)
+
+#### Pools trade Latest trades for a token
+
+Tokens also migrate onto other venues once liquid — the same token can show `uniswap_v3` and `pancake_swap_v3` markets with `WETH` and `USDG` quotes.
+
+▶️ [Pools trade Latest trades for a token](https://ide.bitquery.io/Pools-trade-Latest-trades-for-a-token)
+
+#### Pools trade Top tokens by volume
+
+The two-step pattern: pass a token set harvested from `TokenCreated` into the `Trading` cube.
+
+▶️ [Pools trade Top tokens by volume](https://ide.bitquery.io/Pools-trade-Top-tokens-by-volume)
+
+#### Pools trade Crowd Launch bids
+
+The launch transaction also contains the token's mint, the entry contract's `TokenCreated`, and the auction's first `TickInitialized` / `ClearingPriceUpdated` events, so one transaction hash links token, creator, and auction contract.
+
+▶️ [Pools trade Crowd Launch bids](https://ide.bitquery.io/Pools-trade-Crowd-Launch-bids)
+
+#### Pools trade Latest launches
+
+The decoded `TokenCreated` event on the two entry contracts is the cleanest launch feed — one row per launch.
+
+▶️ [Pools trade Latest launches](https://ide.bitquery.io/Pools-trade-Latest-launches)
+
+#### Pools trade Launches per day
+
+Grouping by `LogHeader.Address` too shows the split between the two entry contracts.
+
+▶️ [Pools trade Launches per day](https://ide.bitquery.io/Pools-trade-Launches-per-day)
+
+#### Pools trade Most active token creators
+
+Useful for spotting spam-bot deployers — a single wallet can mint hundreds of tokens a day.
+
+▶️ [Pools trade Most active token creators](https://ide.bitquery.io/Pools-trade-Most-active-token-creators)
+
+#### Pools trade PoolKey from TokenLaunched
+
+Pools trade PoolKey from TokenLaunched. Uses the `Events` cube.
+
+▶️ [Pools trade PoolKey from TokenLaunched](https://ide.bitquery.io/Pools-trade-PoolKey-from-TokenLaunched)
+
+#### Pools trade Token description and image
+
+The filter below pins the factory by address because the entry contract emits a *different* `TokenCreated` under the same name (see Reading decoded arguments).
+
+▶️ [Pools trade Token description and image](https://ide.bitquery.io/Pools-trade-Token-description-and-image)
+
+#### Pools trade TokenDistributed decoded event
+
+Topic0 filtering remains available and is the precise way to pin one exact signature — useful for the overloaded `TokenCreated` above. Supply the hash without a `0x` prefix; see the dataset note below for its one limitation.
+
+▶️ [Pools trade TokenDistributed decoded event](https://ide.bitquery.io/Pools-trade-raw-event-by-topic0)
+
+### Transfers
+
+#### Ape.store Newly created tokens
+
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
+
+▶️ [Ape.store Newly created tokens](https://ide.bitquery.io/Apestore-Newly-created-tokens)
+
+#### Bags.fm Newly created tokens
+
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
+
+▶️ [Bags.fm Newly created tokens](https://ide.bitquery.io/Bagsfm-Newly-created-tokens)
+
+#### Bankr Bot Newly created tokens
+
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
+
+▶️ [Bankr Bot Newly created tokens](https://ide.bitquery.io/Bankr-Bot-Newly-created-tokens)
+
+#### Flap.sh Newly created tokens using transfer data
+
+Track Flap.sh mints as transfers from the zero address with amount `1000000000` in transactions sent to the Flap.sh contract.
+
+▶️ [Flap.sh Newly created tokens using transfer data](https://ide.bitquery.io/Flapsh-Newly-created-tokens-using-transfer-data)
+
+#### Klik Finance Newly created tokens using transfers
+
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
+
+▶️ [Klik Finance Newly created tokens using transfers](https://ide.bitquery.io/Klik-Finance-Newly-created-tokens-using-transfers)
+
+#### Robinhood Chain API - Latest Token Transfers
+
+Robinhood Chain API - Latest Token Transfers. Uses the `Transfers` cube.
+
+▶️ [Robinhood Chain API - Latest Token Transfers](https://ide.bitquery.io/latest-transfers-on-robinhood)
+
+#### Robinhood Chain Token Lookup by Contract Address
+
+Metadata splits across two sources. Name, symbol, decimals, and contract are indexed on every transfer's `Currency` object — one query against the launch mint gives you all four for any token.
+
+▶️ [Robinhood Chain Token Lookup by Contract Address](https://ide.bitquery.io/Pools-trade-Token-name-symbol-decimals)
+
+#### Token Lookup by Contract Address - Robinhood Chain
+
+Follow the steps here: How to generate Bitquery API token ➤.
+
+▶️ [Token Lookup by Contract Address - Robinhood Chain](https://ide.bitquery.io/token-lookup-by-address-robinhood-chain)
+
+#### Transfers for a token on robinhood
+
+Filter with `Transfer.Currency.SmartContract`. Example: WETH on Robinhood.
+
+▶️ [Transfers for a token on robinhood](https://ide.bitquery.io/Transfers-for-a-token-on-robinhood)
+
+#### Transfers for a wallet on Robinhood
+
+Filter where the address is either `Transfer.Sender` or `Transfer.Receiver` to build a full transfer history. Replace the sample address with your wallet or contract.
+
+▶️ [Transfers for a wallet on Robinhood](https://ide.bitquery.io/transfers-for-a-wallet-on-Robinhood)
+
+### Balances & Holders
+
+#### Pools trade Per-transaction balance changes
+
+A stream of this filtered to `SlippageBasisPoints: {gt: 100}` is a ready-made "toxic fill" alert for a token's pool.
+
+▶️ [Pools trade Per-transaction balance changes](https://ide.bitquery.io/Pools-trade-Per-transaction-balance-changes)
+
+#### Wallet Token Balances on Robinhood Chain
+
+Wallet Token Balances on Robinhood Chain. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Wallet Token Balances on Robinhood Chain](https://ide.bitquery.io/wallet-token-balances-robinhood-chain)
+
+### Price & OHLC
+
+#### Latest price of a token on a pool
+
+This API endpoint retrieves the latest price of a token for a particular token pair or liquidity pool using the `Trading.Pairs` cube.
+
+▶️ [Latest price of a token on a pool](https://ide.bitquery.io/latest-price-of-a-token-on-a-pool)
+
+#### Latest price of a token
+
+If you want to monitor price for a particular pool, we suggest usage of `Trading.Pairs` instead of `Trading.Tokens` where you could specify the pool address.
+
+▶️ [Latest price of a token](https://ide.bitquery.io/latest-price-of-a-token_10)
+
+#### Pools trade OHLCV price candles
+
+Deduplicate on `(TransactionHeader.Hash, Block.Time, Side, Amounts.Base, Pair.QuoteToken.Symbol, Trader.Address)` before aggregating.
+
+▶️ [Pools trade OHLCV price candles](https://ide.bitquery.io/Pools-trade-OHLCV-price-candles)
+
+### Supply & Market Cap
+
+#### Pools trade Token holders and supply
+
+Pools trade Token holders and supply. Uses the `Holders` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Pools trade Token holders and supply](https://ide.bitquery.io/Pools-trade-Token-holders-and-supply)
+
+### Liquidity & Pools
+
+#### Pools trade Per-swap slippage
+
+Pools trade Per-swap slippage.
+
+▶️ [Pools trade Per-swap slippage](https://ide.bitquery.io/Pools-trade-Per-swap-slippage)
+
+#### Pools trade Pool creation Initialize
+
+The v4 PoolManager's `Initialize` is decoded, so you can read the same `PoolKey` without manual decoding — at the cost of having to scope it to a token.
+
+▶️ [Pools trade Pool creation Initialize](https://ide.bitquery.io/Pools-trade-Pool-creation-Initialize)
+
+### Transactions
+
+#### Daily Active Wallets on Robinhood Chain
+
+Daily Active Wallets on Robinhood Chain. Uses the `Transactions` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Daily Active Wallets on Robinhood Chain](https://ide.bitquery.io/robinhood-chain-active-wallets)
+
+#### Robinhood Chain Daily Transaction Count
+
+Robinhood Chain Daily Transaction Count. Uses the `Transactions` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Robinhood Chain Daily Transaction Count](https://ide.bitquery.io/robinhood-chain-daily-transactions)
+
+#### Robinhood Chain Gas Usage and Gas Price
+
+Robinhood Chain Gas Usage and Gas Price. Uses the `Transactions` cube.
+
+▶️ [Robinhood Chain Gas Usage and Gas Price](https://ide.bitquery.io/robinhood-chain-gas-fees)
+
+### Events & Calls
+
+#### All events from Flap.sh
+
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
+
+▶️ [All events from Flap.sh](https://ide.bitquery.io/All-events-from-Flapsh)
+
+#### Flap.sh Newly created tokens using logs TokenCreated
+
+Filter Flap.sh `TokenCreated` events and decode argument values (token address, metadata fields, and related parameters).
+
+▶️ [Flap.sh Newly created tokens using logs TokenCreated](https://ide.bitquery.io/Flapsh-Newly-created-tokens-using-logs-TokenCreated)
+
+#### New Contracts Deployed on Robinhood Chain
+
+To pin one exact ABI variant — or to match an undecoded method — filter the 4-byte selector instead (uppercase hex, no `0x`)
+
+▶️ [New Contracts Deployed on Robinhood Chain](https://ide.bitquery.io/new-contracts-deployed-robinhood-chain)
+
+### Blocks & Validators
+
+#### Robinhood Chain Blocks per Day and Block Time
+
+Robinhood Chain Blocks per Day and Block Time. Uses the `Blocks` cube. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Robinhood Chain Blocks per Day and Block Time](https://ide.bitquery.io/robinhood-chain-block-time)
+
+### Uniswap
+
+#### Uniswap v4 Pools on Robinhood Chain
+
+New Uniswap v4 pools: decoded Initialize events on the PoolManager with currencies, fee tier, tick spacing and hooks.
+
+▶️ [Uniswap v4 Pools on Robinhood Chain](https://ide.bitquery.io/uniswap-v4-pools-on-robinhood-chain)
+
+#### Uniswap v4 Hooks in Use on Robinhood Chain
+
+Uniswap v4 Hooks in Use on Robinhood Chain. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Uniswap v4 Hooks in Use on Robinhood Chain](https://ide.bitquery.io/uniswap-v4-hooks-robinhood-chain)
+
+#### Uniswap v4 Pool Liquidity on Robinhood Chain (pools.trade)
+
+Three realtime cubes carry data traders usually have to compute themselves. All three are realtime-only on Robinhood — `dataset: archive` and `dataset: combined` both error — so use them for live monitoring and persist what you need.
+
+▶️ [Uniswap v4 Pool Liquidity on Robinhood Chain (pools.trade)](https://ide.bitquery.io/Pools-trade-Live-pool-liquidity)
+
+## Polymarket
+
+### Trades
+
+#### Latest Trades
+
+Fetch the most recent prediction market trades with full details, ordered by block time.
+
+▶️ [Latest Trades](https://ide.bitquery.io/latest-prediction-market-trades_8)
+
+#### Total Volume and Yes/No Volume for a Market
+
+Aggregate USD volume for a market over a time window: total volume plus volume per outcome (e.g. Yes/No). Pass the market's outcome token AssetIds in `$marketAssets`.
+
+▶️ [Total Volume and Yes/No Volume for a Market](https://ide.bitquery.io/total-volume-outcome-1-volume-outcome-2-volume-of-a-market_1)
+
+#### Trades for a Specific Trader
+
+Fetch all trades where the given address is either Buyer or Seller. Pass the trader address as the `$trader` variable.
+
+▶️ [Trades for a Specific Trader](https://ide.bitquery.io/Trades-for-a-specific-trader_1)
+
+#### How do I count trades for a specific Polymarket trader?
+
+Use `PredictionTrades` with `any` filter on `Buyer` or `Seller` to return the total trade count for a wallet. Add `ProtocolName: "polymarket"` to restrict to Polymarket only. Replace the address with your target wallet.
+
+▶️ [How do I count trades for a specific Polymarket trader?](https://ide.bitquery.io/How-do-I-count-trades-for-a-specific-Polymarket-trader)
+
+#### How do I get top buyers and sellers on Polymarket by volume?
+
+Use `PredictionTrades` with `limitBy` and `sum(of: Trade_OutcomeTrade_CollateralAmountInUSD)` grouped by Buyer (or Seller) to rank the top 100 wallets by volume over the last 5 days. Useful for leaderboards, whale tracking, and trader analytics.
+
+▶️ [How do I get top buyers and sellers on Polymarket by volume?](https://ide.bitquery.io/How-do-I-get-top-buyers-and-sellers-on-Polymarket-by-volume)
+
+#### Latest prediction market trades
+
+Fetch the most recent prediction market trades with full details, ordered by block time.
+
+▶️ [Latest prediction market trades](https://ide.bitquery.io/latest-prediction-market-trades)
+
+#### Prediction_trades
+
+Prediction_trades.
+
+▶️ [Prediction_trades](https://ide.bitquery.io/prediction_trades)
+
+#### Top 100 markets by volumein last24 hrs
+
+Rank Polymarket markets by buy + sell collateral USD, with buy/sell breakdown, trade count, distinct buyers/sellers, and optional resolution join. Uses `limitBy: Trade_Prediction_Question_Id` so each row is one market.
+
+▶️ [Top 100 markets by volumein last24 hrs](https://ide.bitquery.io/top-100-markets-by-volumein-last24-hrs_1)
+
+#### Top AI markets by volume Polymarket
+
+Returns AI markets (title includes the standalone word " AI ") ranked by USD trading volume in the last 24 hours, with buyer and seller counts. Adjust `time_ago`, `limit`, and the title keyword as needed.
+
+▶️ [Top AI markets by volume Polymarket](https://ide.bitquery.io/Top-AI-markets-by-volume-Polymarket)
+
+#### Top Buyers/Sellers of Bitcoin up down market
+
+Returns the top 10 buyers and top 10 sellers by traded volume in Bitcoin Up or Down markets on Polymarket over the last 24 hours. Results are aggregated by trader address and ordered by `buy_amount` (buyers) or `sell_amount` (sellers).
+
+▶️ [Top Buyers/Sellers of Bitcoin up down market](https://ide.bitquery.io/Top-BuyersSellers-of-Bitcoin-up-down-market)
+
+### Markets
+
+#### Created vs Resolved Count (Last 24 Hours)
+
+Count how many Created and Resolved events occurred in the last 24 hours.
+
+▶️ [Created vs Resolved Count (Last 24 Hours)](https://ide.bitquery.io/last-24-hr-resolution-and-ceated-count_1)
+
+#### Latest Creations + Resolutions
+
+Fetch the most recent creation and resolution events with full details, ordered by block time.
+
+▶️ [Latest Creations + Resolutions](https://ide.bitquery.io/latest-Prediction-managements-resolutions-creations_1)
+
+#### Latest Market Creations
+
+Fetch the most recent Created events (new markets). All possible outcomes per market are in Prediction.Condition.Outcomes.
+
+▶️ [Latest Market Creations](https://ide.bitquery.io/latest-polymarket-creations_1)
+
+#### Latest Market Resolutions
+
+Query that returns the 10 most recent Resolved events. Winning outcome is in Prediction.Outcome; Prediction.OutcomeToken holds the asset ID and contract details.
+
+▶️ [Latest Market Resolutions](https://ide.bitquery.io/latest-polymarket-resolutions_2)
+
+#### Latest Prediction managements (resolutions, creations)
+
+Fetch the most recent creation and resolution events with full details, ordered by block time.
+
+▶️ [Latest Prediction managements (resolutions, creations)](https://ide.bitquery.io/latest-Prediction-managements-resolutions-creations)
+
+#### Latest polymarket creations
+
+Fetch the most recent Created events. For each market, all possible outcomes are listed under Prediction.Condition.Outcomes.
+
+▶️ [Latest polymarket creations](https://ide.bitquery.io/latest-polymarket-creations)
+
+#### Latest polymarket resolutions
+
+Latest polymarket resolutions.
+
+▶️ [Latest polymarket resolutions](https://ide.bitquery.io/latest-polymarket-resolutions_1)
+
+#### Latest resolved crudeoil markets
+
+Returns the 10 most recent Resolved events for Polymarket Crude Oil markets.
+
+▶️ [Latest resolved crudeoil markets](https://ide.bitquery.io/latest-resolved-crudeoil-markets)
+
+#### Latest resolved sports markets
+
+Returns the 10 most recent Resolved sports markets (management description includes `"sports"`), including the resolved/winning Outcome and full question metadata. Use this to grade results and settle bets.
+
+▶️ [Latest resolved sports markets](https://ide.bitquery.io/Latest-resolved-sports-markets)
+
+#### Query latest created resolved prediction markets for Bitcoin
+
+Query latest created resolved prediction markets for Bitcoin.
+
+▶️ [Query latest created resolved prediction markets for Bitcoin](https://ide.bitquery.io/Query-latest-created-resolved-prediction-markets-for-Bitcoin)
+
+### Settlements
+
+#### Latest Settlements
+
+Fetch the most recent settlements with full details, ordered by block time.
+
+▶️ [Latest Settlements](https://ide.bitquery.io/latest-prediction-market-settlements_3)
+
+#### Latest Whale Settlements
+
+Find the most recent high-value redemptions (e.g. amount ≥ 10,000 in outcome token units). Useful for tracking large payouts and whale activity.
+
+▶️ [Latest Whale Settlements](https://ide.bitquery.io/latest-whale-settlements-on-prediction-market_3)
+
+#### Redemption / Merge / Split Count (Last 1 Hour)
+
+Count how many settlement events occurred in the last hour, grouped by event signature (Split, Merge, Redemption).
+
+▶️ [Redemption / Merge / Split Count (Last 1 Hour)](https://ide.bitquery.io/redemptions-merge-split-count-in-last-1-hour_1)
+
+#### Top 10 Market Questions by Redeemed Amount (Last 1 Hour)
+
+Aggregate redemptions by market question and sort by total redeemed amount. See which markets had the most payout activity recently.
+
+▶️ [Top 10 Market Questions by Redeemed Amount (Last 1 Hour)](https://ide.bitquery.io/top-10-market-questions-in-last-1-hour_3)
+
+#### Top 10 Redeemers (Last 1 Hour)
+
+Rank addresses by total amount redeemed in the last hour across all markets. Useful for leaderboards and whale tracking.
+
+▶️ [Top 10 Redeemers (Last 1 Hour)](https://ide.bitquery.io/top-10-redeemers_1)
+
+#### Top 10 Winners of a Specific Market Question
+
+Rank holders by total redeemed amount for one market (filter by question title).
+
+▶️ [Top 10 Winners of a Specific Market Question](https://ide.bitquery.io/top-10-winners-of-a-market-question_2)
+
+#### Latest prediction market settlements
+
+Fetch the most recent settlements with full details, ordered by block time.
+
+▶️ [Latest prediction market settlements](https://ide.bitquery.io/latest-prediction-market-settlements_2)
+
+#### Latest whale settlements on prediction market
+
+Find the most recent high-value redemptions (e.g. amount ≥ 10,000 USD). Useful for tracking large payouts and whale activity.
+
+▶️ [Latest whale settlements on prediction market](https://ide.bitquery.io/latest-whale-settlements-on-prediction-market_2)
+
+#### Redemptions, merge, split count in last 1 hour
+
+Count how many settlement events occurred in the last hour, grouped by event signature (Split, Merge, Redemption).
+
+▶️ [Redemptions, merge, split count in last 1 hour](https://ide.bitquery.io/redemptions-merge-split-count-in-last-1-hour)
+
+#### Top 10 redeemers
+
+Rank addresses by total amount redeemed in the last hour across all markets. Useful for leaderboards and whale tracking.
+
+▶️ [Top 10 redeemers](https://ide.bitquery.io/top-10-redeemers)
+
+### Transfers
+
+#### Freshwallet check for polymarket
+
+Look up the buyer's earliest on-chain activity. If the wallet's first transfer is close to the time of its first big bet, it is a fresh wallet and scores high. Replace the address with the buyer from Step 1.
+
+▶️ [Freshwallet check for polymarket](https://ide.bitquery.io/freshwallet-check-for-polymarket)
+
+#### FundingSource for poylmarket
+
+FundingSource for poylmarket. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [FundingSource for poylmarket](https://ide.bitquery.io/FundingSource-for-poylmarket)
+
+#### SiblingWallets for polymarket
+
+Take the funder from Step 3 and list every other wallet it funded. Wallets sharing a funder are likely controlled by the same operator. A large cluster placing correlated bets is a strong signal.
+
+▶️ [SiblingWallets for polymarket](https://ide.bitquery.io/SiblingWallets-for-polymarket)
+
+### Balances & Holders
+
+#### Polymarket TVL
+
+Summarize USDC.e (`0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`) held by Conditional Tokens and neg-risk wrapped collateral contracts. Extend the `Address` list if you track additional custodians.
+
+▶️ [Polymarket TVL](https://ide.bitquery.io/Polymarket-TVL)
+
+### Price & OHLC
+
+#### Current Price per Outcome (Latest Trade)
+
+Get the latest trade price for each outcome in a market. Uses `limitBy` for one row per outcome, with Price and PriceInUSD at the most recent block time.
+
+▶️ [Current Price per Outcome (Latest Trade)](https://ide.bitquery.io/Current-price-inside-the-market-for-all-options-based-on-latest-trade_1)
+
+#### Current price inside the market for all options based on latest trade
+
+Get the latest trade price for each outcome in a market (e.g. Yes/No, Up/Down—each market defines its own outcome labels).
+
+▶️ [Current price inside the market for all options based on latest trade](https://ide.bitquery.io/Current-price-inside-the-market-for-all-options-based-on-latest-trade)
+
+#### Latest price of outcomes of a crude oil market
+
+Returns the latest trade price (and price in USD) per outcome for a single market by `MarketId`. Replace `"1570893"` with the target Crude Oil market ID from Polymarket or from the creation/resolution queries above.
+
+▶️ [Latest price of outcomes of a crude oil market](https://ide.bitquery.io/latest-price-of-outcomes-of-a-crude-oil-market)
+
+#### OHLC of a outcome of a gold market
+
+Returns OHLC (Open, High, Low, Close) in USD for one outcome of a Gold market, bucketed by time (e.g. 1-minute intervals). Replace `MarketId` `"1606192"` and outcome `"Down"` with the desired market and outcome label (e.g. `"Up"` or `"Down"`).
+
+▶️ [OHLC of a outcome of a gold market](https://ide.bitquery.io/OHLC-of-a-outcome-of-a-gold-market)
+
+#### Polymarket AI odds movement OHLC
+
+Returns OHLC (Open, High, Low, Close) in USD for one outcome of an AI market, bucketed by interval (here 5 minutes). It shows how the implied probability moved over time, and powers charts and backtests. Replace `"<MARKET_ID>"` and `"<OUTCOME_LABEL>"`
+
+▶️ [Polymarket AI odds movement OHLC](https://ide.bitquery.io/Polymarket-AI-odds-movement-OHLC)
+
+#### Polymarket sports odds movement OHLC
+
+Returns OHLC (Open, High, Low, Close) in USD for one outcome of a game, bucketed by interval (here 5 minutes). It shows how the win probability moved over time, and powers line-movement charts and strategy backtests.
+
+▶️ [Polymarket sports odds movement OHLC](https://ide.bitquery.io/Polymarket-sports-odds-movement-OHLC)
+
+### Liquidity & Pools
+
+#### Top cricket Markets by Liquidity
+
+Returns the top 100 cricket related polymarkets sorted by liquidity position in the past 24 hours.
+
+▶️ [Top cricket Markets by Liquidity](https://ide.bitquery.io/Top-cricket-Markets-by-Liquidity)
+
+#### Top FIFA World Cup Markets by Liquidity
+
+Returns the top 100 FIFA World Cup related polymarkets sorted by liquidity position in the past 24 hours. Here `position` is the metric used for sorting, hence it could be regarded as the liquidity position of the particular market.
+
+▶️ [Top FIFA World Cup Markets by Liquidity](https://ide.bitquery.io/Top-FIFA-World-Cup-Markets-by-Liquidity)
+
+## Perpetuals
+
+### Hyperliquid
+
+#### Hyperliquid BTC Perp Trades
+
+Hyperliquid BTC Perp Trades. Uses the `Trades` cube.
+
+▶️ [Hyperliquid BTC Perp Trades](https://ide.bitquery.io/hyperliquid-btc-perp-trades)
+
+#### Hyperliquid Latest Trades (Perps + Spot + HIP-3)
+
+Each fill carries the execution (price, size, side, aggressor flag), the position it changed (leverage, margin mode, size before, realized PnL) and fees. `Direction` is one of `Open Long`, `Open Short`, `Close Long`, `Close Short`.
+
+▶️ [Hyperliquid Latest Trades (Perps + Spot + HIP-3)](https://ide.bitquery.io/hyperliquid-latest-trades)
+
+#### Hyperliquid Trader Leverage Updates
+
+Hyperliquid Trader Leverage Updates.
+
+▶️ [Hyperliquid Trader Leverage Updates](https://ide.bitquery.io/hyperliquid-leverage-updates)
+
+#### Hyperliquid BTC OHLCV Candles (1 minute)
+
+The `Candles` cube provides OHLCV per market and interval. `Interval.Time.Duration` is the candle length in seconds (e.g. `60` for one minute), `Start` the interval open time. OHLCV values are floats.
+
+▶️ [Hyperliquid BTC OHLCV Candles (1 minute)](https://ide.bitquery.io/hyperliquid-btc-ohlcv-candles)
+
+#### Hyperliquid Mark Prices (All Markets)
+
+Follow the steps here: How to generate Bitquery API token ➤.
+
+▶️ [Hyperliquid Mark Prices (All Markets)](https://ide.bitquery.io/hyperliquid-mark-prices)
+
+### Phoenix
+
+#### Phoenix Perps Fills by Trader Wallet - Solana
+
+Stream every stop-loss and take-profit placement as it happens.
+
+▶️ [Phoenix Perps Fills by Trader Wallet - Solana](https://ide.bitquery.io/sol_perps_filled_orders_by_signer)
+
+#### Whale Trades on Solana Perps (Phoenix)
+
+Positive = received, negative = paid. Replace the field list with `total: sum(of: Position_Funding)` for the net carry cost of holding their positions.
+
+▶️ [Whale Trades on Solana Perps (Phoenix)](https://ide.bitquery.io/solana-perps-whale-trades)
+
+### Other venues
+
+#### Trader Realized PnL on Solana Perps
+
+Rows with `Size: 0` are markets they've fully closed — drop them and the rest is the live book, with entry prices.
+
+▶️ [Trader Realized PnL on Solana Perps](https://ide.bitquery.io/solana-perps-trader-pnl)
+
+#### Solana Perps OHLC Candles from Mark Price
+
+As a `query`, add `orderBy: { descending: Block_Time }` and a `limit` for the recent whale prints.
+
+▶️ [Solana Perps OHLC Candles from Mark Price](https://ide.bitquery.io/solana-perps-ohlc-candles)
+
+## TRON
+
+### Trades
+
+#### Historical Tron Token Trades within 30 Days
+
+This query returns the historical trades on the TRON network for a token with the time window of past 30 days. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Historical Tron Token Trades within 30 Days](https://ide.bitquery.io/Historical-Tron-trades-for-a-token-within-30-days)
+
+#### Tron DEX Trades
+
+This query returns the latest trades on the TRON network from a trader perspective. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Tron DEX Trades](https://ide.bitquery.io/Tron-Trades)
+
+#### Tron Dex Trade By Tokens
+
+This query returns the latest token trades on the TRON network. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Tron Dex Trade By Tokens](https://ide.bitquery.io/Tron-trades-for-a-token)
+
+#### Sunmpump launchtoDEX
+
+This query allows you to track when tokens are launched on SunSwap using the `launchToDEX` function. It returns the most recent 10 token launches, displaying details such as the token address, transaction hash, block timestamp, and the method call signature.
+
+▶️ [Sunmpump launchtoDEX](https://ide.bitquery.io/sunmpump-launchtoDEX_1)
+
+#### Sunswap v2 latest Trades — historical (beyond 30 days)
+
+Retrieves details about each trade, including the amounts and prices of tokens bought and sold, as well as information about the trading pair. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Sunswap v2 latest Trades — historical (beyond 30 days)](https://ide.bitquery.io/sunswap-v2-latest-Trades)
+
+#### Historical Tron Token Trades beyond 30 Days — historical (beyond 30 days)
+
+This query returns the historical token trades on the TRON network for time window beyond 30 days. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Historical Tron Token Trades beyond 30 Days — historical (beyond 30 days)](https://ide.bitquery.io/Historical-tron-token-trades-beyond-30-days)
+
+#### All dexs info — historical (beyond 30 days)
+
+Fetches all the DEXs information on Tron network such as unique sellers, unique buyers etc. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [All dexs info — historical (beyond 30 days)](https://ide.bitquery.io/all-dexs-info)
+
+#### DEX Markets for a token — historical (beyond 30 days)
+
+Fetches the DEXs where a specific token is being traded on Tron network. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [DEX Markets for a token — historical (beyond 30 days)](https://ide.bitquery.io/DEX-Markets-for-a-token_1)
+
+#### First 100 buyers tron token — historical (beyond 30 days)
+
+Find the earliest buyers of any Tron token by using Tron `DEXTradeByTokens` API. This is widely used for memecoin sniper detection, early-holder analysis, and alpha groups monitoring SunPump / SunSwap launches. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [First 100 buyers tron token — historical (beyond 30 days)](https://ide.bitquery.io/first-100-buyers-tron-token)
+
+#### Peg health tron — historical (beyond 30 days)
+
+Browse multi-chain stablecoin DEX prices on DEXrabbit's Stablecoins category. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Peg health tron — historical (beyond 30 days)](https://ide.bitquery.io/peg-health-tron)
+
+### Transfers
+
+#### Historical TRON Transfers for a Wallet
+
+This query returns the historical transfers for a wallet in a given time window on the TRON network and includes details such as token amount transferred, sender, receiver, and token info.
+
+▶️ [Historical TRON Transfers for a Wallet](https://ide.bitquery.io/Historical-Tron-transfers-for-a-wallet)
+
+#### Latest TRON Transfers
+
+This query returns the most recent transfers on the TRON network and includes details such as token amount transferred, sender, receiver, and token info.
+
+▶️ [Latest TRON Transfers](https://ide.bitquery.io/Tron-transfer_10_1)
+
+#### Daily transfer volume tron
+
+Aggregate daily transfer volume in USD for any TRC20 token for analytics dashboards, weekly newsletters, and on-chain reports for stablecoins, governance tokens, and memecoins on Tron.
+
+▶️ [Daily transfer volume tron](https://ide.bitquery.io/daily-transfer-volume-tron)
+
+#### Top transfers of a token
+
+Retrieves the top 10 transfers by amount of the token `TXL6rJbvmjD46zeN1JssfgxvSo99qC8MRT`.
+
+▶️ [Top transfers of a token](https://ide.bitquery.io/top-transfers-of-a-token_2)
+
+#### Tron total txn fees paid by the Account
+
+Get the total fees (in SOL and USD) paid by a specific Tron account across all transfers.
+
+▶️ [Tron total txn fees paid by the Account](https://ide.bitquery.io/Tron-total-txn-fees-paid-by-the-Account)
+
+#### Transfers of a wallet API
+
+Fetches the recent 10 transfers of a specific wallet address `TFXttAWURRrXrd9JvFPVLEh1esJK8NHxn7`.
+
+▶️ [Transfers of a wallet API](https://ide.bitquery.io/Transfers-of-a-wallet-API)
+
+#### Tron Transaction fees paid by Account aggregated by currency
+
+Get total fees paid by a Tron account for transferring each type of token.
+
+▶️ [Tron Transaction fees paid by Account aggregated by currency](https://ide.bitquery.io/Tron-Transaction-fees-paid-by-Account-aggregated-by-currency)
+
+#### Tron wallet transfers with transaction fees paid
+
+Track wallet token transfers and get the fees paid for each by the address.
+
+▶️ [Tron wallet transfers with transaction fees paid](https://ide.bitquery.io/tron-wallet-transfers-with-transaction-fees-paid)
+
+### Balances & Holders
+
+#### Historical Balance of a Wallet for a Currency
+
+This query returns the current balance of a wallet for all currencies on the TRON network.
+
+▶️ [Historical Balance of a Wallet for a Currency](https://ide.bitquery.io/Historical-Tron-Wallet-Balance-for-a-currency)
+
+#### Top token holders of a token
+
+Returns the top holders of a token ranked by current balance. Use the Holders API with `orderBy` and `limit`.
+
+▶️ [Top token holders of a token](https://ide.bitquery.io/top-token-holders-of-a-token)
+
+#### Tron Balances for Native currency
+
+Returns the native TRX balance for a wallet (not TRC10 or TRC20 tokens). Filter with `Currency: { Native: true }` instead of a token contract address.
+
+▶️ [Tron Balances for Native currency](https://ide.bitquery.io/Tron-Balances-for-Native-currency)
+
+#### Tron USDT Balance At Date (Balances Cube)
+
+Unlike summing Transfers, this includes mints, burns, and genesis supply.
+
+▶️ [Tron USDT Balance At Date (Balances Cube)](https://ide.bitquery.io/tron-usdt-balance-at-date)
+
+#### Tron balances by date
+
+Returns balance snapshots over time for an address. Use `dataset: archive`. Order by `Block_Date` descending and use `limit` to paginate. Add `Currency.SmartContract` under `Currency` to filter by a specific token.
+
+▶️ [Tron balances by date](https://ide.bitquery.io/tron-balances-by-date)
+
+#### Tron token balance
+
+Add a `Currency.SmartContract` filter. Always use the contract address, not the token name.
+
+▶️ [Tron token balance](https://ide.bitquery.io/tron-token-balance)
+
+#### TronWalletPortfolio Tron
+
+Returns balances for all the currecies owned by a wallet address. Use `Amount(selectWhere: { gt: "0" })` to exclude zero balances and `dataset: combined` for the latest balances.
+
+▶️ [TronWalletPortfolio Tron](https://ide.bitquery.io/TronWalletPortfolio-Tron)
+
+#### SunPump Bonding Curve TRX Balance
+
+TRX balance in bonding curve based on dex trades. Calculated as `balance = in_sum - out_sum`
+
+▶️ [SunPump Bonding Curve TRX Balance](https://ide.bitquery.io/SunPump-Bonding-Curve-TRX-Balance)
+
+#### SunPump Historical Bonding Curve TRX Balance
+
+Calculated as `balance = in_sum - out_sum`
+
+▶️ [SunPump Historical Bonding Curve TRX Balance](https://ide.bitquery.io/SunPump-Historical-Bonding-Curve-TRX-Balance)
+
+### Liquidity & Pools
+
+#### Sun Pump Virtual Liquidity Pools
+
+Sun Pump does not use a dedicated pool for each pair; instead, all liquidity is managed within a single contract. You can query the virtual liquidity pools directly by running the following query.
+
+▶️ [Sun Pump Virtual Liquidity Pools](https://ide.bitquery.io/Sun-Pump-Virtual-Liquidity-Pools_1)
+
+### Events & Calls
+
+#### Latest created Sunpump tokens
+
+If you remove `subscription` from the below GraphQL query it will become API, for example check.
+
+▶️ [Latest created Sunpump tokens](https://ide.bitquery.io/latest-created-Sunpump-tokens)
+
+#### Latest tokens created on Sunpump
+
+The `Arguments` include the token address, creator, and token index. You can run it.
+
+▶️ [Latest tokens created on Sunpump](https://ide.bitquery.io/Latest-tokens-created-on-Sunpump_2)
+
+#### TokenPurchased on Sunpump
+
+This query allows you to track `TokenPurchased` events on SunPump. It retrieves the 10 most recent token purchase events, showing important details such as the token address, buyer information, transaction hash, and token amount involved.
+
+▶️ [TokenPurchased on Sunpump](https://ide.bitquery.io/TokenPurchased-on-Sunpump)
+
+## Cross-Chain
+
+### Trades
+
+#### Volume of Multiple Tokens Across Different Chains
+
+Get volume and price change data for multiple tokens trading on different chains (Solana, Ethereum, BSC, Tron) in a single query. Returns volume for 1h, 4h, and 24h periods, plus price change percentages. > **Note:** For EVM chains (Ethereum, BSC, etc.) in the Trading API, use **all lowercase…
+
+▶️ [Volume of Multiple Tokens Across Different Chains](https://ide.bitquery.io/volume-of-a-token_2)
+
+### Price & OHLC
+
+#### SMA and Volume Data (for past 28, 14 and 7 Days Time)
+
+Use this API to get SMA and volume over the past 28 days, with 14 days, and 7 days breakdowns. Note that the oldest possible data it could return is 30 days ago. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [SMA and Volume Data (for past 28, 14 and 7 Days Time)](https://ide.bitquery.io/multiple-tokens-volume-and-SMA)
+
+#### Historical OHLC of a Token Pair Across Chains
+
+This query fetches historical OHLC (Open, High, Low, Close) price data for a token pair across different blockchains for as long back as 30 days. For **native tokens**, you only need to specify their ID (e.g., `bid:eth` for ETH). Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Historical OHLC of a Token Pair Across Chains](https://ide.bitquery.io/Historical-Token-OHLC-Multi-Chains_1)
+
+#### Latest Price of Any Token
+
+This query gives you bitcoin currency 1-sec OHLC across different blockchains. You can adjust duration in `Duration: {eq: 1}` filter. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Latest Price of Any Token](https://ide.bitquery.io/Latest-bitcoin-price-on-across-chains_5)
+
+#### OHLC of a currency on multiple blockchains
+
+This query retrieves the OHLC (Open, High, Low, Close) prices of a currency(in this eg Bitcoin; it will include all sorts of currencies whose underlying asset is Bitcoin like cbBTC, WBTC, etc) across all supported blockchains, aggregated into a given time interval (e.g., 60 seconds in this example). Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [OHLC of a currency on multiple blockchains](https://ide.bitquery.io/OHLC-of-a-currency-on-multiple-blockchains_2)
+
+#### Historical Price and Volume Data for a Token Pair beyond 30 days
+
+Use this API to get historical price and volume for a specific token pair address on a specific network for the time window beyond the 30 days. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Historical Price and Volume Data for a Token Pair beyond 30 days](https://ide.bitquery.io/historical-price-and-historical-volume)
+
+#### All time High Trade Price for a Token — historical (beyond 30 days)
+
+Retrieves the all-time high (ATH) price in USD for a specified token contract. All time high price could lie beyond the 30 days window provided by Trading API, hence we use these network specific APIs to get the ATH for a token. While this provides the option to go beyond the 30 days time…. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [All time High Trade Price for a Token — historical (beyond 30 days)](https://ide.bitquery.io/ATH-of-eth-token_1)
 
 ## Ethereum
 
@@ -51,27 +1471,15 @@ Every query below is saved in the [Bitquery IDE](https://ide.bitquery.io) and wa
 
 #### Latest DEX trades for a token
 
-Most recent swaps for one token across every Ethereum DEX. Change the token address in the `Currency: {SmartContract:}` filter.
+Most recent swaps for one token across every Ethereum DEX. Change the token address in the `Currency: {SmartContract:}` filter. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [Latest DEX trades for a token](https://ide.bitquery.io/Ethereum-Trades-of-a-Token_1)
 
-#### Realised PnL, buy and sell volume
-
-Profit and loss for a wallet on one token, from its own trade history. Needs the historical data add-on — see the comment at the top of the query.
-
-▶️ [Realised PnL, buy and sell volume](https://ide.bitquery.io/Realised-Pnl-Buy-volume-Sell-Volume-Ethereum_1)
-
 #### Trades by a wallet
 
-Every buy and sell made by one address. Replace the wallet in `Transaction: {From:}`.
+Every buy and sell made by one address. Replace the wallet in `Transaction: {From:}`. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [Trades by a wallet](https://ide.bitquery.io/Ethereum-Trades-of-a-Trader_1)
-
-#### Address is Buyer or Seller V2
-
-Returns trades where the specified address is either as a buyer or a seller. This is achieved by utilizing the `any` filter, which acts as an OR condition to encompass both buyer and seller roles in the results.
-
-▶️ [Address is Buyer or Seller V2](https://ide.bitquery.io/Address-is-Buyer-or-Seller-V2)
 
 #### All events on fluid DEX VaultFactory
 
@@ -79,35 +1487,47 @@ Get a comprehensive list of all events emitted by the Fluid DEX Vault Factory co
 
 ▶️ [All events on fluid DEX VaultFactory](https://ide.bitquery.io/all-events-on-fluid-DEX-VaultFactory)
 
-#### Buys, Sells, BuyVolume, SellVolume, Makers, TotalTradedVolume, PriceinUSD for a eth pair
+#### Address is Buyer or Seller V2 — historical (beyond 30 days)
 
-Will fetch the buys, sells, buy volume, sell volume and also the number of makers for a particular token just like how DEXScreener shows in its UI.
+Returns trades where the specified address is either as a buyer or a seller. This is achieved by utilizing the `any` filter, which acts as an OR condition to encompass both buyer and seller roles in the results. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Buys, Sells, BuyVolume, SellVolume, Makers, TotalTradedVolume, PriceinUSD for a eth pair](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-a-eth-pair)
+▶️ [Address is Buyer or Seller V2 — historical (beyond 30 days)](https://ide.bitquery.io/Address-is-Buyer-or-Seller-V2)
 
-#### Coin ticker api
+#### First 500 buyers of a token — historical (beyond 30 days)
 
-Coin ticker api. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Earliest buyers of a token in order, useful for launch and insider analysis. Needs the historical data add-on — see the comment at the top of the query. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Coin ticker api](https://ide.bitquery.io/Coin-ticker-api_4)
+▶️ [First 500 buyers of a token — historical (beyond 30 days)](https://ide.bitquery.io/first-500-buyers-of-a-ERC20-token_1)
 
-#### Dex info
+#### Realised PnL, buy and sell volume — historical (beyond 30 days)
 
-Will fetch a specific DEX stats for the selected network.
+Profit and loss for a wallet on one token, from its own trade history. Needs the historical data add-on — see the comment at the top of the query. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Dex info](https://ide.bitquery.io/dex-info)
+▶️ [Realised PnL, buy and sell volume — historical (beyond 30 days)](https://ide.bitquery.io/Realised-Pnl-Buy-volume-Sell-Volume-Ethereum_1)
 
-#### Dex markets
+#### Buys, Sells, BuyVolume, SellVolume, Makers, TotalTradedVolume, PriceinUSD for a eth pair — historical (beyond 30 days)
 
-Will fetch all the DEXs info for the selected network.
+Will fetch the buys, sells, buy volume, sell volume and also the number of makers for a particular token just like how DEXScreener shows in its UI. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Dex markets](https://ide.bitquery.io/dex-markets)
+▶️ [Buys, Sells, BuyVolume, SellVolume, Makers, TotalTradedVolume, PriceinUSD for a eth pair — historical (beyond 30 days)](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-a-eth-pair)
 
-#### First 500 buyers of a token
+#### Coin ticker api — historical (beyond 30 days)
 
-Earliest buyers of a token in order, useful for launch and insider analysis. Needs the historical data add-on — see the comment at the top of the query.
+Coin ticker api. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [First 500 buyers of a token](https://ide.bitquery.io/first-500-buyers-of-a-ERC20-token_1)
+▶️ [Coin ticker api — historical (beyond 30 days)](https://ide.bitquery.io/Coin-ticker-api_4)
+
+#### Dex info — historical (beyond 30 days)
+
+Will fetch a specific DEX stats for the selected network. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Dex info — historical (beyond 30 days)](https://ide.bitquery.io/dex-info)
+
+#### Dex markets — historical (beyond 30 days)
+
+Will fetch all the DEXs info for the selected network. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Dex markets — historical (beyond 30 days)](https://ide.bitquery.io/dex-markets)
 
 ### Transfers
 
@@ -235,67 +1655,85 @@ Balance update after transfer sent from multiple addresses. Uses the `Transactio
 
 ### Price & OHLC
 
-#### All-time high price of a token
+#### Token price from top market (rank 1)
 
-Highest price a token has ever traded at, with the date it happened. Needs the historical data add-on — see the comment at the top of the query.
+Prices WETH from its single top market rather than blending every pool — the recommended way to price one specific token. Replace `token` in the Variables pane, lowercase.
 
-▶️ [All-time high price of a token](https://ide.bitquery.io/ATH-of-eth-token)
-
-#### Prices for multiple tokens at once
-
-Latest USD price for a list of tokens in a single request. Add addresses to the `in` filter.
-
-▶️ [Prices for multiple tokens at once](https://ide.bitquery.io/Price-of-multiple-tokens-in-realtime)
-
-#### OHLCV by pair address
-
-Open, high, low, close and volume candles for one pair. Change the interval to re-bucket the candles.
-
-▶️ [OHLCV by pair address](https://ide.bitquery.io/OHLC0_8)
-
-#### Price change over 5m, 1h, 6h and 24h
-
-Percentage moves across four windows for one token in one query.
-
-▶️ [Price change over 5m, 1h, 6h and 24h](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_4)
-
-#### Top 10 tokens by price change, last hour
-
-Biggest movers on Ethereum over the past hour, ranked.
-
-▶️ [Top 10 tokens by price change, last hour](https://ide.bitquery.io/Top-10-eth-tokens-by-price-change-in-last-1-hr_2)
-
-#### Historical Price and Volume Data for a Token Pair beyond 30 days
-
-Use this API to get historical price and volume for a specific token pair address on a specific network for the time window beyond the 30 days.
-
-▶️ [Historical Price and Volume Data for a Token Pair beyond 30 days](https://ide.bitquery.io/historical-price-and-historical-volume)
+▶️ [Token price from top market (rank 1)](https://ide.bitquery.io/Ethereum-Token-price-from-top-market-rank-1)
 
 #### Ohlc of a token pair 1 hour interval
 
-Fetches the Open, High, Low, and Close (OHLC) price data (USD-quoted) for a given token pair across DEXs, using a specified quote token and time interval (in seconds).
+Fetches the Open, High, Low, and Close (OHLC) price data (USD-quoted) for a given token pair across DEXs, using a specified quote token and time interval (in seconds). Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [Ohlc of a token pair 1 hour interval](https://ide.bitquery.io/ohlc-of-a-token-pair-1-hour-interval)
 
+#### Historical Price and Volume Data for a Token Pair beyond 30 days
+
+Use this API to get historical price and volume for a specific token pair address on a specific network for the time window beyond the 30 days. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Historical Price and Volume Data for a Token Pair beyond 30 days](https://ide.bitquery.io/historical-price-and-historical-volume)
+
 #### Pepe historical ohlcv 30days
 
-Fetch hourly OHLCV candles for the past 30 days. Change `Duration` for different intervals, such as 60 (1 minute) or 300 (5 minutes).
+Fetch hourly OHLCV candles for the past 30 days. Change `Duration` for different intervals, such as 60 (1 minute) or 300 (5 minutes). Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [Pepe historical ohlcv 30days](https://ide.bitquery.io/pepe-historical-ohlcv-30days)
 
-#### Price change 5min, 1hr, 6hr precentage of a specific token
+#### Prices for multiple tokens at once — historical (beyond 30 days)
 
-Price change 5min, 1hr, 6hr precentage of a specific token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Latest USD price for a list of tokens in a single request. Add addresses to the `in` filter. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Price change 5min, 1hr, 6hr precentage of a specific token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_1)
+▶️ [Prices for multiple tokens at once — historical (beyond 30 days)](https://ide.bitquery.io/Price-of-multiple-tokens-in-realtime)
 
-#### Price of a token in realtime
+#### Price of a token in realtime — historical (beyond 30 days)
 
-Will give the latest Price of a specified token using DEXTrades API. Here we have calculated the price of a token in USD and also against the sell currency. Here is the.
+Will give the latest Price of a specified token using DEXTrades API. Here we have calculated the price of a token in USD and also against the sell currency. Here is the. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Price of a token in realtime](https://ide.bitquery.io/Price-of-a-token-in-realtime)
+▶️ [Price of a token in realtime — historical (beyond 30 days)](https://ide.bitquery.io/Price-of-a-token-in-realtime)
+
+#### All-time high price of a token — historical (beyond 30 days)
+
+Highest price a token has ever traded at, with the date it happened. Needs the historical data add-on — see the comment at the top of the query. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [All-time high price of a token — historical (beyond 30 days)](https://ide.bitquery.io/ATH-of-eth-token)
+
+#### OHLCV by pair address — historical (beyond 30 days)
+
+Open, high, low, close and volume candles for one pair. Change the interval to re-bucket the candles. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [OHLCV by pair address — historical (beyond 30 days)](https://ide.bitquery.io/OHLC0_8)
+
+#### Price change over 5m, 1h, 6h and 24h — historical (beyond 30 days)
+
+Percentage moves across four windows for one token in one query. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Price change over 5m, 1h, 6h and 24h — historical (beyond 30 days)](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_4)
+
+#### Top 10 tokens by price change, last hour — historical (beyond 30 days)
+
+Biggest movers on Ethereum over the past hour, ranked. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Top 10 tokens by price change, last hour — historical (beyond 30 days)](https://ide.bitquery.io/Top-10-eth-tokens-by-price-change-in-last-1-hr_2)
+
+#### Price change 5min, 1hr, 6hr precentage of a specific token — historical (beyond 30 days)
+
+Price change 5min, 1hr, 6hr precentage of a specific token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Price change 5min, 1hr, 6hr precentage of a specific token — historical (beyond 30 days)](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_1)
 
 ### Supply & Market Cap
+
+#### Pepe volume marketcap
+
+Provides the latest trade volume for the past one hour along with the latest market cap.
+
+▶️ [Pepe volume marketcap](https://ide.bitquery.io/pepe-volume-marketcap)
+
+#### Top tokens by market cap
+
+Ethereum tokens ranked by market capitalisation.
+
+▶️ [Top tokens by market cap](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-Ethereum)
 
 #### Total supply and market cap of a token
 
@@ -320,18 +1758,6 @@ Retrieve the total supply and market capitalization of a specific ERC-20 token. 
 Get the current total supply for specific tokens like USDC and USDT on Ethereum or any EVM network. This is ideal for stablecoin tracking and portfolio applications.
 
 ▶️ [Latest token supply on USDT and USDC on ethereum chain](https://ide.bitquery.io/latest-token-supply-on-USDT-and-USDC-on-ethereum-chain)
-
-#### Pepe volume marketcap
-
-Provides the latest trade volume for the past one hour along with the latest market cap.
-
-▶️ [Pepe volume marketcap](https://ide.bitquery.io/pepe-volume-marketcap)
-
-#### Top tokens by market cap
-
-Ethereum tokens ranked by market capitalisation.
-
-▶️ [Top tokens by market cap](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-Ethereum)
 
 #### Total Supply and onchain Marketcap of a specific token
 
@@ -605,573 +2031,69 @@ Top token pairs on PancakeSwap v3. Uses the `DEXTradeByTokens` cube. Change the 
 
 ▶️ [Top token pairs on PancakeSwap v3](https://ide.bitquery.io/Top-token-pairs-on-PancakeSwap-v3)
 
-## Solana
-
-### Trades
-
-#### Get Multiple Token Analytics
-
-Returns analytics data for multiple token addresses.
-
-▶️ [Get Multiple Token Analytics](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-multiple-solana-tokens)
-
-#### Get Token Metadata
-
-Get the token metadata for contract (mint, standard, name, symbol).
-
-▶️ [Get Token Metadata](https://ide.bitquery.io/Solana-currency-details)
-
-#### Get Token Pair Stats
-
-Get the pair stats by using pair address.
-
-▶️ [Get Token Pair Stats](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-solana-token-pair)
-
-#### Get Token Pairs by Address
-
-Get the supported pairs for a specific token address.
-
-▶️ [Get Token Pairs by Address](https://ide.bitquery.io/traded-pairs-of-a-token_2)
-
-#### Get Volume Stats for Solana Chain
-
-Returns volume statistics, active wallets, and total transactions for Solana.
-
-▶️ [Get Volume Stats for Solana Chain](https://ide.bitquery.io/Chain-stats-like-total-volume-traded-total-transactions-active-wallets_1)
-
-#### Realised PnL, avg buy price, buy volume, sell volume of a Trader for specific token
-
-Get realised PnL, average buy price, buy volume, and sell volume for a token on Solana of a trader for over a time window.
-
-▶️ [Realised PnL, avg buy price, buy volume, sell volume of a Trader for specific token](https://ide.bitquery.io/Realised-Pnl-avg-buy-price-Buy-volume-Sell-Volume-Solana_2)
-
-#### Search tokens by name, symbol, mint address
-
-Search for tokens based on contract address, token name or token symbol.
-
-▶️ [Search tokens by name, symbol, mint address](https://ide.bitquery.io/Token-Search-API---trump-symbol)
-
-#### Get Swaps by Pair Address
-
-Get all trades related transactions for a specific pair address.
-
-▶️ [Get Swaps by Pair Address](https://ide.bitquery.io/swaps-for-a-market-address-on-Solana)
-
-#### Get Trades by Wallet Address
-
-Get all trades related transactions (buy, sell) for a specific wallet address.
-
-▶️ [Get Trades by Wallet Address](https://ide.bitquery.io/Solana-dextrades-by-a-trader_2)
-
-#### Buys Sells BuyVolume SellVolume Makers TotalTradedVolume PriceinUSD for solana token pair
-
-Returns the essential stats for a token such as buy volume, sell volume, total buys, total sells, makers, total trade volume, buyers, sellers (in last 5 min, 1 hour) of a specific token.
-
-▶️ [Buys Sells BuyVolume SellVolume Makers TotalTradedVolume PriceinUSD for solana token pair](https://ide.bitquery.io/Buys-Sells-BuyVolume-SellVolume-Makers-TotalTradedVolume-PriceinUSD-for-solana-token-pair00_2)
-
-### Transfers
-
-#### Simple SOL transfers (Transactions not trades)
-
-This API returns simple SOL transfers; in other words, it contains transactions that are simple token transfers, not trades.
-
-▶️ [Simple SOL transfers (Transactions not trades)](https://ide.bitquery.io/Simple-SOL-transfers-Transactions-not-trades)
-
-#### Solana Token Transfers for a Specific Address
-
-This API retrieves the history of token transfers (both sent and received) for a specific Solana address within a defined time period.
-
-▶️ [Solana Token Transfers for a Specific Address](https://ide.bitquery.io/Solana-historical-token-transfers-of-an-address-between-a-time)
-
-#### Solana Transfers
-
-This query gets the latest 10 transfers on Solana. You can increase the limit to get more transfers. This query only uses real-time data.
-
-▶️ [Solana Transfers](https://ide.bitquery.io/Solana-transfers0_5)
-
-#### Solana Historical Transfers
-
-Solana Historical Transfers.
-
-▶️ [Solana Historical Transfers](https://ide.bitquery.io/solana-historical-transfers_1)
-
-#### Currency with elon inclusion
-
-You can search tokens on Solana using names or symbols case insensitively also using our APIs and get prices and other details.
-
-▶️ [Currency with elon inclusion](https://ide.bitquery.io/Currency-with-elon-inclusion)
-
-#### Solana token transfers of Bags fm tokens
-
-Track all transfers of Bags FM tokens across wallets. This Bags FM token transfers endpoint provides complete transfer history. 🔗.
-
-▶️ [Solana token transfers of Bags fm tokens](https://ide.bitquery.io/Solana-token-transfers-of-Bags-fm-tokens)
-
-#### Total txn fees paid by the Account
-
-Get the total fees (in SOL and USD) paid by a specific Solana account across all transfers.
-
-▶️ [Total txn fees paid by the Account](https://ide.bitquery.io/total-txn-fees-paid-by-the-Account)
-
-#### Transaction fees paid by Account aggregated by currency
-
-Get total fees paid by a Solana account for transferring each type of token.
-
-▶️ [Transaction fees paid by Account aggregated by currency](https://ide.bitquery.io/Transaction-fees-paid-by-Account-aggregated-by-currency)
-
-#### Transfers of a wallet
-
-Fetches the recent 10 transfers of a specific wallet address `9nnLbotNTcUhvbrsA6Mdkx45Sm82G35zo28AqUvjExn8`.
-
-▶️ [Transfers of a wallet](https://ide.bitquery.io/Transfers-of-a-wallet_1)
-
-#### Wallet transfers with transaction fees paid
-
-Track wallet token transfers and get the fees paid for each by the address.
-
-▶️ [Wallet transfers with transaction fees paid](https://ide.bitquery.io/wallet-transfers-with-transaction-fees-paid)
-
-### Balances & Holders
-
-#### Solana Instruction Balance Updates
-
-This query returns Solana balance update info for any balance update event, including the address, amount, currency details, and the details of the program responsible for this update.
-
-▶️ [Solana Instruction Balance Updates](https://ide.bitquery.io/Solana-InstructionBalanceUpdates)
-
-#### Balance updates
-
-Returns balance update associated with a instruction invocation.
-
-▶️ [Balance updates](https://ide.bitquery.io/balance-updates)
-
-#### Solana balance updates executing burn instruction
-
-The query below uses the InstructionBalanceUpdates API to fetch balance updates that occur when token burn instructions execute.
-
-▶️ [Solana balance updates executing burn instruction](https://ide.bitquery.io/solana-balance-updates-executing-burn-instruction)
-
-#### Trades of wallets with balance Updates in that trades
-
-Below query will give you the trades of the wallets present in `addressList` along with the balance updates happened in those trades..
-
-▶️ [Trades of wallets with balance Updates in that trades](https://ide.bitquery.io/Trades-of-wallets-with-balance-Updates-in-that-trades)
-
-### Price & OHLC
-
-#### Get OHLCV by Pair Address
-
-You can get charting data easily with this query. Adjust the intervals as necessary. This query supports historical data.
-
-▶️ [Get OHLCV by Pair Address](https://ide.bitquery.io/OHLC-for-a-token_8)
-
-#### Get Token Prices on Solana
-
-Returns price information for multiple Solana tokens in a single request.
-
-▶️ [Get Token Prices on Solana](https://ide.bitquery.io/Get-multiple-Token-Prices)
-
-#### Historical Price and Volume Data (Volume & Price, Last 24h using Trading API)
-
-Use this API to get historical price and volume for a specific token over the past 24 hours.
-
-▶️ [Historical Price and Volume Data (Volume & Price, Last 24h using Trading API)](https://ide.bitquery.io/24h-historical-price-and-historical-volume-on-Solana)
-
-#### Price change 5min, 1hr, 6hr precentage of a specific token
-
-With this, you can get the price change 5min, 1hr, 6hr precentage of a specific token.
-
-▶️ [Price change 5min, 1hr, 6hr precentage of a specific token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_5)
-
-#### Top 10 solana tokens by price change in last 1 hr
-
-With this, you can get top 10 solana tokens by price change in last 1 hr.
-
-▶️ [Top 10 solana tokens by price change in last 1 hr](https://ide.bitquery.io/Top-10-solana-tokens-by-price-change-in-last-1-hr_4)
-
-#### Get Latest Price of a Token in USD
-
-Get Latest Price of a Token in USD. Uses the `Pairs` cube. Replace the address in the `where` clause to use it.
-
-▶️ [Get Latest Price of a Token in USD](https://ide.bitquery.io/Pumpfun-token-latest-price-USD)
-
-#### ATH of multiple tokens quantile Solana
-
-ATH of multiple tokens quantile Solana. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query.
-
-▶️ [ATH of multiple tokens quantile Solana](https://ide.bitquery.io/ATH-of-multiple-tokens-quantile-Solana)
-
-#### ATH with price delta Solana
-
-Fetches a Solana token’s ATH price, ATH date, and price change percentages over the past 24h, 7d, and 30d using Bitquery Solana APIs. Try the.
-
-▶️ [ATH with price delta Solana](https://ide.bitquery.io/ATH-with-price-delta-Solana)
-
-#### AldrinAmm OHLC for specific pair
-
-If you want to get OHLC data for any specific currency pair on AldrinAmm, you can use this api. Only use.
-
-▶️ [AldrinAmm OHLC for specific pair](https://ide.bitquery.io/AldrinAmm-OHLC-for-specific-pair)
-
-#### Get Latest Price of Apple xStock in USD Real-time
-
-You can use the following query to get the latest price of a Apple xStock on Solana.
-
-▶️ [Get Latest Price of Apple xStock in USD Real-time](https://ide.bitquery.io/Get-Latest-Price-of-Apple-xStock-in--USD-Real-time)
-
-### Supply & Market Cap
-
-#### Bags.fm token creation using Solana token supply updates
-
-Bags.fm token creation using Solana token supply updates. Uses the `TokenSupplyUpdates` cube. Replace the address in the `where` clause to use it.
-
-▶️ [Bags.fm token creation using Solana token supply updates](https://ide.bitquery.io/Bagsfm-token-creation-using-Solana-token-supply-updates)
-
-#### Market cap of token
-
-You can fetch Marketcap of a token using below query.
-
-▶️ [Market cap of token](https://ide.bitquery.io/market-cap-of-token_1)
-
-#### Marketcap of tokens
-
-Returns the ATH (All-Time High) market cap, starting market cap, and related price metrics for multiple tokens. It calculates market cap using a 1 billion token supply and uses quantile to find the ATH price.
-
-▶️ [Marketcap of tokens](https://ide.bitquery.io/Marketcap-of-tokens)
-
-#### Sandisk - Backpack Securities MCAP
-
-See the Pairs cube for full field reference.
-
-▶️ [Sandisk - Backpack Securities MCAP](https://ide.bitquery.io/Sandisk---Backpack-Securities-MCAP)
-
-#### Token burn example solana
-
-You can also track real-time token burn using the TokenSupplyUpdates API. Check out the.
-
-▶️ [Token burn example solana](https://ide.bitquery.io/token-burn-example-solana)
-
-#### Token supply
-
-Will return the latest token supply of a specific token. We are getting here supply for this `6D7NaB2xsLd7cauWu1wKk6KBsJohJmP2qZH9GEfVi5Ui` token `PostBalance` will give you the current supply for this token.
-
-▶️ [Token supply](https://ide.bitquery.io/token-supply_2)
-
-#### Tokens with market cap range
-
-Lets say we need to get the tokens whose marketcap has crossed the `1M USD` mark but is less than `2M USD` for various reasons like automated trading. We can get the token details that have crossed a particular marketcap using.
-
-▶️ [Tokens with market cap range](https://ide.bitquery.io/tokens-with-market-cap-range)
-
-#### Top 10 marketcap jump tokens in last 1hr
-
-Use below query to get top 10 marketcap jump tokens in last 1hr.
-
-▶️ [Top 10 marketcap jump tokens in last 1hr](https://ide.bitquery.io/top-10-marketcap-jump-tokens-in-last-1hr)
-
-#### Top Solana tokens based on market cap
-
-Top Solana tokens based on market cap. Uses the `TokenSupplyUpdates` cube.
-
-▶️ [Top Solana tokens based on market cap](https://ide.bitquery.io/top-Solana-tokens-based-on-market-cap)
-
-#### Top Tokens by Market Cap on solana
-
-Ranks tokens on Solana by `Supply.MarketCap`, with 24h window, 1s interval, $1,000+ USD volume, `limitBy` per `Token_Id`, up to 50 rows. `Token.Network` is Solana.
-
-▶️ [Top Tokens by Market Cap on solana](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-solana)
-
-### Liquidity & Pools
-
-#### All Token Pairs Across DEXs with Current Liquidity
-
-This query retrieves all instances of a specific token pair across decentralized exchanges (DEXs) on Solana, along with their current liquidity.
-
-▶️ [All Token Pairs Across DEXs with Current Liquidity](https://ide.bitquery.io/All-Liquidity-pairs-of-a-token-and-current-liquidity-on-solana)
-
-#### Latest Pools Created on Launchpad
-
-This query returns the latest created pools on Raydium launchpad. You can set the limit here also.
-
-▶️ [Latest Pools Created on Launchpad](https://ide.bitquery.io/Launchpad-latest-pool-created)
-
-#### Liquidity of All Pools of a Token on Solana
-
-Get latest liquidity snapshots for all pools where a token is either base or quote currency.
-
-▶️ [Liquidity of All Pools of a Token on Solana](https://ide.bitquery.io/liqidity-of-all-pools-of-a-token)
-
-#### Solana Pool Liquidity Changes
-
-This query retrieves the latest changes to liquidity pools on Solana, including the change amount and the price at which the change happened. This query also uses only the real-time data set.
-
-▶️ [Solana Pool Liquidity Changes](https://ide.bitquery.io/Solana-DEXPools)
-
-#### All liquidity add instructions track on Solana
-
-Tracks liquidity addition events on Solana DEX pools by monitoring specific instructions.
-
-▶️ [All liquidity add instructions track on Solana](https://ide.bitquery.io/All-liquidity-add-instructions-track-on-Solana)
-
-#### CPMM pools created
-
-The mint addresses for the tokens being used in the pool are listed for example `tokenMint1` and `tokenMint0` , indicating which tokens the CPMM will support.
-
-▶️ [CPMM pools created](https://ide.bitquery.io/CPMM-pools-created_1)
-
-#### Get LP Latest liqudity on Solana
-
-Get LP Latest liqudity on Solana. Uses the `DEXPools` cube. Replace the address in the `where` clause to use it.
-
-▶️ [Get LP Latest liqudity on Solana](https://ide.bitquery.io/Get-LP-Latest-liqudity-on-Solana)
-
-#### Get all the liquidity pools info for a particular token
-
-Will give the information on all the liquidity pools of a particular token `EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm`.
-
-▶️ [Get all the liquidity pools info for a particular token](https://ide.bitquery.io/get-all-the-liquidity-pools-info-for-a-particular-token_1)
-
-#### Liquidity change in recent month
-
-Liquidity change in recent month. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query.
-
-▶️ [Liquidity change in recent month](https://ide.bitquery.io/liquidity-change-in-recent-month)
-
-#### Liquidity lock using instructions balance update
-
-Using the below query, you can retrieve latest liquidity locks made using streamflow.
-
-▶️ [Liquidity lock using instructions balance update](https://ide.bitquery.io/Liquidity-lock-using-instructions-balance-update)
-
-### Events & Calls
-
-#### Not Anchor Error Solana Logs
-
-To exclude instructions containing specific log phrases such as 'AnchorError' you can use the `notLike` filter.
-
-▶️ [Not Anchor Error Solana Logs](https://ide.bitquery.io/Not-Anchor-Error-Solana-Logs)
-
-#### Solana Zeta Market logs
-
-If you need to filter out the instructions from Solana logs that involve a particular exchange but you don’t have any information, like address and protocol, then you can use the “includes” keyword on Logs.
-
-▶️ [Solana Zeta Market logs](https://ide.bitquery.io/Solana-Zeta-Market-logs)
-
-### Pump.fun
-
-#### Top 10 pump fun tokens by Marketcap change in last 5mins
-
-This query returns the top 10 pump fun tokens by Marketcap change in last 5mins. You can increase the limit to get more tokens.
-
-▶️ [Top 10 pump fun tokens by Marketcap change in last 5mins](https://ide.bitquery.io/Top-10-pump-fun-tokens-by-Marketcap-change-in-last-5mins_1)
-
-#### Top PumpFun Tokens by Marketcap
-
-This query returns the top 10 PumpFun tokens based on market cap. You can increase the limit to get more tokens.
-
-▶️ [Top PumpFun Tokens by Marketcap](https://ide.bitquery.io/top-tokens-by-mktcap-on-pump-fun-in-last-15-min)
-
-#### Get Bonding Curve Progress of a Token on Pump Fun
-
-Returns Bonding Curve Percentage of a Token on the Pump Fun.
-
-▶️ [Get Bonding Curve Progress of a Token on Pump Fun](https://ide.bitquery.io/get-the-bonding-curve-progress-percentage_1)
-
-#### ATH Market Cap of Pump Fun Tokens in a Specific Timeframe
-
-Use Bitquery's `DEXTradeByTokens` with `dataset: combined`, `Trade.PriceInUSD(maximum: Trade_PriceInUSD)`, and `quantile(of: Trade_PriceInUSD, level: 0.98)` to get ATH price. Market cap = ATH price × 1 billion (Pump.fun tokens have 1B supply).
-
-▶️ [ATH Market Cap of Pump Fun Tokens in a Specific Timeframe](https://ide.bitquery.io/ATH-Market-Cap-of-Pump-Fun-Tokens-in-a-Specific-Timeframe)
-
-#### All tokens traded on Pump.fun in the last 1 hour
-
-To get all tokens traded on Pump.fun in the last 1 hour, use a query that filters trades by the Pump.fun protocol and a block time within the past hour.
-
-▶️ [All tokens traded on Pump.fun in the last 1 hour](https://ide.bitquery.io/all-tokens-traded-on-Pumpfun-in-the-last-1-hour_1)
-
-#### How do I get tokens that reached a specific market cap on Pump.fun?
-
-To find tokens on Pump.fun that have reached a specific market capitalization threshold, you can use the following Bitquery GraphQL example.
-
-▶️ [How do I get tokens that reached a specific market cap on Pump.fun?](https://ide.bitquery.io/How-do-I-get-tokens-that-reached-a-specific-market-cap-on-Pumpfun)
-
-### Meteora
-
-#### Get the Top Traders of a specific Token on Meteora DAMM v2 DEX
-
-The below query gets the Top Traders of the specified Token on Meteora DAMM v2. This provides insights into the most active traders and their trading patterns.
-
-▶️ [Get the Top Traders of a specific Token on Meteora DAMM v2 DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DAMM-v2-DEX_1)
-
-#### Get the Top Traders of a specific Token on Meteora DLMM DEX
-
-The below query gets the Top Traders of the specified Token on Meteora DLMM. This provides insights into the most active traders and their trading patterns.
-
-▶️ [Get the Top Traders of a specific Token on Meteora DLMM DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DLMM-DEX)
-
-#### Get the Top Traders of a specific Token on Meteora DYN DEX
-
-The below query gets the Top Traders of the specified Token `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` on Meteora DYN.
-
-▶️ [Get the Top Traders of a specific Token on Meteora DYN DEX](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DYN-DEX)
-
-#### Meteora DAMM v2 OHLC API
-
-If you want to get OHLC (Open, High, Low, Close) data for any specific currency pair on Meteora DAMM v2, you can use this API. This provides technical analysis data for charting and trading strategies.
-
-▶️ [Meteora DAMM v2 OHLC API](https://ide.bitquery.io/Meteora-DAMM-v2-OHLC-API)
-
-#### Meteora DLMM OHLC API
-
-If you want to get OHLC (Open, High, Low, Close) data for any specific currency pair on Meteora DLMM, you can use this API. This provides technical analysis data for charting and trading strategies.
-
-▶️ [Meteora DLMM OHLC API](https://ide.bitquery.io/Meteora-DLMM-OHLC-API)
-
-#### Meteora DYN OHLC API
-
-If you want to get OHLC data for any specific currency pair on Meteora DYN, you can use this api. Only use.
-
-▶️ [Meteora DYN OHLC API](https://ide.bitquery.io/Meteora-DYN-OHLC-API)
-
-### Raydium
-
-#### Top 100 About to Graduate Raydium Launchpad Tokens
-
-Returns top 100 About to Graduate Raydium Launchpadn Tokens.
-
-▶️ [Top 100 About to Graduate Raydium Launchpad Tokens](https://ide.bitquery.io/Top-100-graduating-raydium-launchlab-tokens-in-last-5-minutes)
-
-#### Historical PumpFun Migrated Token on Raydium and Pumpswap.
-
-Historical PumpFun Migrated Token on Raydium and Pumpswap. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause. Needs the historical data add-on — see the comment at the top of the query.
-
-▶️ [Historical PumpFun Migrated Token on Raydium and Pumpswap.](https://ide.bitquery.io/all-pumpfun-migrated-token-query_4)
-
-#### Get Bonding Curve Progress of a Raydium Launchpad Token
-
-Returns Bonding Curve Percentage of a Raydium Launchpad Token.
-
-▶️ [Get Bonding Curve Progress of a Raydium Launchpad Token](https://ide.bitquery.io/bonding-curve-progress-percentage-of-a-letsbonkfun-token)
-
-#### Latest Price of a Token on Raydium Launchpad
-
-This query returns the latest price of a token on the Raydium launchpad.
-
-▶️ [Latest Price of a Token on Raydium Launchpad](https://ide.bitquery.io/Latest-Price-of-a-Token-on-Launchpad)
-
-#### Latest Trades for a specific currency on Raydium
-
-This query returns the latest trades for a token on Raydium. You can set the limit here also.
-
-▶️ [Latest Trades for a specific currency on Raydium](https://ide.bitquery.io/Trades-for-a-token-on-Raydium-on-Solana)
-
-#### DecreaseLiquidityV2 latest raydium clmm
-
-DecreaseLiquidityV2 latest raydium clmm. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
-
-▶️ [DecreaseLiquidityV2 latest raydium clmm](https://ide.bitquery.io/decreaseLiquidityV2-latest-raydium-clmm_1)
-
-### LetsBonk.fun
-
-#### Latest Price of a LetsBonk.fun Token on Launchpad
-
-Provides the most recent price data for a specific LetsBonk.fun token `token Mint Address` launched on Raydium Launchpad. You can filter by the token’s `MintAddress`, and the query will return the last recorded trade price.
-
-▶️ [Latest Price of a LetsBonk.fun Token on Launchpad](https://ide.bitquery.io/Latest-Price-of-a-LetsBonkfun-Token-on-Launchpad)
-
-#### Latest Trades of a letsbonk.fun token on Launchpad
-
-Fetches the most recent trades of a LetsBonk.fun Token `token Mint Address` on the Raydium Launchpad. Run the query.
-
-▶️ [Latest Trades of a letsbonk.fun token on Launchpad](https://ide.bitquery.io/Latest-Trades-of-a-letsbonkfun-token-on-Launchpad)
-
-#### Liquidity for a Letsbonk.fun token pair
-
-Liquidity for a Letsbonk.fun token pair. Uses the `DEXPools` cube. Replace the address in the `where` clause to use it.
-
-▶️ [Liquidity for a Letsbonk.fun token pair](https://ide.bitquery.io/liquidity-for-a-Letsbonkfun-token-pair_2)
-
-#### Ohlc for letsbonk.fun token
-
-Ohlc for letsbonk.fun token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
-
-▶️ [Ohlc for letsbonk.fun token](https://ide.bitquery.io/ohlc-for-letsbonkfun-token)
-
-#### Pool address for letsbonk.fun token
-
-Pool address for letsbonk.fun token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
-
-▶️ [Pool address for letsbonk.fun token](https://ide.bitquery.io/pool-address-for-letsbonkfun-token_1)
-
-#### Top buyers of a letsbonk.fun token on launchpad
-
-Top buyers of a letsbonk.fun token on launchpad. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
-
-▶️ [Top buyers of a letsbonk.fun token on launchpad](https://ide.bitquery.io/top-buyers-of-a-letsbonkfun-token-on-launchpad)
-
 ## BSC
 
 ### Trades
 
 #### BSC DEX Trades
 
-This query returns the latest trades on the BSC network from a trader perspective and returns useful metrics such as marketcap and pool ranking.
+This query returns the latest trades on the BSC network from a trader perspective and returns useful metrics such as marketcap and pool ranking. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [BSC DEX Trades](https://ide.bitquery.io/BSC-dextrades_9)
 
 #### BSC Dex Trade By Tokens
 
-This query returns the latest trades on the BSC network. This is useful when looking for trades of a token.
+This query returns the latest trades on the BSC network. This is useful when looking for trades of a token. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [BSC Dex Trade By Tokens](https://ide.bitquery.io/BSC-dextrades-for-a-token)
 
-#### Top Gainers on BSC
-
-Get Top Gainers for the BSC network.
-
-▶️ [Top Gainers on BSC](https://ide.bitquery.io/bsc-top-gainers)
-
 #### Get Trades by a Trader
 
-Get all trades by a particular trader.
+Get all trades by a particular trader. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [Get Trades by a Trader](https://ide.bitquery.io/BSC-dextrades-by-a-trader)
 
-#### All dexs info on bsc
+#### First 500 buyers of a specific BSC chain token — historical (beyond 30 days)
 
-Will fetch all the DEXs info for the BSC network.
+Below API gets you the first 500 buyers of a specific BSC token, here as example we have taken this token `0x031b41e504677879370e9DBcF937283A8691Fa7f`. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [All dexs info on bsc](https://ide.bitquery.io/all-dexs-info-on-bsc)
+▶️ [First 500 buyers of a specific BSC chain token — historical (beyond 30 days)](https://ide.bitquery.io/first-500-buyers-of-a-specific-BSC-chain-token_2)
 
-#### First 500 buyers of a specific BSC chain token
+#### Get all the DEXs on BSC network — historical (beyond 30 days)
 
-Below API gets you the first 500 buyers of a specific BSC token, here as example we have taken this token `0x031b41e504677879370e9DBcF937283A8691Fa7f`.
+Retrieves all the DEXes operating on BSC network and gives info such as `ProtocolName` , `ProtocolVersion` and `ProtocolFamily`. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [First 500 buyers of a specific BSC chain token](https://ide.bitquery.io/first-500-buyers-of-a-specific-BSC-chain-token_2)
+▶️ [Get all the DEXs on BSC network — historical (beyond 30 days)](https://ide.bitquery.io/Get-all-the-DEXs-on-BSC-network)
 
-#### Get all dex markets for a token
+#### Latest Flap.sh trades using DEXTrades API — historical (beyond 30 days)
 
-Will fetch all the DEXs where a token is listed for the BSC network.
+Monitor all recent trades across Flap.sh tokens using the DEXTrades API. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Get all dex markets for a token](https://ide.bitquery.io/get-all-dex-markets-for-a-token)
+▶️ [Latest Flap.sh trades using DEXTrades API — historical (beyond 30 days)](https://ide.bitquery.io/Latest-Flapsh-trades-using-DEXTrades-API)
 
-#### Get all the DEXs on BSC network
+#### Top Gainers on BSC — historical (beyond 30 days)
 
-Retrieves all the DEXes operating on BSC network and gives info such as `ProtocolName` , `ProtocolVersion` and `ProtocolFamily`.
+Get Top Gainers for the BSC network. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Get all the DEXs on BSC network](https://ide.bitquery.io/Get-all-the-DEXs-on-BSC-network)
+▶️ [Top Gainers on BSC — historical (beyond 30 days)](https://ide.bitquery.io/bsc-top-gainers)
 
-#### Latest Flap.sh trades for a specific token
+#### All dexs info on bsc — historical (beyond 30 days)
 
-Get trading activity for a specific Flap.sh token using DEXTradeByTokens API.
+Will fetch all the DEXs info for the BSC network. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Latest Flap.sh trades for a specific token](https://ide.bitquery.io/Latest-Flapsh-trades-for-a-specific-token)
+▶️ [All dexs info on bsc — historical (beyond 30 days)](https://ide.bitquery.io/all-dexs-info-on-bsc)
 
-#### Latest Flap.sh trades using DEXTrades API
+#### Get all dex markets for a token — historical (beyond 30 days)
 
-Monitor all recent trades across Flap.sh tokens using the DEXTrades API.
+Will fetch all the DEXs where a token is listed for the BSC network. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Latest Flap.sh trades using DEXTrades API](https://ide.bitquery.io/Latest-Flapsh-trades-using-DEXTrades-API)
+▶️ [Get all dex markets for a token — historical (beyond 30 days)](https://ide.bitquery.io/get-all-dex-markets-for-a-token)
+
+#### Latest Flap.sh trades for a specific token — historical (beyond 30 days)
+
+Get trading activity for a specific Flap.sh token using DEXTradeByTokens API. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Latest Flap.sh trades for a specific token — historical (beyond 30 days)](https://ide.bitquery.io/Latest-Flapsh-trades-for-a-specific-token)
 
 ### Settlements
 
@@ -1307,79 +2229,85 @@ Balance update after transfer sent bsc. Uses the `TransactionBalances` cube. Rep
 
 ### Price & OHLC
 
-#### BEP-20 Token Price
+#### Token price from top market (rank 1)
 
-Get the latest price of a BEP-20 token on BSC network.
+Prices WBNB from its single top market rather than blending every pool — the recommended way to price one specific token. Replace `token` in the Variables pane, lowercase.
 
-▶️ [BEP-20 Token Price](https://ide.bitquery.io/realtime-usd-price-of-a-token)
-
-#### Get Price Change 5min, 1h, 6h and 24h of a specific BSC token
-
-This query gets you Price Change 5min, 1h, 6h and 24h of a specific token on the BSC network.
-
-▶️ [Get Price Change 5min, 1h, 6h and 24h of a specific BSC token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_3)
-
-#### OHLC for a BEP-20 Token
-
-Get OHLC statistics for a BEP-20 token on BSC network.
-
-▶️ [OHLC for a BEP-20 Token](https://ide.bitquery.io/OHLC-for-a-token-on-bsc_1)
-
-#### Top 10 BSC Tokens by Price Change in last 1h
-
-This query gets you top 10 BSC Tokens by Price Change in last 1h.
-
-▶️ [Top 10 BSC Tokens by Price Change in last 1h](https://ide.bitquery.io/Top-10-bsc-tokens-by-price-change-in-last-1-hr)
-
-#### BSC OHLC API For Token Pair
-
-Will fetch the OHLC of a token pair for the BSC network.
-
-▶️ [BSC OHLC API For Token Pair](https://ide.bitquery.io/BSC-OHLC-API-For-Token-Pair)
-
-#### Meme rush token ATH price
-
-Fetches the All-Time High (ATH) price of a specific Meme Rush token on BSC, using the `DEXTradeByTokens` dataset to calculate the 98th percentile of trade prices (approximate ATH).
-
-▶️ [Meme rush token ATH price](https://ide.bitquery.io/meme-rush-token-ATH-price)
-
-#### Latest price of a token on bsc
-
-Will fetch latest trades for a token pair for the BSC network.
-
-▶️ [Latest price of a token on bsc](https://ide.bitquery.io/Latest-price-of-a-token-on-bsc)
+▶️ [Token price from top market (rank 1)](https://ide.bitquery.io/BSC-Token-price-from-top-market-rank-1)
 
 #### OHLCV data for specific Flap.sh token against BNB
 
-Get OHLCV data for Flap.sh tokens paired with BNB.
+Get OHLCV data for Flap.sh tokens paired with BNB. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [OHLCV data for specific Flap.sh token against BNB](https://ide.bitquery.io/OHLCV-data-for-specific-Flapsh-token-against-BNB)
 
 #### OHLCV data for specific Flap.sh token in USD
 
-Get OHLCV (Open, High, Low, Close, Volume) data for Flap.sh tokens quoted in USD.
+Get OHLCV (Open, High, Low, Close, Volume) data for Flap.sh tokens quoted in USD. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [OHLCV data for specific Flap.sh token in USD](https://ide.bitquery.io/OHLCV-data-for-specific-Flapsh-token-in-USD)
 
-#### Percentage price change for a meme rush token
+#### BEP-20 Token Price — historical (beyond 30 days)
 
-Use the below query to get the price change in percentage for various time fields including `24 hours`, `1 hour` and `5 minutes`. Try it.
+Get the latest price of a BEP-20 token on BSC network. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Percentage price change for a meme rush token](https://ide.bitquery.io/Percentage-price-change-for-a-meme-rush-token)
+▶️ [BEP-20 Token Price — historical (beyond 30 days)](https://ide.bitquery.io/realtime-usd-price-of-a-token)
+
+#### Get Price Change 5min, 1h, 6h and 24h of a specific BSC token — historical (beyond 30 days)
+
+This query gets you Price Change 5min, 1h, 6h and 24h of a specific token on the BSC network. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get Price Change 5min, 1h, 6h and 24h of a specific BSC token — historical (beyond 30 days)](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_3)
+
+#### OHLC for a BEP-20 Token — historical (beyond 30 days)
+
+Get OHLC statistics for a BEP-20 token on BSC network. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [OHLC for a BEP-20 Token — historical (beyond 30 days)](https://ide.bitquery.io/OHLC-for-a-token-on-bsc_1)
+
+#### Top 10 BSC Tokens by Price Change in last 1h — historical (beyond 30 days)
+
+This query gets you top 10 BSC Tokens by Price Change in last 1h. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Top 10 BSC Tokens by Price Change in last 1h — historical (beyond 30 days)](https://ide.bitquery.io/Top-10-bsc-tokens-by-price-change-in-last-1-hr)
+
+#### BSC OHLC API For Token Pair — historical (beyond 30 days)
+
+Will fetch the OHLC of a token pair for the BSC network. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [BSC OHLC API For Token Pair — historical (beyond 30 days)](https://ide.bitquery.io/BSC-OHLC-API-For-Token-Pair)
+
+#### Meme rush token ATH price — historical (beyond 30 days)
+
+Fetches the All-Time High (ATH) price of a specific Meme Rush token on BSC, using the `DEXTradeByTokens` dataset to calculate the 98th percentile of trade prices (approximate ATH). Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Meme rush token ATH price — historical (beyond 30 days)](https://ide.bitquery.io/meme-rush-token-ATH-price)
+
+#### Latest price of a token on bsc — historical (beyond 30 days)
+
+Will fetch latest trades for a token pair for the BSC network. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Latest price of a token on bsc — historical (beyond 30 days)](https://ide.bitquery.io/Latest-price-of-a-token-on-bsc)
+
+#### Percentage price change for a meme rush token — historical (beyond 30 days)
+
+Use the below query to get the price change in percentage for various time fields including `24 hours`, `1 hour` and `5 minutes`. Try it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Percentage price change for a meme rush token — historical (beyond 30 days)](https://ide.bitquery.io/Percentage-price-change-for-a-meme-rush-token)
 
 ### Supply & Market Cap
-
-#### Get Total Supply and Marketcap of an ERC20 token
-
-Get Total Supply and Marketcap of an ERC20 token.
-
-▶️ [Get Total Supply and Marketcap of an ERC20 token](https://ide.bitquery.io/Total-Supply-and-onchain-Marketcap-of-a-specific-token-bsc_1)
 
 #### Top Tokens by Market Cap on bsc
 
 Ranks tokens on BNB Smart Chain by `Supply.MarketCap`, with 24h window, 1s interval, $1,000+ USD volume, `limitBy` per `Token_Id`, up to 50 rows. `Token.Network` is Binance Smart Chain.
 
 ▶️ [Top Tokens by Market Cap on bsc](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-bsc)
+
+#### Get Total Supply and Marketcap of an ERC20 token
+
+Get Total Supply and Marketcap of an ERC20 token.
+
+▶️ [Get Total Supply and Marketcap of an ERC20 token](https://ide.bitquery.io/Total-Supply-and-onchain-Marketcap-of-a-specific-token-bsc_1)
 
 #### Total Supply and onchain Marketcap of a specific token bsc
 
@@ -1593,49 +2521,25 @@ Top buyers of a currency on uniswap v4 bsc. Uses the `DEXTrades` cube. Change th
 
 #### Base DEX Trades
 
-This query returns the latest trades on the Base network from a trader perspective and returns useful metrics such as marketcap and pool ranking.
+This query returns the latest trades on the Base network from a trader perspective and returns useful metrics such as marketcap and pool ranking. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [Base DEX Trades](https://ide.bitquery.io/base-dextrades_3)
 
 #### Base Dex Trade By Tokens
 
-This query returns the latest trades on the Base network. This is useful when looking for trades of a token.
+This query returns the latest trades on the Base network. This is useful when looking for trades of a token. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [Base Dex Trade By Tokens](https://ide.bitquery.io/base-dextrades-for-a-token)
 
 #### Get Trades by a Trader
 
-Get all trades by a particular trader.
+Get all trades by a particular trader. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [Get Trades by a Trader](https://ide.bitquery.io/base-dextrades-by-a-trader)
 
-#### First 500 buyers of a specific base token
-
-Below API gets you the first 500 buyers of a specific Base chain token, here as example we have taken this token `0x58538e6A46E07434d7E7375Bc268D3cb839C0133`.
-
-▶️ [First 500 buyers of a specific base token](https://ide.bitquery.io/first-500-buyers-of-a-specific-base-token)
-
-#### Latest Trades of a Token on Zora Base
-
-Latest Trades of a Token on Zora Base. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
-
-▶️ [Latest Trades of a Token on Zora Base](https://ide.bitquery.io/Latest-Trades-of-a-Token-on-Zora-Base)
-
-#### Latest Zora Trades on Base
-
-Fetches the latest DEX trades on the Zora protocol (`zora_v4`) on Base blockchain.
-
-▶️ [Latest Zora Trades on Base](https://ide.bitquery.io/Latest-Zora-Trades-on-Base)
-
-#### Most Traded Tokens on Aerodome Last Month
-
-Discover the most actively traded tokens on Aerodrome Finance over any time period. This query analyzes all DEX trades within a specified timeframe and ranks tokens by trade count, helping you identify trending tokens and market activity patterns.
-
-▶️ [Most Traded Tokens on Aerodome Last Month](https://ide.bitquery.io/Most-Traded-Tokens-on-Aerodome-Last-Month)
-
 #### Top Traders by PnL of a specific base pool
 
-Rank traders by `PnL` on one pool: filter `Pair.Market.Address`, last 30 minutes, `limit: 10`, and `orderBy` `PnL` descending. Useful for leaderboards, smart-money screens, and pool-specific trader analytics.
+Rank traders by `PnL` on one pool: filter `Pair.Market.Address`, last 30 minutes, `limit: 10`, and `orderBy` `PnL` descending. Useful for leaderboards, smart-money screens, and pool-specific trader analytics. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [Top Traders by PnL of a specific base pool](https://ide.bitquery.io/Top-Traders-by-PnL-of-a-specific-base-pool_1)
 
@@ -1644,6 +2548,30 @@ Rank traders by `PnL` on one pool: filter `Pair.Market.Address`, last 30 minutes
 Ape store token trades. Uses the `Calls` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [Ape store token trades](https://ide.bitquery.io/ape-store-token-trades)
+
+#### First 500 buyers of a specific base token — historical (beyond 30 days)
+
+Below API gets you the first 500 buyers of a specific Base chain token, here as example we have taken this token `0x58538e6A46E07434d7E7375Bc268D3cb839C0133`. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [First 500 buyers of a specific base token — historical (beyond 30 days)](https://ide.bitquery.io/first-500-buyers-of-a-specific-base-token)
+
+#### Latest Trades of a Token on Zora Base — historical (beyond 30 days)
+
+Latest Trades of a Token on Zora Base. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Latest Trades of a Token on Zora Base — historical (beyond 30 days)](https://ide.bitquery.io/Latest-Trades-of-a-Token-on-Zora-Base)
+
+#### Latest Zora Trades on Base — historical (beyond 30 days)
+
+Fetches the latest DEX trades on the Zora protocol (`zora_v4`) on Base blockchain. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Latest Zora Trades on Base — historical (beyond 30 days)](https://ide.bitquery.io/Latest-Zora-Trades-on-Base)
+
+#### Most Traded Tokens on Aerodome Last Month — historical (beyond 30 days)
+
+Discover the most actively traded tokens on Aerodrome Finance over any time period. This query analyzes all DEX trades within a specified timeframe and ranks tokens by trade count, helping you identify trending tokens and market activity patterns. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Most Traded Tokens on Aerodome Last Month — historical (beyond 30 days)](https://ide.bitquery.io/Most-Traded-Tokens-on-Aerodome-Last-Month)
 
 ### Transfers
 
@@ -1672,6 +2600,12 @@ We use the `any` filter [ OR condition] to get transactions from or to a wallet.
 ▶️ [Tx from to base address](https://ide.bitquery.io/tx-from-to-base-address)
 
 ### Balances & Holders
+
+#### Current balance of an address
+
+Every token balance held by one Base address. Balances are cumulative, so this reads the whole history — replace the address to use it.
+
+▶️ [Current balance of an address](https://ide.bitquery.io/Base-Current-balance-of-an-address)
 
 #### Real-Time Holders of Multiple Tokens
 
@@ -1735,61 +2669,61 @@ The number of unique holders, token supply, and Gini coefficient for the balance
 
 ### Price & OHLC
 
-#### Get ATH Price of a token
+#### Token price from top market (rank 1)
 
-Retrieves the all-time high (ATH) price in USD for a specified token contract.
+Prices WETH from its single top market rather than blending every pool — the recommended way to price one specific token. Replace `token` in the Variables pane, lowercase.
 
-▶️ [Get ATH Price of a token](https://ide.bitquery.io/ATH-of-base-token)
+▶️ [Token price from top market (rank 1)](https://ide.bitquery.io/Base-Token-price-from-top-market-rank-1)
 
-#### Get Multiple Token Prices
+#### Get Multiple Token Prices — historical (beyond 30 days)
 
-Returns an array of token prices denominated in the blockchain's native token and USD for a given token contract address.
+Returns an array of token prices denominated in the blockchain's native token and USD for a given token contract address. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Get Multiple Token Prices](https://ide.bitquery.io/Price-of-multiple-tokens-in-realtime_1)
+▶️ [Get Multiple Token Prices — historical (beyond 30 days)](https://ide.bitquery.io/Price-of-multiple-tokens-in-realtime_1)
 
-#### Get OHLCV by Pair Address
+#### Get ATH Price of a token — historical (beyond 30 days)
 
-Get the OHLCV candle stick by using pair address.
+Retrieves the all-time high (ATH) price in USD for a specified token contract. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Get OHLCV by Pair Address](https://ide.bitquery.io/OHLC--base)
+▶️ [Get ATH Price of a token — historical (beyond 30 days)](https://ide.bitquery.io/ATH-of-base-token)
 
-#### Get Price Change 5min, 1h, 6h and 24h of a specific token
+#### Get OHLCV by Pair Address — historical (beyond 30 days)
 
-This query gets you Price Change 5min, 1h, 6h and 24h of a specific token on the Base network.
+Get the OHLCV candle stick by using pair address. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Get Price Change 5min, 1h, 6h and 24h of a specific token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_6)
+▶️ [Get OHLCV by Pair Address — historical (beyond 30 days)](https://ide.bitquery.io/OHLC--base)
 
-#### Top 10 Base Tokens by Price Change in last 1h
+#### Get Price Change 5min, 1h, 6h and 24h of a specific token — historical (beyond 30 days)
 
-This query gets you top 10 Base Tokens by Price Change in last 1h.
+This query gets you Price Change 5min, 1h, 6h and 24h of a specific token on the Base network. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Top 10 Base Tokens by Price Change in last 1h](https://ide.bitquery.io/Top-10-base-tokens-by-price-change-in-last-1-hr_1)
+▶️ [Get Price Change 5min, 1h, 6h and 24h of a specific token — historical (beyond 30 days)](https://ide.bitquery.io/Price-change-5min-1hr-6hr-precentage-of-a-specific-token_6)
 
-#### OHLC-of-AERO-Coin
+#### Top 10 Base Tokens by Price Change in last 1h — historical (beyond 30 days)
 
-OHLC-of-AERO-Coin. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+This query gets you top 10 Base Tokens by Price Change in last 1h. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [OHLC-of-AERO-Coin](https://ide.bitquery.io/OHLC-of-AERO-Coin_1)
+▶️ [Top 10 Base Tokens by Price Change in last 1h — historical (beyond 30 days)](https://ide.bitquery.io/Top-10-base-tokens-by-price-change-in-last-1-hr_1)
 
-#### Price change 5min, 1hr, 6hr, 24h precentage of a specific token
+#### OHLC-of-AERO-Coin — historical (beyond 30 days)
 
-Price change 5min, 1hr, 6hr, 24h precentage of a specific token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+OHLC-of-AERO-Coin. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Price change 5min, 1hr, 6hr, 24h precentage of a specific token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-24h-precentage-of-a-specific-token)
+▶️ [OHLC-of-AERO-Coin — historical (beyond 30 days)](https://ide.bitquery.io/OHLC-of-AERO-Coin_1)
 
-#### Top 10 base tokens by price change in last 1 hr
+#### Price change 5min, 1hr, 6hr, 24h precentage of a specific token — historical (beyond 30 days)
 
-Top 10 base tokens by price change in last 1 hr. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query.
+Price change 5min, 1hr, 6hr, 24h precentage of a specific token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Top 10 base tokens by price change in last 1 hr](https://ide.bitquery.io/Top-10-base-tokens-by-price-change-in-last-1-hr)
+▶️ [Price change 5min, 1hr, 6hr, 24h precentage of a specific token — historical (beyond 30 days)](https://ide.bitquery.io/Price-change-5min-1hr-6hr-24h-precentage-of-a-specific-token)
+
+#### Top 10 base tokens by price change in last 1 hr — historical (beyond 30 days)
+
+Top 10 base tokens by price change in last 1 hr. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Top 10 base tokens by price change in last 1 hr — historical (beyond 30 days)](https://ide.bitquery.io/Top-10-base-tokens-by-price-change-in-last-1-hr)
 
 ### Supply & Market Cap
-
-#### Get Token Total Supply and Market Cap
-
-Retrieve the total supply and market capitalization of a specific token. This query provides on-chain market cap data.
-
-▶️ [Get Token Total Supply and Market Cap](https://ide.bitquery.io/Get-Token-Total-Supply-and-Market-Cap_5)
 
 #### Top Tokens by Market Cap on Base
 
@@ -1797,17 +2731,23 @@ This query ranks Base tokens by `Supply.MarketCap`. It uses roughly the last 24 
 
 ▶️ [Top Tokens by Market Cap on Base](https://ide.bitquery.io/Top-Tokens-by-Market-Cap-on-Base)
 
-#### Total supply of a AERO on Base
-
-Total supply of a AERO on Base. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
-
-▶️ [Total supply of a AERO on Base](https://ide.bitquery.io/Total-supply-of-a-AERO-on-Base)
-
 #### Bankr token latest marketcap OHLC
 
 Bankr token latest marketcap OHLC. Uses the `Tokens` cube.
 
 ▶️ [Bankr token latest marketcap OHLC](https://ide.bitquery.io/Bankr-token-latest-marketcap-OHLC)
+
+#### Get Token Total Supply and Market Cap
+
+Retrieve the total supply and market capitalization of a specific token. This query provides on-chain market cap data.
+
+▶️ [Get Token Total Supply and Market Cap](https://ide.bitquery.io/Get-Token-Total-Supply-and-Market-Cap_5)
+
+#### Total supply of a AERO on Base
+
+Total supply of a AERO on Base. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Total supply of a AERO on Base](https://ide.bitquery.io/Total-supply-of-a-AERO-on-Base)
 
 #### Total Supply and onchain Marketcap of a specific token base
 
@@ -2061,43 +3001,49 @@ Filter withdraw activity for a single gauge pool. Useful for monitoring liquidit
 
 ### Trades
 
-#### Pair last trades
-
-Retrieves all DEX trades on the arbitrum where the Arbitrum currency is `ArbitrumCurrency` and the quote currency is `quoteCurrency` that occurred between the specified dates.
-
-▶️ [Pair last trades](https://ide.bitquery.io/Pair-last-trades_2)
-
 #### Swap Events Arbitrum
 
 Returns the 10 most recent `swap` events on the Arbitrum network. We get this by using the signature hash `c42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67` for the swap event.
 
 ▶️ [Swap Events Arbitrum](https://ide.bitquery.io/Swap-Events-Arbitrum)
 
+#### Pair last trades
+
+Retrieves all DEX trades on the arbitrum where the Arbitrum currency is `ArbitrumCurrency` and the quote currency is `quoteCurrency` that occurred between the specified dates. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Pair last trades](https://ide.bitquery.io/Pair-last-trades_2)
+
 #### Top Sold Tokens on Arbitrum
 
-Top Sold Tokens on Arbitrum. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
+Top Sold Tokens on Arbitrum. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Top Sold Tokens on Arbitrum](https://ide.bitquery.io/Top-Sold-Tokens-on-Arbitrum)
 
 #### Top bought tokens on Arbitrum
 
-Top bought tokens on Arbitrum. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
+Top bought tokens on Arbitrum. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Top bought tokens on Arbitrum](https://ide.bitquery.io/top-bought-tokens-on-Arbitrum)
 
 #### Top traders for a token on Arbitrum
 
-Top traders for a token on Arbitrum. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Top traders for a token on Arbitrum. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Top traders for a token on Arbitrum](https://ide.bitquery.io/top-traders-for-a-token-on-Arbitrum_3)
 
 #### Trending token pairs on Arbitrum
 
-Crypto Trades API: one row per swap, with USD and supply. Filter `Pair.Market.Network: Arbitrum`. When to use this vs chain DEX APIs.
+Crypto Trades API: one row per swap, with USD and supply. Filter `Pair.Market.Network: Arbitrum`. When to use this vs chain DEX APIs. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Trending token pairs on Arbitrum](https://ide.bitquery.io/trending-token-pairs-on-Arbitrum)
 
 ### Balances & Holders
+
+#### Current balance of an address
+
+Every token balance held by one Arbitrum address. Balances are cumulative, so this reads the whole history — replace the address to use it.
+
+▶️ [Current balance of an address](https://ide.bitquery.io/Arbitrum-Current-balance-of-an-address)
 
 #### Arbitrum Balance of an Address
 
@@ -2137,23 +3083,29 @@ The number of unique holders, token supply, and Gini coefficient for the balance
 
 ### Price & OHLC
 
-#### Ohlc for a pair on Arbitrum
+#### Token price from top market (rank 1)
 
-Ohlc for a pair on Arbitrum. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+Prices WETH from its single top market rather than blending every pool — the recommended way to price one specific token. Replace `token` in the Variables pane, lowercase.
 
-▶️ [Ohlc for a pair on Arbitrum](https://ide.bitquery.io/ohlc-for-a-pair-on-Arbitrum_1)
+▶️ [Token price from top market (rank 1)](https://ide.bitquery.io/Arbitrum-Token-price-from-top-market-rank-1)
 
-#### Price change 5min, 1hr, 6hr, 24hr precentage of a specific token
+#### Ohlc for a pair on Arbitrum — historical (beyond 30 days)
 
-Price change 5min, 1hr, 6hr, 24hr precentage of a specific token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+Ohlc for a pair on Arbitrum. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Price change 5min, 1hr, 6hr, 24hr precentage of a specific token](https://ide.bitquery.io/Price-change-5min-1hr-6hr-24hr-precentage-of-a-specific-token_1)
+▶️ [Ohlc for a pair on Arbitrum — historical (beyond 30 days)](https://ide.bitquery.io/ohlc-for-a-pair-on-Arbitrum_1)
 
-#### Top 10 arb tokens by price change in last 1 hr
+#### Price change 5min, 1hr, 6hr, 24hr precentage of a specific token — historical (beyond 30 days)
 
-Top 10 arb tokens by price change in last 1 hr. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query.
+Price change 5min, 1hr, 6hr, 24hr precentage of a specific token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Top 10 arb tokens by price change in last 1 hr](https://ide.bitquery.io/Top-10-arb-tokens-by-price-change-in-last-1-hr)
+▶️ [Price change 5min, 1hr, 6hr, 24hr precentage of a specific token — historical (beyond 30 days)](https://ide.bitquery.io/Price-change-5min-1hr-6hr-24hr-precentage-of-a-specific-token_1)
+
+#### Top 10 arb tokens by price change in last 1 hr — historical (beyond 30 days)
+
+Top 10 arb tokens by price change in last 1 hr. Uses the `DEXTradeByTokens` cube. Needs the historical data add-on — see the comment at the top of the query. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Top 10 arb tokens by price change in last 1 hr — historical (beyond 30 days)](https://ide.bitquery.io/Top-10-arb-tokens-by-price-change-in-last-1-hr)
 
 ### Supply & Market Cap
 
@@ -2257,23 +3209,29 @@ Trade stats for a token pair on uniswap v4 arbitrum. Uses the `DEXTradeByTokens`
 
 #### Top tokens on optimism
 
-Top tokens on optimism. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
+Top tokens on optimism. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Top tokens on optimism](https://ide.bitquery.io/top-tokens-on-optimism)
 
 #### Top traders for wld usdc pair
 
-You can checkout a completed product using this info on DEXRabbit.
+You can checkout a completed product using this info on DEXRabbit. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Top traders for wld usdc pair](https://ide.bitquery.io/top-traders-for-wld-usdc-pair)
 
 #### Top traders on optimism
 
-Top traders on optimism. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause.
+Top traders on optimism. Uses the `DEXTradeByTokens` cube. Adjust the date range in the `where` clause. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Top traders on optimism](https://ide.bitquery.io/top-traders-on-optimism)
 
 ### Balances & Holders
+
+#### Current balance of an address
+
+Every token balance held by one Optimism address. Balances are cumulative, so this reads the whole history — replace the address to use it.
+
+▶️ [Current balance of an address](https://ide.bitquery.io/Optimism-Current-balance-of-an-address)
 
 #### Optimism Balance of an Address
 
@@ -2337,21 +3295,29 @@ Trade stats for a token pair on uniswap v4 optimism. Uses the `DEXTradeByTokens`
 
 ▶️ [Trade stats for a token pair on uniswap v4 optimism](https://ide.bitquery.io/trade-stats-for-a-token-pair-on-uniswap-v4-optimism)
 
+### Price & OHLC
+
+#### Token price from top market (rank 1)
+
+Prices WETH from its single top market rather than blending every pool — the recommended way to price one specific token. Replace `token` in the Variables pane, lowercase.
+
+▶️ [Token price from top market (rank 1)](https://ide.bitquery.io/Optimism-Token-price-from-top-market-rank-1)
+
 ## Polygon
 
 ### Trades
 
 #### Top Traders by PnL of a specific polygon pool
 
-Rank traders by `PnL` on one pool: filter `Pair.Market.Address`, last 30 minutes, `limit: 10`, and `orderBy` `PnL` descending. Useful for leaderboards, smart-money screens, and pool-specific trader analytics.
+Rank traders by `PnL` on one pool: filter `Pair.Market.Address`, last 30 minutes, `limit: 10`, and `orderBy` `PnL` descending. Useful for leaderboards, smart-money screens, and pool-specific trader analytics. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [Top Traders by PnL of a specific polygon pool](https://ide.bitquery.io/Top-Traders-by-PnL-of-a-specific-polygon-pool)
 
-#### Top traders of a token on matic
+#### Top traders of a token on matic — historical (beyond 30 days)
 
-This query ranks traders of one token by volume, splitting bought and sold amounts and totalling volume in native and USD terms. `since_relative` keeps the window rolling.
+This query ranks traders of one token by volume, splitting bought and sold amounts and totalling volume in native and USD terms. `since_relative` keeps the window rolling. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Top traders of a token on matic](https://ide.bitquery.io/top-traders-of-a-token-on-matic_1)
+▶️ [Top traders of a token on matic — historical (beyond 30 days)](https://ide.bitquery.io/top-traders-of-a-token-on-matic_1)
 
 ### Transfers
 
@@ -2362,6 +3328,12 @@ This is cheaper than scanning all `PredictionTrades` when you only need a yes/no
 ▶️ [Check if an address interacted with polymarket ever](https://ide.bitquery.io/check-if-an-address-interacted-with-polymarket-ever)
 
 ### Balances & Holders
+
+#### Current balance of an address
+
+Every token balance held by one Polygon address. Balances are cumulative, so this reads the whole history — replace the address to use it.
+
+▶️ [Current balance of an address](https://ide.bitquery.io/Polygon-Current-balance-of-an-address)
 
 #### Balance of an address
 
@@ -2465,454 +3437,6 @@ Fetches the traded volume, buy volume and sell volume of a token `0x0d500b1d8e8e
 
 ▶️ [Trade volume matic uniswapv3](https://ide.bitquery.io/trade_volume_matic_uniswapv3)
 
-## TRON
-
-### Trades
-
-#### Historical Tron Token Trades beyond 30 Days
-
-This query returns the historical token trades on the TRON network for time window beyond 30 days.
-
-▶️ [Historical Tron Token Trades beyond 30 Days](https://ide.bitquery.io/Historical-tron-token-trades-beyond-30-days)
-
-#### Historical Tron Token Trades within 30 Days
-
-This query returns the historical trades on the TRON network for a token with the time window of past 30 days.
-
-▶️ [Historical Tron Token Trades within 30 Days](https://ide.bitquery.io/Historical-Tron-trades-for-a-token-within-30-days)
-
-#### Tron DEX Trades
-
-This query returns the latest trades on the TRON network from a trader perspective.
-
-▶️ [Tron DEX Trades](https://ide.bitquery.io/Tron-Trades)
-
-#### Tron Dex Trade By Tokens
-
-This query returns the latest token trades on the TRON network.
-
-▶️ [Tron Dex Trade By Tokens](https://ide.bitquery.io/Tron-trades-for-a-token)
-
-#### All dexs info
-
-Fetches all the DEXs information on Tron network such as unique sellers, unique buyers etc.
-
-▶️ [All dexs info](https://ide.bitquery.io/all-dexs-info)
-
-#### DEX Markets for a token
-
-Fetches the DEXs where a specific token is being traded on Tron network.
-
-▶️ [DEX Markets for a token](https://ide.bitquery.io/DEX-Markets-for-a-token_1)
-
-#### First 100 buyers tron token
-
-Find the earliest buyers of any Tron token by using Tron `DEXTradeByTokens` API. This is widely used for memecoin sniper detection, early-holder analysis, and alpha groups monitoring SunPump / SunSwap launches.
-
-▶️ [First 100 buyers tron token](https://ide.bitquery.io/first-100-buyers-tron-token)
-
-#### Peg health tron
-
-Browse multi-chain stablecoin DEX prices on DEXrabbit's Stablecoins category.
-
-▶️ [Peg health tron](https://ide.bitquery.io/peg-health-tron)
-
-#### Sunmpump launchtoDEX
-
-This query allows you to track when tokens are launched on SunSwap using the `launchToDEX` function. It returns the most recent 10 token launches, displaying details such as the token address, transaction hash, block timestamp, and the method call signature.
-
-▶️ [Sunmpump launchtoDEX](https://ide.bitquery.io/sunmpump-launchtoDEX_1)
-
-#### Sunswap v2 latest Trades
-
-Retrieves details about each trade, including the amounts and prices of tokens bought and sold, as well as information about the trading pair.
-
-▶️ [Sunswap v2 latest Trades](https://ide.bitquery.io/sunswap-v2-latest-Trades)
-
-### Transfers
-
-#### Historical TRON Transfers for a Wallet
-
-This query returns the historical transfers for a wallet in a given time window on the TRON network and includes details such as token amount transferred, sender, receiver, and token info.
-
-▶️ [Historical TRON Transfers for a Wallet](https://ide.bitquery.io/Historical-Tron-transfers-for-a-wallet)
-
-#### Latest TRON Transfers
-
-This query returns the most recent transfers on the TRON network and includes details such as token amount transferred, sender, receiver, and token info.
-
-▶️ [Latest TRON Transfers](https://ide.bitquery.io/Tron-transfer_10_1)
-
-#### Daily transfer volume tron
-
-Aggregate daily transfer volume in USD for any TRC20 token for analytics dashboards, weekly newsletters, and on-chain reports for stablecoins, governance tokens, and memecoins on Tron.
-
-▶️ [Daily transfer volume tron](https://ide.bitquery.io/daily-transfer-volume-tron)
-
-#### Top transfers of a token
-
-Retrieves the top 10 transfers by amount of the token `TXL6rJbvmjD46zeN1JssfgxvSo99qC8MRT`.
-
-▶️ [Top transfers of a token](https://ide.bitquery.io/top-transfers-of-a-token_2)
-
-#### Tron total txn fees paid by the Account
-
-Get the total fees (in SOL and USD) paid by a specific Tron account across all transfers.
-
-▶️ [Tron total txn fees paid by the Account](https://ide.bitquery.io/Tron-total-txn-fees-paid-by-the-Account)
-
-#### Transfers of a wallet API
-
-Fetches the recent 10 transfers of a specific wallet address `TFXttAWURRrXrd9JvFPVLEh1esJK8NHxn7`.
-
-▶️ [Transfers of a wallet API](https://ide.bitquery.io/Transfers-of-a-wallet-API)
-
-#### Tron Transaction fees paid by Account aggregated by currency
-
-Get total fees paid by a Tron account for transferring each type of token.
-
-▶️ [Tron Transaction fees paid by Account aggregated by currency](https://ide.bitquery.io/Tron-Transaction-fees-paid-by-Account-aggregated-by-currency)
-
-#### Tron wallet transfers with transaction fees paid
-
-Track wallet token transfers and get the fees paid for each by the address.
-
-▶️ [Tron wallet transfers with transaction fees paid](https://ide.bitquery.io/tron-wallet-transfers-with-transaction-fees-paid)
-
-### Balances & Holders
-
-#### Historical Balance of a Wallet for a Currency
-
-This query returns the current balance of a wallet for all currencies on the TRON network.
-
-▶️ [Historical Balance of a Wallet for a Currency](https://ide.bitquery.io/Historical-Tron-Wallet-Balance-for-a-currency)
-
-#### Top token holders of a token
-
-Returns the top holders of a token ranked by current balance. Use the Holders API with `orderBy` and `limit`.
-
-▶️ [Top token holders of a token](https://ide.bitquery.io/top-token-holders-of-a-token)
-
-#### Tron Balances for Native currency
-
-Returns the native TRX balance for a wallet (not TRC10 or TRC20 tokens). Filter with `Currency: { Native: true }` instead of a token contract address.
-
-▶️ [Tron Balances for Native currency](https://ide.bitquery.io/Tron-Balances-for-Native-currency)
-
-#### Tron USDT Balance At Date (Balances Cube)
-
-Unlike summing Transfers, this includes mints, burns, and genesis supply.
-
-▶️ [Tron USDT Balance At Date (Balances Cube)](https://ide.bitquery.io/tron-usdt-balance-at-date)
-
-#### Tron balances by date
-
-Returns balance snapshots over time for an address. Use `dataset: archive`. Order by `Block_Date` descending and use `limit` to paginate. Add `Currency.SmartContract` under `Currency` to filter by a specific token.
-
-▶️ [Tron balances by date](https://ide.bitquery.io/tron-balances-by-date)
-
-#### Tron token balance
-
-Add a `Currency.SmartContract` filter. Always use the contract address, not the token name.
-
-▶️ [Tron token balance](https://ide.bitquery.io/tron-token-balance)
-
-#### TronWalletPortfolio Tron
-
-Returns balances for all the currecies owned by a wallet address. Use `Amount(selectWhere: { gt: "0" })` to exclude zero balances and `dataset: combined` for the latest balances.
-
-▶️ [TronWalletPortfolio Tron](https://ide.bitquery.io/TronWalletPortfolio-Tron)
-
-#### SunPump Bonding Curve TRX Balance
-
-TRX balance in bonding curve based on dex trades. Calculated as `balance = in_sum - out_sum`
-
-▶️ [SunPump Bonding Curve TRX Balance](https://ide.bitquery.io/SunPump-Bonding-Curve-TRX-Balance)
-
-#### SunPump Historical Bonding Curve TRX Balance
-
-Calculated as `balance = in_sum - out_sum`
-
-▶️ [SunPump Historical Bonding Curve TRX Balance](https://ide.bitquery.io/SunPump-Historical-Bonding-Curve-TRX-Balance)
-
-### Liquidity & Pools
-
-#### Sun Pump Virtual Liquidity Pools
-
-Sun Pump does not use a dedicated pool for each pair; instead, all liquidity is managed within a single contract. You can query the virtual liquidity pools directly by running the following query.
-
-▶️ [Sun Pump Virtual Liquidity Pools](https://ide.bitquery.io/Sun-Pump-Virtual-Liquidity-Pools_1)
-
-### Events & Calls
-
-#### Latest created Sunpump tokens
-
-If you remove `subscription` from the below GraphQL query it will become API, for example check.
-
-▶️ [Latest created Sunpump tokens](https://ide.bitquery.io/latest-created-Sunpump-tokens)
-
-#### Latest tokens created on Sunpump
-
-The `Arguments` include the token address, creator, and token index. You can run it.
-
-▶️ [Latest tokens created on Sunpump](https://ide.bitquery.io/Latest-tokens-created-on-Sunpump_2)
-
-#### TokenPurchased on Sunpump
-
-This query allows you to track `TokenPurchased` events on SunPump. It retrieves the 10 most recent token purchase events, showing important details such as the token address, buyer information, transaction hash, and token amount involved.
-
-▶️ [TokenPurchased on Sunpump](https://ide.bitquery.io/TokenPurchased-on-Sunpump)
-
-## Robinhood Chain
-
-### Trades
-
-#### Largest Trades on Robinhood Chain (24h, USD)
-
-Largest Trades on Robinhood Chain (24h, USD). Uses the `Trades` cube.
-
-▶️ [Largest Trades on Robinhood Chain (24h, USD)](https://ide.bitquery.io/largest-swaps-robinhood-chain)
-
-#### Pools trade Crowd Launch bids
-
-The launch transaction also contains the token's mint, the entry contract's `TokenCreated`, and the auction's first `TickInitialized` / `ClearingPriceUpdated` events, so one transaction hash links token, creator, and auction contract.
-
-▶️ [Pools trade Crowd Launch bids](https://ide.bitquery.io/Pools-trade-Crowd-Launch-bids)
-
-#### Pools trade Latest launches
-
-The decoded `TokenCreated` event on the two entry contracts is the cleanest launch feed — one row per launch.
-
-▶️ [Pools trade Latest launches](https://ide.bitquery.io/Pools-trade-Latest-launches)
-
-#### Pools trade Latest trades for a token
-
-Tokens also migrate onto other venues once liquid — the same token can show `uniswap_v3` and `pancake_swap_v3` markets with `WETH` and `USDG` quotes.
-
-▶️ [Pools trade Latest trades for a token](https://ide.bitquery.io/Pools-trade-Latest-trades-for-a-token)
-
-#### Pools trade Launches per day
-
-Grouping by `LogHeader.Address` too shows the split between the two entry contracts.
-
-▶️ [Pools trade Launches per day](https://ide.bitquery.io/Pools-trade-Launches-per-day)
-
-#### Pools trade Most active token creators
-
-Useful for spotting spam-bot deployers — a single wallet can mint hundreds of tokens a day.
-
-▶️ [Pools trade Most active token creators](https://ide.bitquery.io/Pools-trade-Most-active-token-creators)
-
-#### Pools trade PoolKey from TokenLaunched
-
-Pools trade PoolKey from TokenLaunched. Uses the `Events` cube.
-
-▶️ [Pools trade PoolKey from TokenLaunched](https://ide.bitquery.io/Pools-trade-PoolKey-from-TokenLaunched)
-
-#### Pools trade Token description and image
-
-The filter below pins the factory by address because the entry contract emits a *different* `TokenCreated` under the same name (see Reading decoded arguments).
-
-▶️ [Pools trade Token description and image](https://ide.bitquery.io/Pools-trade-Token-description-and-image)
-
-#### Pools trade TokenDistributed decoded event
-
-Topic0 filtering remains available and is the precise way to pin one exact signature — useful for the overloaded `TokenCreated` above. Supply the hash without a `0x` prefix; see the dataset note below for its one limitation.
-
-▶️ [Pools trade TokenDistributed decoded event](https://ide.bitquery.io/Pools-trade-raw-event-by-topic0)
-
-#### Pools trade Top tokens by volume
-
-The two-step pattern: pass a token set harvested from `TokenCreated` into the `Trading` cube.
-
-▶️ [Pools trade Top tokens by volume](https://ide.bitquery.io/Pools-trade-Top-tokens-by-volume)
-
-### Transfers
-
-#### Ape.store Newly created tokens
-
-Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
-
-▶️ [Ape.store Newly created tokens](https://ide.bitquery.io/Apestore-Newly-created-tokens)
-
-#### Bags.fm Newly created tokens
-
-Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
-
-▶️ [Bags.fm Newly created tokens](https://ide.bitquery.io/Bagsfm-Newly-created-tokens)
-
-#### Bankr Bot Newly created tokens
-
-Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
-
-▶️ [Bankr Bot Newly created tokens](https://ide.bitquery.io/Bankr-Bot-Newly-created-tokens)
-
-#### Flap.sh Newly created tokens using transfer data
-
-Track Flap.sh mints as transfers from the zero address with amount `1000000000` in transactions sent to the Flap.sh contract.
-
-▶️ [Flap.sh Newly created tokens using transfer data](https://ide.bitquery.io/Flapsh-Newly-created-tokens-using-transfer-data)
-
-#### Klik Finance Newly created tokens using transfers
-
-Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
-
-▶️ [Klik Finance Newly created tokens using transfers](https://ide.bitquery.io/Klik-Finance-Newly-created-tokens-using-transfers)
-
-#### Robinhood Chain API - Latest Token Transfers
-
-Robinhood Chain API - Latest Token Transfers. Uses the `Transfers` cube.
-
-▶️ [Robinhood Chain API - Latest Token Transfers](https://ide.bitquery.io/latest-transfers-on-robinhood)
-
-#### Robinhood Chain Token Lookup by Contract Address
-
-Metadata splits across two sources. Name, symbol, decimals, and contract are indexed on every transfer's `Currency` object — one query against the launch mint gives you all four for any token.
-
-▶️ [Robinhood Chain Token Lookup by Contract Address](https://ide.bitquery.io/Pools-trade-Token-name-symbol-decimals)
-
-#### Token Lookup by Contract Address - Robinhood Chain
-
-Follow the steps here: How to generate Bitquery API token ➤.
-
-▶️ [Token Lookup by Contract Address - Robinhood Chain](https://ide.bitquery.io/token-lookup-by-address-robinhood-chain)
-
-#### Transfers for a token on robinhood
-
-Filter with `Transfer.Currency.SmartContract`. Example: WETH on Robinhood.
-
-▶️ [Transfers for a token on robinhood](https://ide.bitquery.io/Transfers-for-a-token-on-robinhood)
-
-#### Transfers for a wallet on Robinhood
-
-Filter where the address is either `Transfer.Sender` or `Transfer.Receiver` to build a full transfer history. Replace the sample address with your wallet or contract.
-
-▶️ [Transfers for a wallet on Robinhood](https://ide.bitquery.io/transfers-for-a-wallet-on-Robinhood)
-
-### Balances & Holders
-
-#### Pools trade Per-transaction balance changes
-
-A stream of this filtered to `SlippageBasisPoints: {gt: 100}` is a ready-made "toxic fill" alert for a token's pool.
-
-▶️ [Pools trade Per-transaction balance changes](https://ide.bitquery.io/Pools-trade-Per-transaction-balance-changes)
-
-#### Wallet Token Balances on Robinhood Chain
-
-Wallet Token Balances on Robinhood Chain. Uses the `Balances` cube. Replace the address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
-
-▶️ [Wallet Token Balances on Robinhood Chain](https://ide.bitquery.io/wallet-token-balances-robinhood-chain)
-
-### Price & OHLC
-
-#### Latest price of a token
-
-If you want to monitor price for a particular pool, we suggest usage of `Trading.Pairs` instead of `Trading.Tokens` where you could specify the pool address.
-
-▶️ [Latest price of a token](https://ide.bitquery.io/latest-price-of-a-token_10)
-
-#### Latest price of a token on a pool
-
-This API endpoint retrieves the latest price of a token for a particular token pair or liquidity pool using the `Trading.Pairs` cube.
-
-▶️ [Latest price of a token on a pool](https://ide.bitquery.io/latest-price-of-a-token-on-a-pool)
-
-#### Pools trade OHLCV price candles
-
-Deduplicate on `(TransactionHeader.Hash, Block.Time, Side, Amounts.Base, Pair.QuoteToken.Symbol, Trader.Address)` before aggregating.
-
-▶️ [Pools trade OHLCV price candles](https://ide.bitquery.io/Pools-trade-OHLCV-price-candles)
-
-### Supply & Market Cap
-
-#### Pools trade Token holders and supply
-
-Pools trade Token holders and supply. Uses the `Holders` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
-
-▶️ [Pools trade Token holders and supply](https://ide.bitquery.io/Pools-trade-Token-holders-and-supply)
-
-### Liquidity & Pools
-
-#### Pools trade Per-swap slippage
-
-Pools trade Per-swap slippage.
-
-▶️ [Pools trade Per-swap slippage](https://ide.bitquery.io/Pools-trade-Per-swap-slippage)
-
-#### Pools trade Pool creation Initialize
-
-The v4 PoolManager's `Initialize` is decoded, so you can read the same `PoolKey` without manual decoding — at the cost of having to scope it to a token.
-
-▶️ [Pools trade Pool creation Initialize](https://ide.bitquery.io/Pools-trade-Pool-creation-Initialize)
-
-### Transactions
-
-#### Daily Active Wallets on Robinhood Chain
-
-Daily Active Wallets on Robinhood Chain. Uses the `Transactions` cube. Needs the historical data add-on — see the comment at the top of the query.
-
-▶️ [Daily Active Wallets on Robinhood Chain](https://ide.bitquery.io/robinhood-chain-active-wallets)
-
-#### Robinhood Chain Daily Transaction Count
-
-Robinhood Chain Daily Transaction Count. Uses the `Transactions` cube. Needs the historical data add-on — see the comment at the top of the query.
-
-▶️ [Robinhood Chain Daily Transaction Count](https://ide.bitquery.io/robinhood-chain-daily-transactions)
-
-#### Robinhood Chain Gas Usage and Gas Price
-
-Robinhood Chain Gas Usage and Gas Price. Uses the `Transactions` cube.
-
-▶️ [Robinhood Chain Gas Usage and Gas Price](https://ide.bitquery.io/robinhood-chain-gas-fees)
-
-### Events & Calls
-
-#### All events from Flap.sh
-
-Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
-
-▶️ [All events from Flap.sh](https://ide.bitquery.io/All-events-from-Flapsh)
-
-#### Flap.sh Newly created tokens using logs TokenCreated
-
-Filter Flap.sh `TokenCreated` events and decode argument values (token address, metadata fields, and related parameters).
-
-▶️ [Flap.sh Newly created tokens using logs TokenCreated](https://ide.bitquery.io/Flapsh-Newly-created-tokens-using-logs-TokenCreated)
-
-#### New Contracts Deployed on Robinhood Chain
-
-To pin one exact ABI variant — or to match an undecoded method — filter the 4-byte selector instead (uppercase hex, no `0x`)
-
-▶️ [New Contracts Deployed on Robinhood Chain](https://ide.bitquery.io/new-contracts-deployed-robinhood-chain)
-
-### Blocks & Validators
-
-#### Robinhood Chain Blocks per Day and Block Time
-
-Robinhood Chain Blocks per Day and Block Time. Uses the `Blocks` cube. Needs the historical data add-on — see the comment at the top of the query.
-
-▶️ [Robinhood Chain Blocks per Day and Block Time](https://ide.bitquery.io/robinhood-chain-block-time)
-
-### Uniswap
-
-#### Uniswap v4 Pools on Robinhood Chain
-
-New Uniswap v4 pools: decoded Initialize events on the PoolManager with currencies, fee tier, tick spacing and hooks.
-
-▶️ [Uniswap v4 Pools on Robinhood Chain](https://ide.bitquery.io/uniswap-v4-pools-on-robinhood-chain)
-
-#### Uniswap v4 Hooks in Use on Robinhood Chain
-
-Uniswap v4 Hooks in Use on Robinhood Chain. Uses the `Events` cube. Replace the address in the `where` clause to use it.
-
-▶️ [Uniswap v4 Hooks in Use on Robinhood Chain](https://ide.bitquery.io/uniswap-v4-hooks-robinhood-chain)
-
-#### Uniswap v4 Pool Liquidity on Robinhood Chain (pools.trade)
-
-Three realtime cubes carry data traders usually have to compute themselves. All three are realtime-only on Robinhood — `dataset: archive` and `dataset: combined` both error — so use them for live monitoring and persist what you need.
-
-▶️ [Uniswap v4 Pool Liquidity on Robinhood Chain (pools.trade)](https://ide.bitquery.io/Pools-trade-Live-pool-liquidity)
-
 ## Avalanche
 
 ### Trades
@@ -2981,6 +3505,12 @@ Recent token transfers on Celo. Add a `currency` filter to follow one token, or 
 
 ### Balances & Holders
 
+#### Balance of an address at a past date
+
+What one Celo address held as of a chosen date. Move the date in the Variables pane.
+
+▶️ [Balance of an address at a past date](https://ide.bitquery.io/Celo-Balance-of-an-address-at-a-past-date)
+
 #### Balances of an address
 
 Native and token balances held by one Celo address. Replace the address to use it.
@@ -3011,84 +3541,6 @@ The most recent blocks on Celo, with height, time, gas used and transaction coun
 
 ▶️ [Latest blocks](https://ide.bitquery.io/Celo-Latest-blocks)
 
-## Bitcoin
-
-### Transfers
-
-#### Inflows and Outflows of a wallet
-
-This API returns all incoming and outgoing transactions for a specific Bitcoin wallet address.
-
-▶️ [Inflows and Outflows of a wallet](https://ide.bitquery.io/Inflows-and-Outflow-of-a-bitcoin-wallet)
-
-### Balances & Holders
-
-#### Bitcoin Balance for multiple addresses
-
-This query calculates the combined balance of multiple Bitcoin wallet addresses by summing their total inflows and outflows: Balance = Total Output - Total Input. You can also set a date to get balances as of a specific point in time.
-
-▶️ [Bitcoin Balance for multiple addresses](https://ide.bitquery.io/BTC-balance-api-for-multiple-addresses)
-
-#### BTC balance api for multiple addresses
-
-Pass an array of addresses to `inputAddress` and `outputAddress` with `{in: [...]}` to get per-wallet totals in a single request. Useful for exchanges, custodians, and portfolio dashboards that monitor many wallets at once.
-
-▶️ [BTC balance api for multiple addresses](https://ide.bitquery.io/BTC-balance-API-for-multiple-addresses)
-
-#### Bitcoin balance
-
-Returns total BTC sent (inputs) and received (outputs) for an address, along with USD-equivalent values and first / last activity dates. Subtract `inputs.value` from `outputs.value` to get the current balance.
-
-▶️ [Bitcoin balance](https://ide.bitquery.io/Bitcoin-balance_5)
-
-#### Bitcoin balance at a given height
-
-Need to know what a wallet held at a particular point in time? The `height` filter caps inputs and outputs at a given block number, which is exactly what you need for audits, tax reporting, and point-in-time portfolio snapshots.
-
-▶️ [Bitcoin balance at a given height](https://ide.bitquery.io/bitcoin-balance-at-a-given-height)
-
-#### Bitcoin balance on a given block height
-
-Sum outputs and subtract inputs with a `height: {lteq: N}` cap to get the wallet's balance at a specific point on-chain. Useful for audits, tax snapshots, and point-in-time portfolio reporting.
-
-▶️ [Bitcoin balance on a given block height](https://ide.bitquery.io/bitcoin-balance-on-a-given-block-height)
-
-### Price & OHLC
-
-#### Btc price in 2016
-
-Pulls the BTC/USD price implied by any output on a given date — Bitquery stores the spot value at the time of each transaction, so you can derive a historical price by dividing USD value by BTC value.
-
-▶️ [Btc price in 2016](https://ide.bitquery.io/btc-price-in-2016)
-
-### Transactions
-
-#### Details of Bitcoin Transaction
-
-This API provides comprehensive details of a specific Bitcoin transaction in a single query.
-
-▶️ [Details of Bitcoin Transaction](https://ide.bitquery.io/Details-of-Bitcoin-Transaction)
-
-### Blocks & Validators
-
-#### Bitcoin miners rewards
-
-Mining rewards live in coinbase outputs (the first transaction in every block, `txIndex: 0`) with `outputDirection: mining`.
-
-▶️ [Bitcoin miners rewards](https://ide.bitquery.io/bitcoin-miners-rewards)
-
-#### Get miners activity in a specific timeframe
-
-Pulls the activity count per miner address inside a date range. Drop or extend the date window to size the cohort however you need.
-
-▶️ [Get miners activity in a specific timeframe](https://ide.bitquery.io/get-miners-activity-in-a-specific-timeframe)
-
-#### Get miners first activity
-
-For a specific set of miner addresses, this query returns the first block each one mined. Useful for cohort analysis, miner onboarding studies, or building "first seen" timelines.
-
-▶️ [Get miners first activity](https://ide.bitquery.io/get-miners-first-activity)
-
 ## Litecoin
 
 ### Transfers
@@ -3100,6 +3552,12 @@ The biggest Litecoin outputs of the past day, ranked by value — a quick way to
 ▶️ [Largest transfers in the last 24 hours](https://ide.bitquery.io/Litecoin-Largest-transfers-in-the-last-24-hours)
 
 ### Balances & Holders
+
+#### Balance of an address at a past date
+
+What one Litecoin address held as of a chosen date. Move the date in the Variables pane.
+
+▶️ [Balance of an address at a past date](https://ide.bitquery.io/Litecoin-Balance-of-an-address-at-a-past-date)
 
 #### Total received by an address
 
@@ -3147,6 +3605,12 @@ The biggest Bitcoin Cash outputs of the past day, ranked by value — a quick wa
 
 ### Balances & Holders
 
+#### Balance of an address at a past date
+
+What one Bitcoin Cash address held as of a chosen date. Move the date in the Variables pane.
+
+▶️ [Balance of an address at a past date](https://ide.bitquery.io/Bitcoin-Cash-Balance-of-an-address-at-a-past-date)
+
 #### Total received by an address
 
 Sums everything an address has ever received on Bitcoin Cash, with a first-and-last-seen window. Replace the address to use it.
@@ -3192,6 +3656,12 @@ The biggest Dogecoin outputs of the past day, ranked by value — a quick way to
 ▶️ [Largest transfers in the last 24 hours](https://ide.bitquery.io/Dogecoin-Largest-transfers-in-the-last-24-hours)
 
 ### Balances & Holders
+
+#### Balance of an address at a past date
+
+What one Dogecoin address held as of a chosen date. Move the date in the Variables pane.
+
+▶️ [Balance of an address at a past date](https://ide.bitquery.io/Dogecoin-Balance-of-an-address-at-a-past-date)
 
 #### Total received by an address
 
@@ -3239,6 +3709,12 @@ The biggest Dash outputs of the past day, ranked by value — a quick way to spo
 
 ### Balances & Holders
 
+#### Balance of an address at a past date
+
+What one Dash address held as of a chosen date. Move the date in the Variables pane.
+
+▶️ [Balance of an address at a past date](https://ide.bitquery.io/Dash-Balance-of-an-address-at-a-past-date)
+
 #### Total received by an address
 
 Sums everything an address has ever received on Dash, with a first-and-last-seen window. Replace the address to use it.
@@ -3284,6 +3760,12 @@ The biggest Zcash outputs of the past day, ranked by value — a quick way to sp
 ▶️ [Largest transfers in the last 24 hours](https://ide.bitquery.io/Zcash-Largest-transfers-in-the-last-24-hours)
 
 ### Balances & Holders
+
+#### Balance of an address at a past date
+
+What one Zcash address held as of a chosen date. Move the date in the Variables pane.
+
+▶️ [Balance of an address at a past date](https://ide.bitquery.io/Zcash-Balance-of-an-address-at-a-past-date)
 
 #### Total received by an address
 
@@ -3495,6 +3977,18 @@ Total SOL fees, Total Volume, Total count trades. Uses the `Trades` cube.
 
 ### Price & OHLC
 
+#### Token price from top market (rank 1)
+
+The recommended way to price one token: takes the single highest-ranked market for it rather than blending every pool. Prices the token from its single top market rather than blending every pool, which is what you want for one specific token.
+
+▶️ [Token price from top market (rank 1)](https://ide.bitquery.io/Token-price-from-top-market--rank-1_2)
+
+#### Multi-token watchlist, top market each
+
+Prices a list of tokens, each from its own top market. Add or remove addresses in the `Token.Address.in` filter.
+
+▶️ [Multi-token watchlist, top market each](https://ide.bitquery.io/Multi-token-watchlist--rank-1-per-token)
+
 #### Historical Bitcoin OHLC data for the last 7 days
 
 Recent Bitcoin OHLC using the Crypto Price API (time range in the query matches what the Price Index supports).
@@ -3527,7 +4021,7 @@ Tokens ranked by market cap. Uses the `Trades` cube.
 
 #### Solana USDT trades query
 
-Solana USDT trades query. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Solana USDT trades query. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Solana USDT trades query](https://ide.bitquery.io/solana-USDT-trades-query)
 
@@ -3615,117 +4109,9 @@ USDT Stablecoin reserves on Solana query. Uses the `TokenSupplyUpdates` cube. Ch
 
 ▶️ [USDT Stablecoin reserves on Solana query](https://ide.bitquery.io/USDT-Stablecoin-reserves-on-Solana--query)
 
-## Perpetuals
-
-### Trades
-
-#### Hyperliquid BTC Perp Trades
-
-Hyperliquid BTC Perp Trades. Uses the `Trades` cube.
-
-▶️ [Hyperliquid BTC Perp Trades](https://ide.bitquery.io/hyperliquid-btc-perp-trades)
-
-#### Hyperliquid Latest Trades (Perps + Spot + HIP-3)
-
-Each fill carries the execution (price, size, side, aggressor flag), the position it changed (leverage, margin mode, size before, realized PnL) and fees. `Direction` is one of `Open Long`, `Open Short`, `Close Long`, `Close Short`.
-
-▶️ [Hyperliquid Latest Trades (Perps + Spot + HIP-3)](https://ide.bitquery.io/hyperliquid-latest-trades)
-
-#### Hyperliquid Trader Leverage Updates
-
-Hyperliquid Trader Leverage Updates.
-
-▶️ [Hyperliquid Trader Leverage Updates](https://ide.bitquery.io/hyperliquid-leverage-updates)
-
-#### Phoenix Perps Fills by Trader Wallet - Solana
-
-Stream every stop-loss and take-profit placement as it happens.
-
-▶️ [Phoenix Perps Fills by Trader Wallet - Solana](https://ide.bitquery.io/sol_perps_filled_orders_by_signer)
-
-#### Trader Realized PnL on Solana Perps
-
-Rows with `Size: 0` are markets they've fully closed — drop them and the rest is the live book, with entry prices.
-
-▶️ [Trader Realized PnL on Solana Perps](https://ide.bitquery.io/solana-perps-trader-pnl)
-
-#### Whale Trades on Solana Perps (Phoenix)
-
-Positive = received, negative = paid. Replace the field list with `total: sum(of: Position_Funding)` for the net carry cost of holding their positions.
-
-▶️ [Whale Trades on Solana Perps (Phoenix)](https://ide.bitquery.io/solana-perps-whale-trades)
-
-### Price & OHLC
-
-#### Hyperliquid BTC OHLCV Candles (1 minute)
-
-The `Candles` cube provides OHLCV per market and interval. `Interval.Time.Duration` is the candle length in seconds (e.g. `60` for one minute), `Start` the interval open time. OHLCV values are floats.
-
-▶️ [Hyperliquid BTC OHLCV Candles (1 minute)](https://ide.bitquery.io/hyperliquid-btc-ohlcv-candles)
-
-#### Hyperliquid Mark Prices (All Markets)
-
-Follow the steps here: How to generate Bitquery API token ➤.
-
-▶️ [Hyperliquid Mark Prices (All Markets)](https://ide.bitquery.io/hyperliquid-mark-prices)
-
-#### Solana Perps OHLC Candles from Mark Price
-
-As a `query`, add `orderBy: { descending: Block_Time }` and a `limit` for the recent whale prints.
-
-▶️ [Solana Perps OHLC Candles from Mark Price](https://ide.bitquery.io/solana-perps-ohlc-candles)
-
 ## NFTs
 
 ### Trades
-
-#### Get NFT trades for a specific NFT contract on specific marketplace
-
-Get trades of NFTs for a given contract and marketplace.
-
-▶️ [Get NFT trades for a specific NFT contract on specific marketplace](https://ide.bitquery.io/Get-NFT-trades-by-contract)
-
-#### Get NFT trades for a specific NFT contract and token ID
-
-Get trades of NFTs for a given contract and token ID.
-
-▶️ [Get NFT trades for a specific NFT contract and token ID](https://ide.bitquery.io/Get-NFT-trades-by-token)
-
-#### Get NFT trades by wallet
-
-Get trades of NFTs for a given wallet.
-
-▶️ [Get NFT trades by wallet](https://ide.bitquery.io/Get-trades-of-NFTs-for-a-given-wallet)
-
-#### Latest NFT Trades
-
-Latest NFT Trades.
-
-▶️ [Latest NFT Trades](https://ide.bitquery.io/Latest-NFT-trades-on-ETH)
-
-#### Top Traded NFTs in a Period
-
-This query gets the top 10 traded NFTs based on the number of trades within a specified date range. You can change the filters such as the date range and limit.
-
-▶️ [Top Traded NFTs in a Period](https://ide.bitquery.io/Top-traded-NFT-tokens-in-a-month)
-
-#### Latests OpenSea Trades
-
-Latests OpenSea Trades.
-
-▶️ [Latests OpenSea Trades](https://ide.bitquery.io/Latests-OpenSea-Trades)
-
-#### Latest NFT trades on Ethereum network
-
-Latest NFT trades on Ethereum network.
-
-▶️ [Latest NFT trades on Ethereum network](https://ide.bitquery.io/latest-NFT-trades-on-Ethereum-network)
-
-#### Pairs of blur token new dataset
-
-Open the above query on GraphQL IDE using this.
-
-▶️ [Pairs of blur token new dataset](https://ide.bitquery.io/pairs-of-blur-token-new-dataset_1)
 
 #### New Uniswap v3 liquidity positions
 
@@ -3733,9 +4119,57 @@ Position NFTs as they are minted — who is adding liquidity to v3 pools, and to
 
 ▶️ [New Uniswap v3 liquidity positions](https://ide.bitquery.io/recent-uniswap-position-NFTs-mint_1)
 
+#### Get NFT trades for a specific NFT contract on specific marketplace
+
+Get trades of NFTs for a given contract and marketplace. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get NFT trades for a specific NFT contract on specific marketplace](https://ide.bitquery.io/Get-NFT-trades-by-contract)
+
+#### Get NFT trades for a specific NFT contract and token ID
+
+Get trades of NFTs for a given contract and token ID. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get NFT trades for a specific NFT contract and token ID](https://ide.bitquery.io/Get-NFT-trades-by-token)
+
+#### Get NFT trades by wallet
+
+Get trades of NFTs for a given wallet. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get NFT trades by wallet](https://ide.bitquery.io/Get-trades-of-NFTs-for-a-given-wallet)
+
+#### Latest NFT Trades
+
+Latest NFT Trades. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Latest NFT Trades](https://ide.bitquery.io/Latest-NFT-trades-on-ETH)
+
+#### Top Traded NFTs in a Period
+
+This query gets the top 10 traded NFTs based on the number of trades within a specified date range. You can change the filters such as the date range and limit. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Top Traded NFTs in a Period](https://ide.bitquery.io/Top-traded-NFT-tokens-in-a-month)
+
+#### Latests OpenSea Trades
+
+Latests OpenSea Trades. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Latests OpenSea Trades](https://ide.bitquery.io/Latests-OpenSea-Trades)
+
+#### Latest NFT trades on Ethereum network
+
+Latest NFT trades on Ethereum network. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Latest NFT trades on Ethereum network](https://ide.bitquery.io/latest-NFT-trades-on-Ethereum-network)
+
+#### Pairs of blur token new dataset
+
+Open the above query on GraphQL IDE using this. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Pairs of blur token new dataset](https://ide.bitquery.io/pairs-of-blur-token-new-dataset_1)
+
 #### NFT currencies on Solana by DEX'es
 
-The subscription query provided fetches the most-traded NFTs in the last few hours. For Solana, only realtime information is available, so the aggregate might not be accurate beyond a few hours.
+The subscription query provided fetches the most-traded NFTs in the last few hours. For Solana, only realtime information is available, so the aggregate might not be accurate beyond a few hours. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [NFT currencies on Solana by DEX'es](https://ide.bitquery.io/NFT-currencies-on-Solana-by-DEXes_1)
 
@@ -3885,274 +4319,6 @@ Locked NFTs are temporarily non-transferrable and can be traded or transferred a
 
 ▶️ [Locked NFT bought on Blur marketplace](https://ide.bitquery.io/Locked-NFT-bought-on-Blur-marketplace)
 
-## Polymarket
-
-### Trades
-
-#### Latest Trades
-
-Fetch the most recent prediction market trades with full details, ordered by block time.
-
-▶️ [Latest Trades](https://ide.bitquery.io/latest-prediction-market-trades_8)
-
-#### Total Volume and Yes/No Volume for a Market
-
-Aggregate USD volume for a market over a time window: total volume plus volume per outcome (e.g. Yes/No). Pass the market's outcome token AssetIds in `$marketAssets`.
-
-▶️ [Total Volume and Yes/No Volume for a Market](https://ide.bitquery.io/total-volume-outcome-1-volume-outcome-2-volume-of-a-market_1)
-
-#### Trades for a Specific Trader
-
-Fetch all trades where the given address is either Buyer or Seller. Pass the trader address as the `$trader` variable.
-
-▶️ [Trades for a Specific Trader](https://ide.bitquery.io/Trades-for-a-specific-trader_1)
-
-#### How do I count trades for a specific Polymarket trader?
-
-Use `PredictionTrades` with `any` filter on `Buyer` or `Seller` to return the total trade count for a wallet. Add `ProtocolName: "polymarket"` to restrict to Polymarket only. Replace the address with your target wallet.
-
-▶️ [How do I count trades for a specific Polymarket trader?](https://ide.bitquery.io/How-do-I-count-trades-for-a-specific-Polymarket-trader)
-
-#### How do I get top buyers and sellers on Polymarket by volume?
-
-Use `PredictionTrades` with `limitBy` and `sum(of: Trade_OutcomeTrade_CollateralAmountInUSD)` grouped by Buyer (or Seller) to rank the top 100 wallets by volume over the last 5 days. Useful for leaderboards, whale tracking, and trader analytics.
-
-▶️ [How do I get top buyers and sellers on Polymarket by volume?](https://ide.bitquery.io/How-do-I-get-top-buyers-and-sellers-on-Polymarket-by-volume)
-
-#### Latest prediction market trades
-
-Fetch the most recent prediction market trades with full details, ordered by block time.
-
-▶️ [Latest prediction market trades](https://ide.bitquery.io/latest-prediction-market-trades)
-
-#### Prediction_trades
-
-Prediction_trades.
-
-▶️ [Prediction_trades](https://ide.bitquery.io/prediction_trades)
-
-#### Top 100 markets by volumein last24 hrs
-
-Rank Polymarket markets by buy + sell collateral USD, with buy/sell breakdown, trade count, distinct buyers/sellers, and optional resolution join. Uses `limitBy: Trade_Prediction_Question_Id` so each row is one market.
-
-▶️ [Top 100 markets by volumein last24 hrs](https://ide.bitquery.io/top-100-markets-by-volumein-last24-hrs_1)
-
-#### Top AI markets by volume Polymarket
-
-Returns AI markets (title includes the standalone word " AI ") ranked by USD trading volume in the last 24 hours, with buyer and seller counts. Adjust `time_ago`, `limit`, and the title keyword as needed.
-
-▶️ [Top AI markets by volume Polymarket](https://ide.bitquery.io/Top-AI-markets-by-volume-Polymarket)
-
-#### Top Buyers/Sellers of Bitcoin up down market
-
-Returns the top 10 buyers and top 10 sellers by traded volume in Bitcoin Up or Down markets on Polymarket over the last 24 hours. Results are aggregated by trader address and ordered by `buy_amount` (buyers) or `sell_amount` (sellers).
-
-▶️ [Top Buyers/Sellers of Bitcoin up down market](https://ide.bitquery.io/Top-BuyersSellers-of-Bitcoin-up-down-market)
-
-### Markets
-
-#### Created vs Resolved Count (Last 24 Hours)
-
-Count how many Created and Resolved events occurred in the last 24 hours.
-
-▶️ [Created vs Resolved Count (Last 24 Hours)](https://ide.bitquery.io/last-24-hr-resolution-and-ceated-count_1)
-
-#### Latest Creations + Resolutions
-
-Fetch the most recent creation and resolution events with full details, ordered by block time.
-
-▶️ [Latest Creations + Resolutions](https://ide.bitquery.io/latest-Prediction-managements-resolutions-creations_1)
-
-#### Latest Market Creations
-
-Fetch the most recent Created events (new markets). All possible outcomes per market are in Prediction.Condition.Outcomes.
-
-▶️ [Latest Market Creations](https://ide.bitquery.io/latest-polymarket-creations_1)
-
-#### Latest Market Resolutions
-
-Query that returns the 10 most recent Resolved events. Winning outcome is in Prediction.Outcome; Prediction.OutcomeToken holds the asset ID and contract details.
-
-▶️ [Latest Market Resolutions](https://ide.bitquery.io/latest-polymarket-resolutions_2)
-
-#### Latest Prediction managements (resolutions, creations)
-
-Fetch the most recent creation and resolution events with full details, ordered by block time.
-
-▶️ [Latest Prediction managements (resolutions, creations)](https://ide.bitquery.io/latest-Prediction-managements-resolutions-creations)
-
-#### Latest polymarket creations
-
-Fetch the most recent Created events. For each market, all possible outcomes are listed under Prediction.Condition.Outcomes.
-
-▶️ [Latest polymarket creations](https://ide.bitquery.io/latest-polymarket-creations)
-
-#### Latest polymarket resolutions
-
-Latest polymarket resolutions.
-
-▶️ [Latest polymarket resolutions](https://ide.bitquery.io/latest-polymarket-resolutions_1)
-
-#### Latest resolved crudeoil markets
-
-Returns the 10 most recent Resolved events for Polymarket Crude Oil markets.
-
-▶️ [Latest resolved crudeoil markets](https://ide.bitquery.io/latest-resolved-crudeoil-markets)
-
-#### Latest resolved sports markets
-
-Returns the 10 most recent Resolved sports markets (management description includes `"sports"`), including the resolved/winning Outcome and full question metadata. Use this to grade results and settle bets.
-
-▶️ [Latest resolved sports markets](https://ide.bitquery.io/Latest-resolved-sports-markets)
-
-#### Query latest created resolved prediction markets for Bitcoin
-
-Query latest created resolved prediction markets for Bitcoin.
-
-▶️ [Query latest created resolved prediction markets for Bitcoin](https://ide.bitquery.io/Query-latest-created-resolved-prediction-markets-for-Bitcoin)
-
-### Settlements
-
-#### Latest Settlements
-
-Fetch the most recent settlements with full details, ordered by block time.
-
-▶️ [Latest Settlements](https://ide.bitquery.io/latest-prediction-market-settlements_3)
-
-#### Latest Whale Settlements
-
-Find the most recent high-value redemptions (e.g. amount ≥ 10,000 in outcome token units). Useful for tracking large payouts and whale activity.
-
-▶️ [Latest Whale Settlements](https://ide.bitquery.io/latest-whale-settlements-on-prediction-market_3)
-
-#### Redemption / Merge / Split Count (Last 1 Hour)
-
-Count how many settlement events occurred in the last hour, grouped by event signature (Split, Merge, Redemption).
-
-▶️ [Redemption / Merge / Split Count (Last 1 Hour)](https://ide.bitquery.io/redemptions-merge-split-count-in-last-1-hour_1)
-
-#### Top 10 Market Questions by Redeemed Amount (Last 1 Hour)
-
-Aggregate redemptions by market question and sort by total redeemed amount. See which markets had the most payout activity recently.
-
-▶️ [Top 10 Market Questions by Redeemed Amount (Last 1 Hour)](https://ide.bitquery.io/top-10-market-questions-in-last-1-hour_3)
-
-#### Top 10 Redeemers (Last 1 Hour)
-
-Rank addresses by total amount redeemed in the last hour across all markets. Useful for leaderboards and whale tracking.
-
-▶️ [Top 10 Redeemers (Last 1 Hour)](https://ide.bitquery.io/top-10-redeemers_1)
-
-#### Top 10 Winners of a Specific Market Question
-
-Rank holders by total redeemed amount for one market (filter by question title).
-
-▶️ [Top 10 Winners of a Specific Market Question](https://ide.bitquery.io/top-10-winners-of-a-market-question_2)
-
-#### Latest prediction market settlements
-
-Fetch the most recent settlements with full details, ordered by block time.
-
-▶️ [Latest prediction market settlements](https://ide.bitquery.io/latest-prediction-market-settlements_2)
-
-#### Latest whale settlements on prediction market
-
-Find the most recent high-value redemptions (e.g. amount ≥ 10,000 USD). Useful for tracking large payouts and whale activity.
-
-▶️ [Latest whale settlements on prediction market](https://ide.bitquery.io/latest-whale-settlements-on-prediction-market_2)
-
-#### Redemptions, merge, split count in last 1 hour
-
-Count how many settlement events occurred in the last hour, grouped by event signature (Split, Merge, Redemption).
-
-▶️ [Redemptions, merge, split count in last 1 hour](https://ide.bitquery.io/redemptions-merge-split-count-in-last-1-hour)
-
-#### Top 10 redeemers
-
-Rank addresses by total amount redeemed in the last hour across all markets. Useful for leaderboards and whale tracking.
-
-▶️ [Top 10 redeemers](https://ide.bitquery.io/top-10-redeemers)
-
-### Transfers
-
-#### Freshwallet check for polymarket
-
-Look up the buyer's earliest on-chain activity. If the wallet's first transfer is close to the time of its first big bet, it is a fresh wallet and scores high. Replace the address with the buyer from Step 1.
-
-▶️ [Freshwallet check for polymarket](https://ide.bitquery.io/freshwallet-check-for-polymarket)
-
-#### FundingSource for poylmarket
-
-FundingSource for poylmarket. Uses the `Transfers` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
-
-▶️ [FundingSource for poylmarket](https://ide.bitquery.io/FundingSource-for-poylmarket)
-
-#### SiblingWallets for polymarket
-
-Take the funder from Step 3 and list every other wallet it funded. Wallets sharing a funder are likely controlled by the same operator. A large cluster placing correlated bets is a strong signal.
-
-▶️ [SiblingWallets for polymarket](https://ide.bitquery.io/SiblingWallets-for-polymarket)
-
-### Balances & Holders
-
-#### Polymarket TVL
-
-Summarize USDC.e (`0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`) held by Conditional Tokens and neg-risk wrapped collateral contracts. Extend the `Address` list if you track additional custodians.
-
-▶️ [Polymarket TVL](https://ide.bitquery.io/Polymarket-TVL)
-
-### Price & OHLC
-
-#### Current Price per Outcome (Latest Trade)
-
-Get the latest trade price for each outcome in a market. Uses `limitBy` for one row per outcome, with Price and PriceInUSD at the most recent block time.
-
-▶️ [Current Price per Outcome (Latest Trade)](https://ide.bitquery.io/Current-price-inside-the-market-for-all-options-based-on-latest-trade_1)
-
-#### Current price inside the market for all options based on latest trade
-
-Get the latest trade price for each outcome in a market (e.g. Yes/No, Up/Down—each market defines its own outcome labels).
-
-▶️ [Current price inside the market for all options based on latest trade](https://ide.bitquery.io/Current-price-inside-the-market-for-all-options-based-on-latest-trade)
-
-#### Latest price of outcomes of a crude oil market
-
-Returns the latest trade price (and price in USD) per outcome for a single market by `MarketId`. Replace `"1570893"` with the target Crude Oil market ID from Polymarket or from the creation/resolution queries above.
-
-▶️ [Latest price of outcomes of a crude oil market](https://ide.bitquery.io/latest-price-of-outcomes-of-a-crude-oil-market)
-
-#### OHLC of a outcome of a gold market
-
-Returns OHLC (Open, High, Low, Close) in USD for one outcome of a Gold market, bucketed by time (e.g. 1-minute intervals). Replace `MarketId` `"1606192"` and outcome `"Down"` with the desired market and outcome label (e.g. `"Up"` or `"Down"`).
-
-▶️ [OHLC of a outcome of a gold market](https://ide.bitquery.io/OHLC-of-a-outcome-of-a-gold-market)
-
-#### Polymarket AI odds movement OHLC
-
-Returns OHLC (Open, High, Low, Close) in USD for one outcome of an AI market, bucketed by interval (here 5 minutes). It shows how the implied probability moved over time, and powers charts and backtests. Replace `"<MARKET_ID>"` and `"<OUTCOME_LABEL>"`
-
-▶️ [Polymarket AI odds movement OHLC](https://ide.bitquery.io/Polymarket-AI-odds-movement-OHLC)
-
-#### Polymarket sports odds movement OHLC
-
-Returns OHLC (Open, High, Low, Close) in USD for one outcome of a game, bucketed by interval (here 5 minutes). It shows how the win probability moved over time, and powers line-movement charts and strategy backtests.
-
-▶️ [Polymarket sports odds movement OHLC](https://ide.bitquery.io/Polymarket-sports-odds-movement-OHLC)
-
-### Liquidity & Pools
-
-#### Top cricket Markets by Liquidity
-
-Returns the top 100 cricket related polymarkets sorted by liquidity position in the past 24 hours.
-
-▶️ [Top cricket Markets by Liquidity](https://ide.bitquery.io/Top-cricket-Markets-by-Liquidity)
-
-#### Top FIFA World Cup Markets by Liquidity
-
-Returns the top 100 FIFA World Cup related polymarkets sorted by liquidity position in the past 24 hours. Here `position` is the metric used for sorting, hence it could be regarded as the liquidity position of the particular market.
-
-▶️ [Top FIFA World Cup Markets by Liquidity](https://ide.bitquery.io/Top-FIFA-World-Cup-Markets-by-Liquidity)
-
 ## Futures DEXs
 
 ### Trades
@@ -4222,51 +4388,3 @@ Get Latest Payments to x402 Server on Solana. Uses the `Transfers` cube. Replace
 Comprehensive payment analytics including total volume, unique users, transaction counts, and time-based breakdowns for a specific x402 server.
 
 ▶️ [Payment Analytics for x402 Server](https://ide.bitquery.io/Payment-analytics-related-specific-x402-server)
-
-## Cross-Chain
-
-### Trades
-
-#### Volume of Multiple Tokens Across Different Chains
-
-Get volume and price change data for multiple tokens trading on different chains (Solana, Ethereum, BSC, Tron) in a single query. Returns volume for 1h, 4h, and 24h periods, plus price change percentages. > **Note:** For EVM chains (Ethereum, BSC, etc.) in the Trading API, use **all lowercase…
-
-▶️ [Volume of Multiple Tokens Across Different Chains](https://ide.bitquery.io/volume-of-a-token_2)
-
-### Price & OHLC
-
-#### Latest Price of Any Token
-
-This query gives you bitcoin currency 1-sec OHLC across different blockchains. You can adjust duration in `Duration: {eq: 1}` filter.
-
-▶️ [Latest Price of Any Token](https://ide.bitquery.io/Latest-bitcoin-price-on-across-chains_5)
-
-#### OHLC of a currency on multiple blockchains
-
-This query retrieves the OHLC (Open, High, Low, Close) prices of a currency(in this eg Bitcoin; it will include all sorts of currencies whose underlying asset is Bitcoin like cbBTC, WBTC, etc) across all supported blockchains, aggregated into a given time interval (e.g., 60 seconds in this example).
-
-▶️ [OHLC of a currency on multiple blockchains](https://ide.bitquery.io/OHLC-of-a-currency-on-multiple-blockchains_2)
-
-#### SMA and Volume Data (for past 28, 14 and 7 Days Time)
-
-Use this API to get SMA and volume over the past 28 days, with 14 days, and 7 days breakdowns. Note that the oldest possible data it could return is 30 days ago.
-
-▶️ [SMA and Volume Data (for past 28, 14 and 7 Days Time)](https://ide.bitquery.io/multiple-tokens-volume-and-SMA)
-
-#### Historical OHLC of a Token Pair Across Chains
-
-This query fetches historical OHLC (Open, High, Low, Close) price data for a token pair across different blockchains for as long back as 30 days. For **native tokens**, you only need to specify their ID (e.g., `bid:eth` for ETH).
-
-▶️ [Historical OHLC of a Token Pair Across Chains](https://ide.bitquery.io/Historical-Token-OHLC-Multi-Chains_1)
-
-#### Historical Price and Volume Data for a Token Pair beyond 30 days
-
-Use this API to get historical price and volume for a specific token pair address on a specific network for the time window beyond the 30 days.
-
-▶️ [Historical Price and Volume Data for a Token Pair beyond 30 days](https://ide.bitquery.io/historical-price-and-historical-volume)
-
-#### All time High Trade Price for a Token
-
-Retrieves the all-time high (ATH) price in USD for a specified token contract. All time high price could lie beyond the 30 days window provided by Trading API, hence we use these network specific APIs to get the ATH for a token. While this provides the option to go beyond the 30 days time…
-
-▶️ [All time High Trade Price for a Token](https://ide.bitquery.io/ATH-of-eth-token_1)

--- a/docs/start/starter-subscriptions.md
+++ b/docs/start/starter-subscriptions.md
@@ -2244,26 +2244,6 @@ Use the same Raydium program filter with negative `ChangeAmount` on the base sid
 
 ▶️ [Liquidity removal for radium](https://ide.bitquery.io/liquidity-removal-for-radium_1)
 
-### Uniswap
-
-#### 1-second price, OHLC, volume, SMA and EMA — Uniswap v3
-
-One-second candles with moving averages for Uniswap v3 tokens, built for trading front-ends.
-
-▶️ [1-second price, OHLC, volume, SMA and EMA — Uniswap v3](https://ide.bitquery.io/Uniswap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
-
-#### Stream all Uniswap Seconds OHLC Kline
-
-Subscribe to `Trading.Pairs` filtered by Uniswap protocols and 1s interval to power sub-minute charts and HFT analytics.
-
-▶️ [Stream all Uniswap Seconds OHLC Kline](https://ide.bitquery.io/Stream-all-Uniswap-Seconds-OHLC-Kline)
-
-#### Uniswap all versions trades stream
-
-Filter `DEXTrades` with `ProtocolName` in `uniswap_v3`, `uniswap_v2`, `uniswap_v1` to stream only Uniswap family pools on mainnet.
-
-▶️ [Uniswap all versions trades stream](https://ide.bitquery.io/uniswap-all-versions-trades-stream)
-
 ### Pump.fun
 
 #### All Pumpswap Trade Stream
@@ -2297,6 +2277,26 @@ This subscription returns the real-time trades happening on Pancakeswap. You can
 PancakeSwap v3 DEX tokens 1 second price stream with OHLC. Uses the `Pairs` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [PancakeSwap v3 DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/PancakeSwap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
+
+### Uniswap
+
+#### 1-second price, OHLC, volume, SMA and EMA — Uniswap v3
+
+One-second candles with moving averages for Uniswap v3 tokens, built for trading front-ends.
+
+▶️ [1-second price, OHLC, volume, SMA and EMA — Uniswap v3](https://ide.bitquery.io/Uniswap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
+
+#### Stream all Uniswap Seconds OHLC Kline
+
+Subscribe to `Trading.Pairs` filtered by Uniswap protocols and 1s interval to power sub-minute charts and HFT analytics.
+
+▶️ [Stream all Uniswap Seconds OHLC Kline](https://ide.bitquery.io/Stream-all-Uniswap-Seconds-OHLC-Kline)
+
+#### Uniswap all versions trades stream
+
+Filter `DEXTrades` with `ProtocolName` in `uniswap_v3`, `uniswap_v2`, `uniswap_v1` to stream only Uniswap family pools on mainnet.
+
+▶️ [Uniswap all versions trades stream](https://ide.bitquery.io/uniswap-all-versions-trades-stream)
 
 ## Stablecoins
 

--- a/docs/start/starter-subscriptions.md
+++ b/docs/start/starter-subscriptions.md
@@ -16,23 +16,869 @@ Every subscription below is saved in the [Bitquery IDE](https://ide.bitquery.io)
 
 ## Table of Contents
 
-- [Ethereum](#ethereum)
+- [Bitcoin](#bitcoin)
 - [Solana](#solana)
+- [Robinhood Chain](#robinhood-chain)
+- [Polymarket](#polymarket)
+- [Perpetuals](#perpetuals)
+- [TRON](#tron)
+- [Cross-Chain](#cross-chain)
+- [Ethereum](#ethereum)
 - [BSC](#bsc)
 - [Base](#base)
 - [Arbitrum](#arbitrum)
 - [Optimism](#optimism)
 - [Polygon](#polygon)
-- [TRON](#tron)
-- [Robinhood Chain](#robinhood-chain)
-- [Bitcoin](#bitcoin)
 - [Trading API](#trading-api)
 - [Stablecoins](#stablecoins)
-- [Perpetuals](#perpetuals)
 - [NFTs](#nfts)
-- [Polymarket](#polymarket)
 - [x402](#x402)
-- [Cross-Chain](#cross-chain)
+
+## Bitcoin
+
+### Price & OHLC
+
+#### Latest Bitcoin Price
+
+You can stream Bitcoin price at 1-second interval using the [Crypto Price APIs](/docs/trading/crypto-price-api/introduction/).
+
+▶️ [Latest Bitcoin Price](https://ide.bitquery.io/Stream-Bitcoin-Price-Across-Chains)
+
+## Solana
+
+### Trades
+
+#### Graduated Tokens
+
+This query gives you tokens which are graduated from Raydium Launchpad to Raydium.
+
+▶️ [Graduated Tokens](https://ide.bitquery.io/Track-Token-Migrations-to-Raydium-DEX-and-Raydium-CPMM-in-realtime)
+
+#### Solana Trades Stream
+
+This subscription streams real-time Solana trades. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Solana Trades Stream](https://ide.bitquery.io/solana-trades-subscription_3)
+
+#### All Trade for Bags.fm tokens
+
+Get all trades of Bags FM tokens from Meteora and other DEXs. This Bags FM token trades WebSocket provides comprehensive trading data. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [All Trade for Bags.fm tokens](https://ide.bitquery.io/All-Trade-for-Bagsfm-tokens)
+
+#### CPMM trades
+
+In this section we will see how to get data on Raydium CPMM trades in real-time. You can check out our Pump Fun docs, Raydium v4 docs and Raydium LaunchPad docs too. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [CPMM trades](https://ide.bitquery.io/CPMM-trades)
+
+#### Large Token Buys and Sells on Solana DEX
+
+This stream provides real-time large buy and sell on Solana DEXs. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Large Token Buys and Sells on Solana DEX](https://ide.bitquery.io/big-trades-on-solana)
+
+#### Specific Token Trades Stream
+
+This subscription stream uses DexTradeByTokens API to stream real-time specific token trades. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Specific Token Trades Stream](https://ide.bitquery.io/token-trades-subscription)
+
+#### Get Solana pair trades data
+
+Will subscribe to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get Solana pair trades data](https://ide.bitquery.io/Get-Solana-pair-trades-data)
+
+#### Get Solana pair trades data just like dexcsreener
+
+Will subscribe to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get Solana pair trades data just like dexcsreener](https://ide.bitquery.io/Get-Solana-pair-trades-data-just-like-dexcsreener)
+
+#### Get Solana pair trades data just like geckoTerminal
+
+Will subscribe to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get Solana pair trades data just like geckoTerminal](https://ide.bitquery.io/Get-Solana-pair-trades-data-just-like-geckoTerminal_1)
+
+#### Latest Trades of TESLA onchain xStock
+
+Below query will give you realtime trades of Tesla xStock (TESLAx). Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Latest Trades of TESLA onchain xStock](https://ide.bitquery.io/Latest-Trades-of-TESLA-onchain-xStock_1)
+
+### Transfers
+
+#### Token Transfers Stream
+
+This stream provides all token transfers on the Solana blockchain, including SOL transfers.
+
+▶️ [Token Transfers Stream](https://ide.bitquery.io/Solana-transfers-stream_3)
+
+#### SPL transfers websocket
+
+One of the most common types of transfers on Solana are SPL token transfers. Let's see an example to get the latest SPL token transfers using our API. Today we are taking an example of JUPITER token transfers.
+
+▶️ [SPL transfers websocket](https://ide.bitquery.io/SPL-transfers-websocket_1)
+
+#### Solana Websocket - Subscribe to all transfers of specific addresses in realtime
+
+Websockets are priced based on their running time, not the amount of data delivered.
+
+▶️ [Solana Websocket - Subscribe to all transfers of specific addresses in realtime](https://ide.bitquery.io/Solana-Websocket---Subscribe-to-all-transfers-of-specific-addresses-in-realtime)
+
+#### Subscribe to the all transfers on Solana
+
+For monitoring the balance changes that result from these transfers, see our Solana Balance Updates API.
+
+▶️ [Subscribe to the all transfers on Solana](https://ide.bitquery.io/Subscribe-to-the-all-transfers-on-Solana)
+
+#### Transfers of All Tip Payment Accounts on Solana
+
+Jito foundation has Tip Payment Program that allows users to transfer tips to a set of static public keys (compared to signing the transaction with the next N leaders) and ensure that the incentives are distributed to the correct block leader, while enabling…
+
+▶️ [Transfers of All Tip Payment Accounts on Solana](https://ide.bitquery.io/Transfers-of-All-Tip-Payment-Accounts-on-Solana)
+
+#### Transfers of Tip Payment Accounts on Solana
+
+The subscription that provides you the transfer data of one of these addresses is.
+
+▶️ [Transfers of Tip Payment Accounts on Solana](https://ide.bitquery.io/Transfers-of-Tip-Payment-Accounts-on-Solana_1)
+
+#### Transfers where sender is the specified address
+
+Transfers where sender is the specified address. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Transfers where sender is the specified address](https://ide.bitquery.io/transfers-where-sender-is-the-specified-address_1)
+
+### Balances & Holders
+
+#### Balance Stream
+
+This stream provides all balance updates on the Solana blockchain.
+
+▶️ [Balance Stream](https://ide.bitquery.io/solana-balance-update-stream_3)
+
+### Price & OHLC
+
+#### Token price stream from top market (rank 1)
+
+Streams a Solana token's price from its top market, one-second intervals, quoted in USD. Prices the token from its single top market rather than blending every pool, which is what you want for one specific token.
+
+▶️ [Token price stream from top market (rank 1)](https://ide.bitquery.io/Token-price-stream-from-top-market--rank-1)
+
+#### Real-Time Token Prices in USD on Solana
+
+Stream live OHLC (Open, High, Low, Close) price and volume data for all tokens on Solana, quoted directly in USD. Useful for dashboards, analytics, or bots that need stable fiat-based prices. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Real-Time Token Prices in USD on Solana](https://ide.bitquery.io/Real-Time-usd-price-on-solana-chain)
+
+#### GoonFi Realtime OHLC, Price, Volume API - Crypto Price API
+
+Below API will give you realtime prices, OHLC, and volume data for all GoonFi trading pairs. We have selected `1` sec as the interval for the OHLC, volume or moving average calculation.
+
+▶️ [GoonFi Realtime OHLC, Price, Volume API - Crypto Price API](https://ide.bitquery.io/GoonFi-Realtime-OHLC-Price-Volume-API---Crypto-Price-API_1)
+
+#### 1-Second OHLC Stream
+
+This subscription generates a real-time OHLC (Open, High, Low, Close) K-line chart for Solana in real-time, useful for Tradingview charting in real-time.
+
+▶️ [1-Second OHLC Stream](https://ide.bitquery.io/1-second-OHLC-k-line-Solana)
+
+#### Byreal token live prices using trades api
+
+Lock onto one token with `Pair.Token.Id` (e.g. `bid:solana:<mint>`) and the Byreal program address. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Byreal token live prices using trades api](https://ide.bitquery.io/Byreal-token-live-prices-using-trades-api)
+
+#### Latest price for more than 1 markets on solana — historical (beyond 30 days)
+
+You can retrieve data from multiple Solana DEX markets using our APIs or streams. The. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Latest price for more than 1 markets on solana — historical (beyond 30 days)](https://ide.bitquery.io/latest-price-for-more-than-1-markets-on-solana_1)
+
+#### Latest price for more than 1 markets on solana for specific currencies — historical (beyond 30 days)
+
+Latest price for more than 1 markets on solana for specific currencies. Uses the `DEXTrades` cube. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Latest price for more than 1 markets on solana for specific currencies — historical (beyond 30 days)](https://ide.bitquery.io/latest-price-for-more-than-1-markets-on-solana-for-specific-currencies)
+
+#### Real-time Token Prices on Solana — historical (beyond 30 days)
+
+This stream delivers real-time token prices on Solana based on the latest trades. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Real-time Token Prices on Solana — historical (beyond 30 days)](https://ide.bitquery.io/Real-time-price-stream-for-specific-token-on-solana)
+
+#### Get Latest Price of SOL in USD Real-time — historical (beyond 30 days)
+
+Get Latest Price of SOL in USD Real-time. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get Latest Price of SOL in USD Real-time — historical (beyond 30 days)](https://ide.bitquery.io/Get-Latest-Price-of-SOL-in--USD-Real-time)
+
+#### Get realtime Price of Apple xStock in USD Real-time — historical (beyond 30 days)
+
+You can use the following query to get the latest price of a Apple xStock on Solana. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get realtime Price of Apple xStock in USD Real-time — historical (beyond 30 days)](https://ide.bitquery.io/Get-realtime-Price-of-Apple-xStock-in--USD-Real-time)
+
+#### Price of a moonshot token — historical (beyond 30 days)
+
+The below query gets real-time price of the specified Token `A1XqfcD1vMEhUNwEKvBVRWFV48ZLDL4oheFVCPEcM3Vk` on the Moonit DEX. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Price of a moonshot token — historical (beyond 30 days)](https://ide.bitquery.io/Price-of-a-Moonshot-token)
+
+### Supply & Market Cap
+
+#### Realtime heaven tokens with marketcap 10k
+
+Subscribe when the token is on Solana, `Market.Protocol` is `Heaven`, `Supply.MarketCap` &gt; 10,000 (USD), and interval duration &gt; 1 second. Adjust `gt` to change the threshold.
+
+▶️ [Realtime heaven tokens with marketcap 10k](https://ide.bitquery.io/realtime-heaven-tokens-with-marketcap-10k)
+
+#### Solana tokens with market cap above $1 million (Trading API)
+
+Subscribe when **`Token.Id`** matches Solana and **`Supply.MarketCap`** &gt; 1,000,000 USD.
+
+▶️ [Solana tokens with market cap above $1 million (Trading API)](https://ide.bitquery.io/realtime-stream-solana-tokens-with-marketcap-above-1-million)
+
+#### All trades on Solana with Price, Marketcap, supply
+
+Stream all Solana DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data.
+
+▶️ [All trades on Solana with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Solana-with-Price-Marketcap-supply)
+
+#### Get All DEX Trades on DBC With Price, Market Cap, and Supply
+
+Stream all Meteora DBC DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.Protocol: dynamic_bonding_curve` to capture every swap across Meteora DBC in a single subscription.
+
+▶️ [Get All DEX Trades on DBC With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-DBC-With-Price-Market-Cap-and-Supply)
+
+#### Bags.fm token creation stream using Solana token supply updates
+
+Track Bags FM token creation using the Solana TokenSupply API. This endpoint provides Bags FM token data including supply information and creation timestamps. For the same API as a WebSocket stream.
+
+▶️ [Bags.fm token creation stream using Solana token supply updates](https://ide.bitquery.io/Bagsfm-token-creation-stream-using-Solana-token-supply-updates)
+
+#### Get newly created Moonshot tokens with metadata
+
+Now you can track the newly created Moonit Tokens along with their metadata and supply. `PostBalance` will give you the current supply for the token.
+
+▶️ [Get newly created Moonshot tokens with metadata](https://ide.bitquery.io/Get-newly-created-Moonshot-tokens-with-metadata)
+
+#### Newly created PF token, dev address, metadata
+
+Now you can track the newly created Pump Fun Tokens along with their dev address, metadata and supply. `PostBalance` will give you the current supply for the token.
+
+▶️ [Newly created PF token, dev address, metadata](https://ide.bitquery.io/newly-created-PF-token-dev-address-metadata)
+
+### Liquidity & Pools
+
+#### DEXPool Liquidity Changes
+
+This stream provides real time liquidity details for all pools on Solana.
+
+▶️ [DEXPool Liquidity Changes](https://ide.bitquery.io/Solana-DEXPools-stream_2)
+
+#### Latest pools created on trends.fun stream
+
+Latest pools created on trends.fun stream. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest pools created on trends.fun stream](https://ide.bitquery.io/latest-pools-created-on-trendsfun-stream)
+
+#### Latest price based on liquidity
+
+Latest price based on liquidity. Uses the `DEXPools` cube.
+
+▶️ [Latest price based on liquidity](https://ide.bitquery.io/latest-price-based-on-liquidity_2)
+
+#### Liquidity for a launchpad token pair stream
+
+Liquidity for a launchpad token pair stream. Uses the `DEXPools` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Liquidity for a launchpad token pair stream](https://ide.bitquery.io/liquidity-for-a-launchpad-token-pair-stream)
+
+#### Search tokens with liquidity over 1 million
+
+You can use the below query to get the tokens which are getting traded and have liquidity over 1 million USD.
+
+▶️ [Search tokens with liquidity over 1 million](https://ide.bitquery.io/Search-tokens-with-liquidity-over-1-million)
+
+#### Trends fun tokens between 95 and 100 bonding curve progress
+
+Track Trends.fun tokens that are approaching graduation with high bonding curve progress percentages. Run the query.
+
+▶️ [Trends fun tokens between 95 and 100 bonding curve progress](https://ide.bitquery.io/trends-fun-tokens-between-95-and-100-bonding-curve-progress)
+
+### Transactions
+
+#### Realtime Solana Transactions
+
+The subscription query below fetches the most recent transactions on the Solana blockchain.
+
+▶️ [Realtime Solana Transactions](https://ide.bitquery.io/Realtime-Solana-Transactions)
+
+### Events & Calls
+
+#### ConsumeEvents instruction on OpenBook V2
+
+We will use this subscription to listen to `consumeEvents` transactions on OpenBook v2. This instruction processes trade events and other activities such as order cancellations.
+
+▶️ [ConsumeEvents instruction on OpenBook V2](https://ide.bitquery.io/consumeEvents-instruction-on-OpenBook-V2_3)
+
+### Pump.fun
+
+#### PumpFun Token Creation
+
+This subscription tracks in real-time newly created Pumpfun tokens, including their metadata and associated developer addresses.
+
+▶️ [PumpFun Token Creation](https://ide.bitquery.io/newly-created-PF-token-developer-address-metadata)
+
+#### PumpFun Trades Stream
+
+This stream returns the real time trades on Pumpfun platform. This stream could be modified to get real time trades for a particular token or trades by a particular trader.
+
+▶️ [PumpFun Trades Stream](https://ide.bitquery.io/Pumpfun-DEX-Trades_1)
+
+#### Pumpswap Trades Stream
+
+This stream returns the real time trades on Pumpswap exchange. This stream could be modified to get real time trades for a particular token or trades by a particular trader.
+
+▶️ [Pumpswap Trades Stream](https://ide.bitquery.io/pumpswap-trades)
+
+#### Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply
+
+Stream all PumpFun DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.ProtocolFamily: Pumpfun` to capture every swap across Pumpfun in a single subscription.
+
+▶️ [Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Pumpfun-With-Price-Market-Cap-and-Supply)
+
+#### Latest Trades for a token on Pumpswap
+
+Subscribe to `DEXTradeByTokens` with PumpSwap `ProgramAddress` and the token mint. Each update is a new trade involving that token on PumpSwap—use this to stream per-token activity without polling.
+
+▶️ [Latest Trades for a token on Pumpswap](https://ide.bitquery.io/Latest-Trades-for-a-token-on-Pumpswap)
+
+#### Price of a pump fun token using price index in usd
+
+Live stream of token price updates on Pump.fun.
+
+▶️ [Price of a pump fun token using price index in usd](https://ide.bitquery.io/Price-of-a-pump-fun-token-using-price-index-in-usd)
+
+### Raydium
+
+#### Latest Pools Created on Raydium
+
+This query returns the latest created pools on Raydium. You can set the limit here also.
+
+▶️ [Latest Pools Created on Raydium](https://ide.bitquery.io/Latest-Radiyum-V4-pools-created_1)
+
+#### Latest Trades on Raydium
+
+This stream gives info about the real time trades on Raydium exchange. You can modify this query to monitor trades on Raydium for a particular token or by a particular trader.
+
+▶️ [Latest Trades on Raydium](https://ide.bitquery.io/Updated-Real-time-trades-on-Raydium-DEX-on-Solana_1)
+
+#### New Pool Creation on Raydium CLMM
+
+This stream gives info about the real time liquidity pool creation on Raydium CLMM.
+
+▶️ [New Pool Creation on Raydium CLMM](https://ide.bitquery.io/Raydium-CLMM-Pool-Creation-stream)
+
+#### New Pool Creation on Raydium CPMM
+
+This stream gives info about the real time liquidity pool creation on Raydium CPMM.
+
+▶️ [New Pool Creation on Raydium CPMM](https://ide.bitquery.io/CPMM-pools-creation-stream)
+
+#### New Pool Creation on Raydium Launchpad
+
+This stream gives info about the real time liquidity pool creation on Raydium Launchpad.
+
+▶️ [New Pool Creation on Raydium Launchpad](https://ide.bitquery.io/Raydium-Launchpad-pool-creations_1)
+
+#### New Pool Creation on Raydium v4
+
+This stream gives info about the real time liquidity pool creation on Raydium exchange.
+
+▶️ [New Pool Creation on Raydium v4](https://ide.bitquery.io/Latest-Radiyum-V4-pools-created_5)
+
+#### Track Raydium Launchpad tokens above 95% Bonding Curve Progress in realtime
+
+Returns Raydium Launchpad tokens which have more than 95% bonding curve progress.
+
+▶️ [Track Raydium Launchpad tokens above 95% Bonding Curve Progress in realtime](https://ide.bitquery.io/LetsBonkfun-Tokens-between-95-and-100-bonding-curve-progress_2)
+
+### Meteora
+
+#### Jup studio token migrations from Meteora DBC to Meteors DEX
+
+We monitor Meteora DBC program address `dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN` for migration instructions including `migrate_meteora_damm` and `migration_damm_v2`.
+
+▶️ [Jup studio token migrations from Meteora DBC to Meteors DEX](https://ide.bitquery.io/jup-studio-token-migrations-from-Meteora-DBC-to-Meteors-DEX_1)
+
+#### Liquidity addition for meteora
+
+In this section, we will discover data streams that provides us with the real time events of liquidity addition and liquidity removal for the Meteora DEX, which has `Meteora` as the Protocol Family.
+
+▶️ [Liquidity addition for meteora](https://ide.bitquery.io/liquidity-addition-for-meteora_1)
+
+#### Liquidity removal for meteora
+
+Liquidity removal for meteora. Uses the `DEXPools` cube.
+
+▶️ [Liquidity removal for meteora](https://ide.bitquery.io/liquidity-removal-for-meteora_1)
+
+#### Meteora DBC token migrations to Meteors DEX
+
+Below query will give you the latest migrated tokens Meteora DBC in realtime.
+
+▶️ [Meteora DBC token migrations to Meteors DEX](https://ide.bitquery.io/meteora-DBC-token-migrations-to-Meteors-DEX)
+
+#### Real time trades on Meteora Dynamic Bonding Curve on Solana
+
+The below query gets real-time information whenever there's a new trade on the Meteora DBC including detailed information about the trade, including the buy and sell details, the block information, and the transaction specifics.
+
+▶️ [Real time trades on Meteora Dynamic Bonding Curve on Solana](https://ide.bitquery.io/Real-time-trades-on-Meteora-Dynamic-Bonding-Curve-on-Solana)
+
+#### Real time trades on MeteoraDAMMv2 DEX on Solana
+
+This query subscribes to real-time trades on the Meteora DAMM v2 (Dynamic Automated Market Maker) on the Solana blockchain by filtering using the program address `cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG`.
+
+▶️ [Real time trades on MeteoraDAMMv2 DEX on Solana](https://ide.bitquery.io/Real-time-trades-on-MeteoraDAMMv2-DEX-on-Solana)
+
+### Orca
+
+#### Latest pool created on Orca - Websocket
+
+For instance, Index 1 and 2 represent the tokens involved in the pool, while Index 4 is for the pool's address. Note that the indexing starts from 0.
+
+▶️ [Latest pool created on Orca - Websocket](https://ide.bitquery.io/Latest-pool-created-on-Orca---Websocket_1)
+
+#### Liquidity addition for orca whirlpool
+
+In this section, we will discover data streams that provides us with the real time events of liquidity addition and liquidity removal for the Orca Whirlpool DEX, which has `whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc` as the Program Address.
+
+▶️ [Liquidity addition for orca whirlpool](https://ide.bitquery.io/liquidity-addition-for-orca-whirlpool_1)
+
+#### Liquidity removal for orca whirlpool
+
+With Orca’s program and negative base change, stream liquidity removals from Whirlpool markets.
+
+▶️ [Liquidity removal for orca whirlpool](https://ide.bitquery.io/liquidity-removal-for-orca-whirlpool_1)
+
+#### Orca DEX Trades Websocket
+
+To access a real-time stream of trades for Solana Orca DEX.
+
+▶️ [Orca DEX Trades Websocket](https://ide.bitquery.io/Orca-DEX-Trades-Websocket)
+
+#### Orca DEX Trades for a specific currency Websocket
+
+By setting the limit to 1, you will receive the most recent trade, which reflects the latest price of the token.
+
+▶️ [Orca DEX Trades for a specific currency Websocket](https://ide.bitquery.io/Orca-DEX-Trades-for-a-specific-currency-Websocket)
+
+#### Price of a token on Orca
+
+You can use the following query to get the latest price of a token, we have used WSOL address here in the below example. We are getting realtime price of WSOL on Orca DEX on Solana in different pools.
+
+▶️ [Price of a token on Orca](https://ide.bitquery.io/Price-of-a-token-on-Orca)
+
+### Jupiter
+
+#### Latest Cancel Expired Order Transactions on Jupiter in realtime
+
+We track Jupiter's Limit Order program address `jupoNjAxXgZ4rjzxzPMP4oxduvQsQtZzyknqvzYNrNu` for `cancelExpiredOrder` instructions. The query returns transaction signatures, account details, and program arguments for expired order cancellations.
+
+▶️ [Latest Cancel Expired Order Transactions on Jupiter in realtime](https://ide.bitquery.io/Latest-Cancel-Expired-Order-Transactions-on-Jupiter-in-realtime_1)
+
+#### Latest Cancel Limit Order Transactions on Jupiter in realtime
+
+We track Jupiter's Limit Order program address `jupoNjAxXgZ4rjzxzPMP4oxduvQsQtZzyknqvzYNrNu` for `cancelOrder` instructions. The query returns input mint addresses, maker addresses, reserve addresses, and cancellation details.
+
+▶️ [Latest Cancel Limit Order Transactions on Jupiter in realtime](https://ide.bitquery.io/Latest-Cancel-Limit-Order-Transactions-on-Jupiter-in-realtime)
+
+#### Tokens involved in Jupiter swap, source address, destination address, DEX involved
+
+We monitor Jupiter's program address `JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4` for `sharedAccountsRoute` instructions to track swap activity. The query returns tokens involved in swaps, source and destination addresses, and routing information.
+
+▶️ [Tokens involved in Jupiter swap, source address, destination address, DEX involved](https://ide.bitquery.io/Tokens-involved-in-Jupiter-swap-source-address-destination-address-DEX-involved_2)
+
+## Robinhood Chain
+
+### Trades
+
+#### Latest DEX Trades on Robinhood Chain
+
+Latest DEX trades on Robinhood Chain (chain id 4663) via the Trading API, with price and USD amounts.
+
+▶️ [Latest DEX Trades on Robinhood Chain](https://ide.bitquery.io/Robinhood-Trades)
+
+#### Bags amm trade websocket
+
+Stream every Bags trade as it is indexed via a GraphQL `subscription` on `Trading.Trades`, scoped to the Bags protocol family on Robinhood. Includes side (buy/sell), trader, base/quote amounts (native and USD), market cap, and full transaction header.
+
+▶️ [Bags amm trade websocket](https://ide.bitquery.io/bags-amm-trade-websocket)
+
+#### Robinhood Chain API - Trades for a Token
+
+Using this GraphQL stream you can get real-time trades for a specific token (example: AssetHood, `ASSETH`) with details such as trader address, token details, marketcap, FDV and transaction hash.
+
+▶️ [Robinhood Chain API - Trades for a Token](https://ide.bitquery.io/Robinhood-Trades-for-a-token)
+
+#### Stream Robinhood Chain Trades in Real Time
+
+These are live examples — meme tokens go quiet over time, so swap in any token, pool, or trader you care about.
+
+▶️ [Stream Robinhood Chain Trades in Real Time](https://ide.bitquery.io/stream-robinhood-chain-trades)
+
+#### Pools trade Stream new Crowd Launch auctions
+
+Every Crowd Launch deploys its auction through the auction factory `0x000000001f26a0044baa66024e7b6599c61963f8`, which emits `AuctionCreated(address,address,uint256,bytes)`.
+
+▶️ [Pools trade Stream new Crowd Launch auctions](https://ide.bitquery.io/Pools-trade-Stream-new-Crowd-Launch-auctions)
+
+### Transfers
+
+#### Ape.store Newly created tokens - Websocket
+
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
+
+▶️ [Ape.store Newly created tokens - Websocket](https://ide.bitquery.io/Apestore-Newly-created-tokens---Websocket)
+
+#### Bags.fm Newly created tokens - Websocket
+
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
+
+▶️ [Bags.fm Newly created tokens - Websocket](https://ide.bitquery.io/Bagsfm-Newly-created-tokens---Websocket)
+
+#### Bankr Bot Newly created tokens - Websocket
+
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
+
+▶️ [Bankr Bot Newly created tokens - Websocket](https://ide.bitquery.io/Bankr-Bot-Newly-created-tokens---Websocket)
+
+#### Flap Sh Newly created tokens using transfer data - Websocket
+
+Track Flap.sh mints as transfers from the zero address with amount `1000000000` in transactions sent to the Flap.sh contract.
+
+▶️ [Flap Sh Newly created tokens using transfer data - Websocket](https://ide.bitquery.io/Flap-Sh-Newly-created-tokens-using-transfer-data---Websocket)
+
+#### Hoodfun newly creaed tokens Websocket
+
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
+
+▶️ [Hoodfun newly creaed tokens Websocket](https://ide.bitquery.io/hoodfun-newly-creaed-tokens---Websocket)
+
+#### Klik Finance Newly created tokens using transfers websocket
+
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
+
+▶️ [Klik Finance Newly created tokens using transfers websocket](https://ide.bitquery.io/Klik-Finance-Newly-created-tokens-using-transfers-websocket)
+
+#### Launchpad newly creaed tokens Websocket
+
+Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
+
+▶️ [Launchpad newly creaed tokens Websocket](https://ide.bitquery.io/launchpad-newly-creaed-tokens---Websocket)
+
+#### Pools trade Stream launches with token detail
+
+The transfer-based stream returns the token's name, symbol, decimals, and contract in the same payload — everything a sniping bot or listings feed needs, with no follow-up metadata call. It also carries the transaction's gas economics and success flag.
+
+▶️ [Pools trade Stream launches with token detail](https://ide.bitquery.io/Pools-trade-Stream-launches-with-token-detail)
+
+#### Real time transfers on robinhood
+
+Stream live transfers for dashboards, bots, and alerting.
+
+▶️ [Real time transfers on robinhood](https://ide.bitquery.io/real-time-transfers-on-robinhood)
+
+### Price & OHLC
+
+#### Robinhood Chain OHLCV / Candlestick API for a Token Pair
+
+This GraphQL stream for 1 second OHLCV streams the USD normalised OHLC/K-line data for a token pair, and also contains info such as interval start and end time, marketcap, volume and token details for both base and quote tokens.
+
+▶️ [Robinhood Chain OHLCV / Candlestick API for a Token Pair](https://ide.bitquery.io/OHLCV-stream-for-a-token-pair-on-robinhood)
+
+### Liquidity & Pools
+
+#### Stream New pools.trade Token Launches
+
+Websocket subscription streaming every new pools.trade token launch on Robinhood Chain the moment it happens.
+
+▶️ [Stream New pools.trade Token Launches](https://ide.bitquery.io/Pools-trade-Stream-new-launches)
+
+### Events & Calls
+
+#### Flap sh Newly created tokens using logs (TokenCreated) - Websocket
+
+Filter Flap.sh `TokenCreated` events and decode argument values (token address, metadata fields, and related parameters).
+
+▶️ [Flap sh Newly created tokens using logs (TokenCreated) - Websocket](https://ide.bitquery.io/Flap-sh-Newly-created-tokens-using-logs-TokenCreated---Websocket)
+
+#### Stream New Tokens on Robinhood Chain (All Launchpads)
+
+Follow the steps here: How to generate Bitquery API token ➤.
+
+▶️ [Stream New Tokens on Robinhood Chain (All Launchpads)](https://ide.bitquery.io/stream-new-tokens-robinhood-chain)
+
+## Polymarket
+
+### Trades
+
+#### Real-Time Trades Stream
+
+Real-Time Trades Stream.
+
+▶️ [Real-Time Trades Stream](https://ide.bitquery.io/prediction-market-trades-subscription)
+
+#### Trades for a Specific Market (Stream)
+
+Subscribe to trades for one market only by filtering on Question.MarketId. Replace the market ID in the query with your target market.
+
+▶️ [Trades for a Specific Market (Stream)](https://ide.bitquery.io/subscribe-to-specific-market-trades)
+
+#### Bitcoin Up or Down Trades Stream
+
+Subscribe to live Polymarket trades for markets whose question title includes "Bitcoin Up or Down".
+
+▶️ [Bitcoin Up or Down Trades Stream](https://ide.bitquery.io/Bitcoin-Up-or-Down-Trades-Stream)
+
+#### How do I track high-value or whale trades on Polymarket?
+
+Use a GraphQL subscription on `PredictionTrades` filtered by `CollateralAmountInUSD: { gt: "10000" }` and `ProtocolName: "polymarket"` to monitor trades exceeding $10,000 USD in real time. Ideal for detecting whale activity and large market movements.
+
+▶️ [How do I track high-value or whale trades on Polymarket?](https://ide.bitquery.io/How-do-I-track-high-value-or-whale-trades-on-Polymarket)
+
+#### Large trades on polymarket
+
+Start by streaming large Polymarket trades. Each event gives you a buyer address to investigate. Change `subscription` to `query` for historical results.
+
+▶️ [Large trades on polymarket](https://ide.bitquery.io/large-trades--on-polymarket)
+
+#### Monitoring specific wallets trades in realtime for Ethereum up or down market
+
+The same wallet-monitoring pattern works for every Polymarket Up or Down market — only the `Question.Title` filter changes. Open any of the pre-built IDE queries below to stream trades for the chain you care about.
+
+▶️ [Monitoring specific wallets trades in realtime for Ethereum up or down market](https://ide.bitquery.io/monitoring-specific-wallets-trades-in-realtime-for-Ethereum-up-or-down-market)
+
+#### Monitoring specific wallets trades in realtime for XRP up or down market
+
+The same wallet-monitoring pattern works for every Polymarket Up or Down market — only the `Question.Title` filter changes. Open any of the pre-built IDE queries below to stream trades for the chain you care about.
+
+▶️ [Monitoring specific wallets trades in realtime for XRP up or down market](https://ide.bitquery.io/monitoring-specific-wallets-trades-in-realtime-for-XRP-up-or-down-market)
+
+#### Polymarket AI whale trades stream
+
+Streams live AI-market trades above a USD threshold (here `$5,000`). This is ideal for whale-alert bots and detecting large, conviction bets. Filter with a `Question.Title` keyword, or swap it for a single-market `MarketId`.
+
+▶️ [Polymarket AI whale trades stream](https://ide.bitquery.io/Polymarket-AI-whale-trades-stream)
+
+#### Polymarket whale trades alert
+
+Stream successful Polymarket trades whose collateral exceeds $10,000 USD. Adjust the threshold string as needed.
+
+▶️ [Polymarket whale trades alert](https://ide.bitquery.io/polymarket-whale-trades-alert_1)
+
+### Markets
+
+#### Real-Time Management Stream (Creations + Resolutions)
+
+Real-Time Management Stream (Creations + Resolutions).
+
+▶️ [Real-Time Management Stream (Creations + Resolutions)](https://ide.bitquery.io/Prediction-Managements-subscription-resolutions-creations)
+
+#### Real-Time Market Creations
+
+Subscribe only to new market (Created) events.
+
+▶️ [Real-Time Market Creations](https://ide.bitquery.io/track-realtime-new-polymarket-creations)
+
+#### Real-Time Market Resolutions
+
+Subscribe only to Resolved events. Winning outcome is in Prediction.Outcome; token details (e.g. AssetId) in Prediction.OutcomeToken.
+
+▶️ [Real-Time Market Resolutions](https://ide.bitquery.io/track-realtime-polymarket-resolutions)
+
+### Settlements
+
+#### Real-Time Settlement Stream
+
+Real-Time Settlement Stream.
+
+▶️ [Real-Time Settlement Stream](https://ide.bitquery.io/realtime-predicion-market-settlements-stream)
+
+## Perpetuals
+
+### Hyperliquid
+
+#### Hyperliquid Real-time Trades Stream (WebSocket)
+
+Hyperliquid Real-time Trades Stream (WebSocket).
+
+▶️ [Hyperliquid Real-time Trades Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-trades-stream)
+
+#### Hyperliquid Price Updates Stream (WebSocket)
+
+Hyperliquid Price Updates Stream (WebSocket).
+
+▶️ [Hyperliquid Price Updates Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-price-updates-stream)
+
+#### Hyperliquid Real-time Candles Stream (WebSocket)
+
+Hyperliquid Real-time Candles Stream (WebSocket).
+
+▶️ [Hyperliquid Real-time Candles Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-candles-stream)
+
+### Phoenix
+
+#### Solana Perps Live Trades Stream (Phoenix Fills)
+
+Stream every stop-loss and take-profit placement as it happens.
+
+▶️ [Solana Perps Live Trades Stream (Phoenix Fills)](https://ide.bitquery.io/solana-perps-live-trades-stream)
+
+#### Solana Perpetuals Mark Price Stream (Phoenix)
+
+Solana Perpetuals Mark Price Stream (Phoenix).
+
+▶️ [Solana Perpetuals Mark Price Stream (Phoenix)](https://ide.bitquery.io/solana-perpetuals-mark-price-stream)
+
+## TRON
+
+### Trades
+
+#### Real-time Trades on Sunpump
+
+This stream returns all the real time DEX trades happening on Sunpump exchange on the Tron network. You can modify this stream to get the trades of a particular token or trades by a particular trader. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Real-time Trades on Sunpump](https://ide.bitquery.io/real-time-sunswapTrades)
+
+#### Real-time Trades on Tron
+
+This stream returns all the real time DEX trades happening on the Tron network. You can modify this stream to get DEX trades on a particular DEX or trades of a particular token or trades by a particular trader. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Real-time Trades on Tron](https://ide.bitquery.io/Latest-trades-on-Tron)
+
+#### Sunpump trades
+
+To subscribe to latest Sunpump trades you can use. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Sunpump trades](https://ide.bitquery.io/Sunpump-trades)
+
+#### USDT TRC20 DEX Trades
+
+Real-time DEX trades where USDT is the bought currency on Tron — protocol, buyer and seller, amounts and order IDs. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [USDT TRC20 DEX Trades](https://ide.bitquery.io/USDT-TRC20-DEX-Trades)
+
+### Transfers
+
+#### Real-time Tether USDT Transfers
+
+This subscription streams the latest USDT (TRC20) transfers on the TRON network. You can modify the stream to monitor Transfers of USDT from or to a particular address.
+
+▶️ [Real-time Tether USDT Transfers](https://ide.bitquery.io/usdt-trc20-transfers_1)
+
+#### Sender is particular address
+
+Sender is particular address. Uses the `Transfers` cube.
+
+▶️ [Sender is particular address](https://ide.bitquery.io/Sender-is-particular-address)
+
+#### Whale transfers of USDT on Tron
+
+The subscription query below fetches the whale transactions on the Tron network. We have used USDT address `TThzxNRLrW2Brp9DcTQU8i4Wd9udCWEdZ3`.
+
+▶️ [Whale transfers of USDT on Tron](https://ide.bitquery.io/Whale-transfers-of-USDT-on-Tron)
+
+### Price & OHLC
+
+#### Track price of a tron token in realtime
+
+Provides real-time updates on price of token `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` in terms of USDT `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`, including details about the DEX. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Track price of a tron token in realtime](https://ide.bitquery.io/Track-price-of-a-tron-token-in-realtime)
+
+### Supply & Market Cap
+
+#### Get All DEX Trades on Tron With Price, Market Cap, and Supply
+
+Crypto Trades API: one row per swap, with USD and supply. Filter `Pair.Market.Network: Tron`. When to use this vs chain DEX APIs.
+
+▶️ [Get All DEX Trades on Tron With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Tron-With-Price-Market-Cap-and-Supply)
+
+### Transactions
+
+#### Monitor TRX address transactions
+
+The subscription query below fetches the transactions on the Tron network for the wallet address `TDqSquXBgUCLYvYC4XZgrprLK589dkhSCf`.
+
+▶️ [Monitor TRX address transactions](https://ide.bitquery.io/monitor-TRX-address-transactions)
+
+### Events & Calls
+
+#### Latest Buy on SunPump
+
+You can use following stream to get latest buys on Sunpump. You can try.
+
+▶️ [Latest Buy on SunPump](https://ide.bitquery.io/latest-Buy-on-SunPump)
+
+#### New tokens on sunpump
+
+Will subscribe to the latest created sun pump tokens. You will find the newly created token address in `Log { SmartContract }`.
+
+▶️ [New tokens on sunpump](https://ide.bitquery.io/New-tokens-on-sunpump_1)
+
+#### Sunpump sell event
+
+You can use following stream to get latest sells on Sunpump. You can try.
+
+▶️ [Sunpump sell event](https://ide.bitquery.io/sunpump-sell-event)
+
+#### Tron sunpump first time buy event
+
+You can use follow stream to get stream of first time buy event for any new token.
+
+▶️ [Tron sunpump first time buy event](https://ide.bitquery.io/Tron-sunpump-first-time-buy-event_1)
+
+### Mempool
+
+#### Events with argumens
+
+Events with argumens. Uses the `Events` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Events with argumens](https://ide.bitquery.io/Events-with-argumens)
+
+#### Sunpump trades mempool
+
+We simulate transactions in mempool, therefore you can also get trades directly from mempool using.
+
+▶️ [Sunpump trades mempool](https://ide.bitquery.io/Sunpump-trades-mempool)
+
+#### Tron mempool transfers
+
+Provides real-time data on token transfers happening in the TRON mempool including the value of the transferred amount in USD.
+
+▶️ [Tron mempool transfers](https://ide.bitquery.io/Tron-mempool-transfers)
+
+## Cross-Chain
+
+### Price & OHLC
+
+#### Crypto Price Stream
+
+This subscription gives you 1-second OHLC, mean price, averages for all tokens across Solana, Ethereum, BNB, Tron.
+
+▶️ [Crypto Price Stream](https://ide.bitquery.io/1-second-crypto-price-stream-with-mcap)
+
+#### Stablecoin 1 sec Price Stream
+
+This subscription gives you 1-second OHLC, mean price, averages for all stablecoins including USDC, USDT, DAI, USDS etc.
+
+▶️ [Stablecoin 1 sec Price Stream](https://ide.bitquery.io/stablecoin-1-second-price-stream)
 
 ## Ethereum
 
@@ -40,9 +886,15 @@ Every subscription below is saved in the [Bitquery IDE](https://ide.bitquery.io)
 
 #### All DEX trades
 
-Every Ethereum DEX trade as it happens. Add a `where` filter to narrow to a token or protocol.
+Every Ethereum DEX trade as it happens. Add a `where` filter to narrow to a token or protocol. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [All DEX trades](https://ide.bitquery.io/All-Ethereum-Trade-Stream_1)
+
+#### Trades of a specific trader of a specific token
+
+Crypto Trades API: filter `Pair.Market.Network: Ethereum` and `Trader.Address`. More examples: Trades API. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
+
+▶️ [Trades of a specific trader of a specific token](https://ide.bitquery.io/trades-of-a-specific-trader-of-a-specific-token)
 
 #### All swap events
 
@@ -50,53 +902,47 @@ Provides information on the latest real-time swap events on Ethereum. You can ru
 
 ▶️ [All swap events](https://ide.bitquery.io/all-swap-events)
 
-#### Get pair trades data just like dexcsreener
-
-Will subscribe to real-time trade transactions for a pair, providing a continuous stream of data as new trades are processed and recorded.
-
-▶️ [Get pair trades data just like dexcsreener](https://ide.bitquery.io/Get-pair-trades-data-just-like-dexcsreener)
-
-#### Get pair trades data just like geckoterminal
-
-Will subscribe to real-time trade transactions for a pair, providing a continuous stream of data as new trades are processed and recorded.
-
-▶️ [Get pair trades data just like geckoterminal](https://ide.bitquery.io/Get-pair-trades-data-just-like-geckoterminal)
-
-#### Latest token trades subscription
-
-Latest token trades subscription. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
-
-▶️ [Latest token trades subscription](https://ide.bitquery.io/latest-token-trades-subscription)
-
-#### Pepe live trades stream
-
-Every PEPE DEX trade as it is confirmed on-chain in real time using Bitquery subscription.
-
-▶️ [Pepe live trades stream](https://ide.bitquery.io/pepe-live-trades-stream)
-
-#### Real time trades of an ethereum address
-
-Real time trades of an ethereum address. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it.
-
-▶️ [Real time trades of an ethereum address](https://ide.bitquery.io/Real-time-trades-of-an-ethereum-address)
-
 #### Stream new position mints on Fluid DEX Vault
 
 Track new position mints on the Fluid DEX Vault Factory contract. This query monitors the `NewPositionMinted` event which is emitted when a new position is created on the vault factory.
 
 ▶️ [Stream new position mints on Fluid DEX Vault](https://ide.bitquery.io/stream-new-position-mints-on-Fluid-DEX-Vault)
 
-#### Subscribe to dex trades on ethereum mainnet
+#### Latest token trades subscription — historical (beyond 30 days)
 
-Will get the realtime DEX trades happening on Ethereum Mainnet. Open it in the GraphQL IDE using this.
+Latest token trades subscription. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Subscribe to dex trades on ethereum mainnet](https://ide.bitquery.io/subscribe-to-dex-trades-on-ethereum-mainnet_2)
+▶️ [Latest token trades subscription — historical (beyond 30 days)](https://ide.bitquery.io/latest-token-trades-subscription)
 
-#### Trades of a specific trader of a specific token
+#### Real time trades of an ethereum address — historical (beyond 30 days)
 
-Crypto Trades API: filter `Pair.Market.Network: Ethereum` and `Trader.Address`. More examples: Trades API.
+Real time trades of an ethereum address. Uses the `DEXTrades` cube. Replace the address in the `where` clause to use it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Trades of a specific trader of a specific token](https://ide.bitquery.io/trades-of-a-specific-trader-of-a-specific-token)
+▶️ [Real time trades of an ethereum address — historical (beyond 30 days)](https://ide.bitquery.io/Real-time-trades-of-an-ethereum-address)
+
+#### Subscribe to dex trades on ethereum mainnet — historical (beyond 30 days)
+
+Will get the realtime DEX trades happening on Ethereum Mainnet. Open it in the GraphQL IDE using this. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Subscribe to dex trades on ethereum mainnet — historical (beyond 30 days)](https://ide.bitquery.io/subscribe-to-dex-trades-on-ethereum-mainnet_2)
+
+#### Get pair trades data just like dexcsreener — historical (beyond 30 days)
+
+Will subscribe to real-time trade transactions for a pair, providing a continuous stream of data as new trades are processed and recorded. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get pair trades data just like dexcsreener — historical (beyond 30 days)](https://ide.bitquery.io/Get-pair-trades-data-just-like-dexcsreener)
+
+#### Get pair trades data just like geckoterminal — historical (beyond 30 days)
+
+Will subscribe to real-time trade transactions for a pair, providing a continuous stream of data as new trades are processed and recorded. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get pair trades data just like geckoterminal — historical (beyond 30 days)](https://ide.bitquery.io/Get-pair-trades-data-just-like-geckoterminal)
+
+#### Pepe live trades stream — historical (beyond 30 days)
+
+Every PEPE DEX trade as it is confirmed on-chain in real time using Bitquery subscription. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Pepe live trades stream — historical (beyond 30 days)](https://ide.bitquery.io/pepe-live-trades-stream)
 
 ### Transfers
 
@@ -190,27 +1036,27 @@ Balance update from transfer for multiple addresses--stream. Uses the `Transacti
 
 #### 1-second OHLC candles
 
-Rolling one-second candles for charting.
+Rolling one-second candles for charting. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [1-second OHLC candles](https://ide.bitquery.io/1-second-OHLC-k-line-Ethereum)
 
-#### Token price stream
-
-Live USD price updates as trades land.
-
-▶️ [Token price stream](https://ide.bitquery.io/token-price-stream)
-
 #### 1 second crypto price stream
 
-For a live ticker, use the Crypto Price API stream.
+For a live ticker, use the Crypto Price API stream. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [1 second crypto price stream](https://ide.bitquery.io/1-second-crypto-price-stream)
 
 #### Pepe-ohlcv-stream
 
-Stream live PEPE price data with 1-minute candles, moving averages, and USD volume.
+Stream live PEPE price data with 1-minute candles, moving averages, and USD volume. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [Pepe-ohlcv-stream](https://ide.bitquery.io/pepe-ohlcv-stream)
+
+#### Token price stream — historical (beyond 30 days)
+
+Live USD price updates as trades land. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Token price stream — historical (beyond 30 days)](https://ide.bitquery.io/token-price-stream)
 
 ### Supply & Market Cap
 
@@ -226,17 +1072,17 @@ Only tokens above a market cap floor. Change the threshold in the `where` clause
 
 ▶️ [Tokens crossing $1M market cap](https://ide.bitquery.io/realtime-stream-ethereum-tokens-with-marketcap-above-1-million)
 
-#### Token supply changes
-
-Mints and burns as they change a token's supply.
-
-▶️ [Token supply changes](https://ide.bitquery.io/latest-token-supply-on-eth-chain)
-
 #### All trades on Ethereum with Price, Marketcap, supply
 
 Stream all Ethereum DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.Network: Ethereum` to capture every swap across all Ethereum DEXs in a single subscription.
 
 ▶️ [All trades on Ethereum with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Ethereum-with-Price-Marketcap-supply)
+
+#### Token supply changes
+
+Mints and burns as they change a token's supply.
+
+▶️ [Token supply changes](https://ide.bitquery.io/latest-token-supply-on-eth-chain)
 
 ### Liquidity & Pools
 
@@ -436,481 +1282,27 @@ Open this query on our GraphQL IDE using this.
 
 ▶️ [Latest pools created Uniswap v3](https://ide.bitquery.io/Latest-pools-created-Uniswap-v3_9)
 
-## Solana
-
-### Trades
-
-#### Graduated Tokens
-
-This query gives you tokens which are graduated from Raydium Launchpad to Raydium.
-
-▶️ [Graduated Tokens](https://ide.bitquery.io/Track-Token-Migrations-to-Raydium-DEX-and-Raydium-CPMM-in-realtime)
-
-#### Large Token Buys and Sells on Solana DEX
-
-This stream provides real-time large buy and sell on Solana DEXs.
-
-▶️ [Large Token Buys and Sells on Solana DEX](https://ide.bitquery.io/big-trades-on-solana)
-
-#### Solana Trades Stream
-
-This subscription streams real-time Solana trades.
-
-▶️ [Solana Trades Stream](https://ide.bitquery.io/solana-trades-subscription_3)
-
-#### Specific Token Trades Stream
-
-This subscription stream uses DexTradeByTokens API to stream real-time specific token trades.
-
-▶️ [Specific Token Trades Stream](https://ide.bitquery.io/token-trades-subscription)
-
-#### All Trade for Bags.fm tokens
-
-Get all trades of Bags FM tokens from Meteora and other DEXs. This Bags FM token trades WebSocket provides comprehensive trading data.
-
-▶️ [All Trade for Bags.fm tokens](https://ide.bitquery.io/All-Trade-for-Bagsfm-tokens)
-
-#### CPMM trades
-
-In this section we will see how to get data on Raydium CPMM trades in real-time. You can check out our Pump Fun docs, Raydium v4 docs and Raydium LaunchPad docs too.
-
-▶️ [CPMM trades](https://ide.bitquery.io/CPMM-trades)
-
-#### Get Solana pair trades data
-
-Will subscribe to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded.
-
-▶️ [Get Solana pair trades data](https://ide.bitquery.io/Get-Solana-pair-trades-data)
-
-#### Get Solana pair trades data just like dexcsreener
-
-Will subscribe to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded.
-
-▶️ [Get Solana pair trades data just like dexcsreener](https://ide.bitquery.io/Get-Solana-pair-trades-data-just-like-dexcsreener)
-
-#### Get Solana pair trades data just like geckoTerminal
-
-Will subscribe to real-time trade transactions for a Solana pair, providing a continuous stream of data as new trades are processed and recorded.
-
-▶️ [Get Solana pair trades data just like geckoTerminal](https://ide.bitquery.io/Get-Solana-pair-trades-data-just-like-geckoTerminal_1)
-
-#### Latest Trades of TESLA onchain xStock
-
-Below query will give you realtime trades of Tesla xStock (TESLAx).
-
-▶️ [Latest Trades of TESLA onchain xStock](https://ide.bitquery.io/Latest-Trades-of-TESLA-onchain-xStock_1)
-
-### Transfers
-
-#### Token Transfers Stream
-
-This stream provides all token transfers on the Solana blockchain, including SOL transfers.
-
-▶️ [Token Transfers Stream](https://ide.bitquery.io/Solana-transfers-stream_3)
-
-#### SPL transfers websocket
-
-One of the most common types of transfers on Solana are SPL token transfers. Let's see an example to get the latest SPL token transfers using our API. Today we are taking an example of JUPITER token transfers.
-
-▶️ [SPL transfers websocket](https://ide.bitquery.io/SPL-transfers-websocket_1)
-
-#### Solana Websocket - Subscribe to all transfers of specific addresses in realtime
-
-Websockets are priced based on their running time, not the amount of data delivered.
-
-▶️ [Solana Websocket - Subscribe to all transfers of specific addresses in realtime](https://ide.bitquery.io/Solana-Websocket---Subscribe-to-all-transfers-of-specific-addresses-in-realtime)
-
-#### Subscribe to the all transfers on Solana
-
-For monitoring the balance changes that result from these transfers, see our Solana Balance Updates API.
-
-▶️ [Subscribe to the all transfers on Solana](https://ide.bitquery.io/Subscribe-to-the-all-transfers-on-Solana)
-
-#### Transfers of All Tip Payment Accounts on Solana
-
-Jito foundation has Tip Payment Program that allows users to transfer tips to a set of static public keys (compared to signing the transaction with the next N leaders) and ensure that the incentives are distributed to the correct block leader, while enabling…
-
-▶️ [Transfers of All Tip Payment Accounts on Solana](https://ide.bitquery.io/Transfers-of-All-Tip-Payment-Accounts-on-Solana)
-
-#### Transfers of Tip Payment Accounts on Solana
-
-The subscription that provides you the transfer data of one of these addresses is.
-
-▶️ [Transfers of Tip Payment Accounts on Solana](https://ide.bitquery.io/Transfers-of-Tip-Payment-Accounts-on-Solana_1)
-
-#### Transfers where sender is the specified address
-
-Transfers where sender is the specified address. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
-
-▶️ [Transfers where sender is the specified address](https://ide.bitquery.io/transfers-where-sender-is-the-specified-address_1)
-
-### Balances & Holders
-
-#### Balance Stream
-
-This stream provides all balance updates on the Solana blockchain.
-
-▶️ [Balance Stream](https://ide.bitquery.io/solana-balance-update-stream_3)
-
-### Price & OHLC
-
-#### 1-Second OHLC Stream
-
-This subscription generates a real-time OHLC (Open, High, Low, Close) K-line chart for Solana in real-time, useful for Tradingview charting in real-time.
-
-▶️ [1-Second OHLC Stream](https://ide.bitquery.io/1-second-OHLC-k-line-Solana)
-
-#### Real-Time Token Prices in USD on Solana
-
-Stream live OHLC (Open, High, Low, Close) price and volume data for all tokens on Solana, quoted directly in USD. Useful for dashboards, analytics, or bots that need stable fiat-based prices.
-
-▶️ [Real-Time Token Prices in USD on Solana](https://ide.bitquery.io/Real-Time-usd-price-on-solana-chain)
-
-#### Real-time Token Prices on Solana
-
-This stream delivers real-time token prices on Solana based on the latest trades.
-
-▶️ [Real-time Token Prices on Solana](https://ide.bitquery.io/Real-time-price-stream-for-specific-token-on-solana)
-
-#### Byreal token live prices using trades api
-
-Lock onto one token with `Pair.Token.Id` (e.g. `bid:solana:<mint>`) and the Byreal program address.
-
-▶️ [Byreal token live prices using trades api](https://ide.bitquery.io/Byreal-token-live-prices-using-trades-api)
-
-#### Get Latest Price of SOL in USD Real-time
-
-Get Latest Price of SOL in USD Real-time. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
-
-▶️ [Get Latest Price of SOL in USD Real-time](https://ide.bitquery.io/Get-Latest-Price-of-SOL-in--USD-Real-time)
-
-#### Get realtime Price of Apple xStock in USD Real-time
-
-You can use the following query to get the latest price of a Apple xStock on Solana.
-
-▶️ [Get realtime Price of Apple xStock in USD Real-time](https://ide.bitquery.io/Get-realtime-Price-of-Apple-xStock-in--USD-Real-time)
-
-#### GoonFi Realtime OHLC, Price, Volume API - Crypto Price API
-
-Below API will give you realtime prices, OHLC, and volume data for all GoonFi trading pairs. We have selected `1` sec as the interval for the OHLC, volume or moving average calculation.
-
-▶️ [GoonFi Realtime OHLC, Price, Volume API - Crypto Price API](https://ide.bitquery.io/GoonFi-Realtime-OHLC-Price-Volume-API---Crypto-Price-API_1)
-
-#### Latest price for more than 1 markets on solana
-
-You can retrieve data from multiple Solana DEX markets using our APIs or streams. The.
-
-▶️ [Latest price for more than 1 markets on solana](https://ide.bitquery.io/latest-price-for-more-than-1-markets-on-solana_1)
-
-#### Latest price for more than 1 markets on solana for specific currencies
-
-Latest price for more than 1 markets on solana for specific currencies. Uses the `DEXTrades` cube.
-
-▶️ [Latest price for more than 1 markets on solana for specific currencies](https://ide.bitquery.io/latest-price-for-more-than-1-markets-on-solana-for-specific-currencies)
-
-#### Price of a moonshot token
-
-The below query gets real-time price of the specified Token `A1XqfcD1vMEhUNwEKvBVRWFV48ZLDL4oheFVCPEcM3Vk` on the Moonit DEX.
-
-▶️ [Price of a moonshot token](https://ide.bitquery.io/Price-of-a-Moonshot-token)
-
-### Supply & Market Cap
-
-#### Solana tokens with market cap above $1 million (Trading API)
-
-Subscribe when **`Token.Id`** matches Solana and **`Supply.MarketCap`** &gt; 1,000,000 USD.
-
-▶️ [Solana tokens with market cap above $1 million (Trading API)](https://ide.bitquery.io/realtime-stream-solana-tokens-with-marketcap-above-1-million)
-
-#### All trades on Solana with Price, Marketcap, supply
-
-Stream all Solana DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data.
-
-▶️ [All trades on Solana with Price, Marketcap, supply](https://ide.bitquery.io/All-trades-on-Solana-with-Price-Marketcap-supply)
-
-#### Bags.fm token creation stream using Solana token supply updates
-
-Track Bags FM token creation using the Solana TokenSupply API. This endpoint provides Bags FM token data including supply information and creation timestamps. For the same API as a WebSocket stream.
-
-▶️ [Bags.fm token creation stream using Solana token supply updates](https://ide.bitquery.io/Bagsfm-token-creation-stream-using-Solana-token-supply-updates)
-
-#### Get All DEX Trades on DBC With Price, Market Cap, and Supply
-
-Stream all Meteora DBC DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.Protocol: dynamic_bonding_curve` to capture every swap across Meteora DBC in a single subscription.
-
-▶️ [Get All DEX Trades on DBC With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-DBC-With-Price-Market-Cap-and-Supply)
-
-#### Get newly created Moonshot tokens with metadata
-
-Now you can track the newly created Moonit Tokens along with their metadata and supply. `PostBalance` will give you the current supply for the token.
-
-▶️ [Get newly created Moonshot tokens with metadata](https://ide.bitquery.io/Get-newly-created-Moonshot-tokens-with-metadata)
-
-#### Newly created PF token, dev address, metadata
-
-Now you can track the newly created Pump Fun Tokens along with their dev address, metadata and supply. `PostBalance` will give you the current supply for the token.
-
-▶️ [Newly created PF token, dev address, metadata](https://ide.bitquery.io/newly-created-PF-token-dev-address-metadata)
-
-#### Realtime heaven tokens with marketcap 10k
-
-Subscribe when the token is on Solana, `Market.Protocol` is `Heaven`, `Supply.MarketCap` &gt; 10,000 (USD), and interval duration &gt; 1 second. Adjust `gt` to change the threshold.
-
-▶️ [Realtime heaven tokens with marketcap 10k](https://ide.bitquery.io/realtime-heaven-tokens-with-marketcap-10k)
-
-### Liquidity & Pools
-
-#### DEXPool Liquidity Changes
-
-This stream provides real time liquidity details for all pools on Solana.
-
-▶️ [DEXPool Liquidity Changes](https://ide.bitquery.io/Solana-DEXPools-stream_2)
-
-#### Latest pools created on trends.fun stream
-
-Latest pools created on trends.fun stream. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
-
-▶️ [Latest pools created on trends.fun stream](https://ide.bitquery.io/latest-pools-created-on-trendsfun-stream)
-
-#### Latest price based on liquidity
-
-Latest price based on liquidity. Uses the `DEXPools` cube.
-
-▶️ [Latest price based on liquidity](https://ide.bitquery.io/latest-price-based-on-liquidity_2)
-
-#### Liquidity for a launchpad token pair stream
-
-Liquidity for a launchpad token pair stream. Uses the `DEXPools` cube. Replace the address in the `where` clause to use it.
-
-▶️ [Liquidity for a launchpad token pair stream](https://ide.bitquery.io/liquidity-for-a-launchpad-token-pair-stream)
-
-#### Search tokens with liquidity over 1 million
-
-You can use the below query to get the tokens which are getting traded and have liquidity over 1 million USD.
-
-▶️ [Search tokens with liquidity over 1 million](https://ide.bitquery.io/Search-tokens-with-liquidity-over-1-million)
-
-#### Trends fun tokens between 95 and 100 bonding curve progress
-
-Track Trends.fun tokens that are approaching graduation with high bonding curve progress percentages. Run the query.
-
-▶️ [Trends fun tokens between 95 and 100 bonding curve progress](https://ide.bitquery.io/trends-fun-tokens-between-95-and-100-bonding-curve-progress)
-
-### Transactions
-
-#### Realtime Solana Transactions
-
-The subscription query below fetches the most recent transactions on the Solana blockchain.
-
-▶️ [Realtime Solana Transactions](https://ide.bitquery.io/Realtime-Solana-Transactions)
-
-### Events & Calls
-
-#### ConsumeEvents instruction on OpenBook V2
-
-We will use this subscription to listen to `consumeEvents` transactions on OpenBook v2. This instruction processes trade events and other activities such as order cancellations.
-
-▶️ [ConsumeEvents instruction on OpenBook V2](https://ide.bitquery.io/consumeEvents-instruction-on-OpenBook-V2_3)
-
-### Raydium
-
-#### Latest Pools Created on Raydium
-
-This query returns the latest created pools on Raydium. You can set the limit here also.
-
-▶️ [Latest Pools Created on Raydium](https://ide.bitquery.io/Latest-Radiyum-V4-pools-created_1)
-
-#### Latest Trades on Raydium
-
-This stream gives info about the real time trades on Raydium exchange. You can modify this query to monitor trades on Raydium for a particular token or by a particular trader.
-
-▶️ [Latest Trades on Raydium](https://ide.bitquery.io/Updated-Real-time-trades-on-Raydium-DEX-on-Solana_1)
-
-#### New Pool Creation on Raydium CLMM
-
-This stream gives info about the real time liquidity pool creation on Raydium CLMM.
-
-▶️ [New Pool Creation on Raydium CLMM](https://ide.bitquery.io/Raydium-CLMM-Pool-Creation-stream)
-
-#### New Pool Creation on Raydium CPMM
-
-This stream gives info about the real time liquidity pool creation on Raydium CPMM.
-
-▶️ [New Pool Creation on Raydium CPMM](https://ide.bitquery.io/CPMM-pools-creation-stream)
-
-#### New Pool Creation on Raydium Launchpad
-
-This stream gives info about the real time liquidity pool creation on Raydium Launchpad.
-
-▶️ [New Pool Creation on Raydium Launchpad](https://ide.bitquery.io/Raydium-Launchpad-pool-creations_1)
-
-#### New Pool Creation on Raydium v4
-
-This stream gives info about the real time liquidity pool creation on Raydium exchange.
-
-▶️ [New Pool Creation on Raydium v4](https://ide.bitquery.io/Latest-Radiyum-V4-pools-created_5)
-
-#### Track Raydium Launchpad tokens above 95% Bonding Curve Progress in realtime
-
-Returns Raydium Launchpad tokens which have more than 95% bonding curve progress.
-
-▶️ [Track Raydium Launchpad tokens above 95% Bonding Curve Progress in realtime](https://ide.bitquery.io/LetsBonkfun-Tokens-between-95-and-100-bonding-curve-progress_2)
-
-### Pump.fun
-
-#### PumpFun Token Creation
-
-This subscription tracks in real-time newly created Pumpfun tokens, including their metadata and associated developer addresses.
-
-▶️ [PumpFun Token Creation](https://ide.bitquery.io/newly-created-PF-token-developer-address-metadata)
-
-#### PumpFun Trades Stream
-
-This stream returns the real time trades on Pumpfun platform. This stream could be modified to get real time trades for a particular token or trades by a particular trader.
-
-▶️ [PumpFun Trades Stream](https://ide.bitquery.io/Pumpfun-DEX-Trades_1)
-
-#### Pumpswap Trades Stream
-
-This stream returns the real time trades on Pumpswap exchange. This stream could be modified to get real time trades for a particular token or trades by a particular trader.
-
-▶️ [Pumpswap Trades Stream](https://ide.bitquery.io/pumpswap-trades)
-
-#### Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply
-
-Stream all PumpFun DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.ProtocolFamily: Pumpfun` to capture every swap across Pumpfun in a single subscription.
-
-▶️ [Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Pumpfun-With-Price-Market-Cap-and-Supply)
-
-#### Latest Trades for a token on Pumpswap
-
-Subscribe to `DEXTradeByTokens` with PumpSwap `ProgramAddress` and the token mint. Each update is a new trade involving that token on PumpSwap—use this to stream per-token activity without polling.
-
-▶️ [Latest Trades for a token on Pumpswap](https://ide.bitquery.io/Latest-Trades-for-a-token-on-Pumpswap)
-
-#### Price of a pump fun token using price index in usd
-
-Live stream of token price updates on Pump.fun.
-
-▶️ [Price of a pump fun token using price index in usd](https://ide.bitquery.io/Price-of-a-pump-fun-token-using-price-index-in-usd)
-
-### Meteora
-
-#### Jup studio token migrations from Meteora DBC to Meteors DEX
-
-We monitor Meteora DBC program address `dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN` for migration instructions including `migrate_meteora_damm` and `migration_damm_v2`.
-
-▶️ [Jup studio token migrations from Meteora DBC to Meteors DEX](https://ide.bitquery.io/jup-studio-token-migrations-from-Meteora-DBC-to-Meteors-DEX_1)
-
-#### Liquidity addition for meteora
-
-In this section, we will discover data streams that provides us with the real time events of liquidity addition and liquidity removal for the Meteora DEX, which has `Meteora` as the Protocol Family.
-
-▶️ [Liquidity addition for meteora](https://ide.bitquery.io/liquidity-addition-for-meteora_1)
-
-#### Liquidity removal for meteora
-
-Liquidity removal for meteora. Uses the `DEXPools` cube.
-
-▶️ [Liquidity removal for meteora](https://ide.bitquery.io/liquidity-removal-for-meteora_1)
-
-#### Meteora DBC token migrations to Meteors DEX
-
-Below query will give you the latest migrated tokens Meteora DBC in realtime.
-
-▶️ [Meteora DBC token migrations to Meteors DEX](https://ide.bitquery.io/meteora-DBC-token-migrations-to-Meteors-DEX)
-
-#### Real time trades on Meteora Dynamic Bonding Curve on Solana
-
-The below query gets real-time information whenever there's a new trade on the Meteora DBC including detailed information about the trade, including the buy and sell details, the block information, and the transaction specifics.
-
-▶️ [Real time trades on Meteora Dynamic Bonding Curve on Solana](https://ide.bitquery.io/Real-time-trades-on-Meteora-Dynamic-Bonding-Curve-on-Solana)
-
-#### Real time trades on MeteoraDAMMv2 DEX on Solana
-
-This query subscribes to real-time trades on the Meteora DAMM v2 (Dynamic Automated Market Maker) on the Solana blockchain by filtering using the program address `cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG`.
-
-▶️ [Real time trades on MeteoraDAMMv2 DEX on Solana](https://ide.bitquery.io/Real-time-trades-on-MeteoraDAMMv2-DEX-on-Solana)
-
-### Orca
-
-#### Latest pool created on Orca - Websocket
-
-For instance, Index 1 and 2 represent the tokens involved in the pool, while Index 4 is for the pool's address. Note that the indexing starts from 0.
-
-▶️ [Latest pool created on Orca - Websocket](https://ide.bitquery.io/Latest-pool-created-on-Orca---Websocket_1)
-
-#### Liquidity addition for orca whirlpool
-
-In this section, we will discover data streams that provides us with the real time events of liquidity addition and liquidity removal for the Orca Whirlpool DEX, which has `whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc` as the Program Address.
-
-▶️ [Liquidity addition for orca whirlpool](https://ide.bitquery.io/liquidity-addition-for-orca-whirlpool_1)
-
-#### Liquidity removal for orca whirlpool
-
-With Orca’s program and negative base change, stream liquidity removals from Whirlpool markets.
-
-▶️ [Liquidity removal for orca whirlpool](https://ide.bitquery.io/liquidity-removal-for-orca-whirlpool_1)
-
-#### Orca DEX Trades Websocket
-
-To access a real-time stream of trades for Solana Orca DEX.
-
-▶️ [Orca DEX Trades Websocket](https://ide.bitquery.io/Orca-DEX-Trades-Websocket)
-
-#### Orca DEX Trades for a specific currency Websocket
-
-By setting the limit to 1, you will receive the most recent trade, which reflects the latest price of the token.
-
-▶️ [Orca DEX Trades for a specific currency Websocket](https://ide.bitquery.io/Orca-DEX-Trades-for-a-specific-currency-Websocket)
-
-#### Price of a token on Orca
-
-You can use the following query to get the latest price of a token, we have used WSOL address here in the below example. We are getting realtime price of WSOL on Orca DEX on Solana in different pools.
-
-▶️ [Price of a token on Orca](https://ide.bitquery.io/Price-of-a-token-on-Orca)
-
-### Jupiter
-
-#### Latest Cancel Expired Order Transactions on Jupiter in realtime
-
-We track Jupiter's Limit Order program address `jupoNjAxXgZ4rjzxzPMP4oxduvQsQtZzyknqvzYNrNu` for `cancelExpiredOrder` instructions. The query returns transaction signatures, account details, and program arguments for expired order cancellations.
-
-▶️ [Latest Cancel Expired Order Transactions on Jupiter in realtime](https://ide.bitquery.io/Latest-Cancel-Expired-Order-Transactions-on-Jupiter-in-realtime_1)
-
-#### Latest Cancel Limit Order Transactions on Jupiter in realtime
-
-We track Jupiter's Limit Order program address `jupoNjAxXgZ4rjzxzPMP4oxduvQsQtZzyknqvzYNrNu` for `cancelOrder` instructions. The query returns input mint addresses, maker addresses, reserve addresses, and cancellation details.
-
-▶️ [Latest Cancel Limit Order Transactions on Jupiter in realtime](https://ide.bitquery.io/Latest-Cancel-Limit-Order-Transactions-on-Jupiter-in-realtime)
-
-#### Tokens involved in Jupiter swap, source address, destination address, DEX involved
-
-We monitor Jupiter's program address `JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4` for `sharedAccountsRoute` instructions to track swap activity. The query returns tokens involved in swaps, source and destination addresses, and routing information.
-
-▶️ [Tokens involved in Jupiter swap, source address, destination address, DEX involved](https://ide.bitquery.io/Tokens-involved-in-Jupiter-swap-source-address-destination-address-DEX-involved_2)
-
 ## BSC
 
 ### Trades
 
-#### Real-time Trades on BSC
-
-This subscription returns the real-time trades happening on BSC Network. You can modify the stream to get real-time trades for a particular token, a particular token pair and even a particular trader.
-
-▶️ [Real-time Trades on BSC](https://ide.bitquery.io/subscribe-to-dex-trades-on-BNB-mainnet)
-
 #### All BNB Trade Stream
 
-Crypto Trades API: one row per swap, with USD and supply. Filter `Pair.Market.Network: Binance Smart Chain`. When to use this vs chain DEX APIs.
+Crypto Trades API: one row per swap, with USD and supply. Filter `Pair.Market.Network: Binance Smart Chain`. When to use this vs chain DEX APIs. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [All BNB Trade Stream](https://ide.bitquery.io/All-BNB-Trade-Stream)
 
-#### Subscribe to bsc dex trades
+#### Real-time Trades on BSC — historical (beyond 30 days)
 
-This example uses the chain-specific DEXTrades cube via `EVM(network: bsc) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD fields can be empty on thin pools. For swap rows with trader + USD, use the stream at the top of this page.
+This subscription returns the real-time trades happening on BSC Network. You can modify the stream to get real-time trades for a particular token, a particular token pair and even a particular trader. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Subscribe to bsc dex trades](https://ide.bitquery.io/subscribe-to-bsc-dex-trades)
+▶️ [Real-time Trades on BSC — historical (beyond 30 days)](https://ide.bitquery.io/subscribe-to-dex-trades-on-BNB-mainnet)
+
+#### Subscribe to bsc dex trades — historical (beyond 30 days)
+
+This example uses the chain-specific DEXTrades cube via `EVM(network: bsc) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD fields can be empty on thin pools. For swap rows with trader + USD, use the stream at the top of this page. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Subscribe to bsc dex trades — historical (beyond 30 days)](https://ide.bitquery.io/subscribe-to-bsc-dex-trades)
 
 ### Transfers
 
@@ -984,17 +1376,17 @@ Monitor balance and gas fee paid for an address using stream bsc. Uses the `Tran
 
 ### Price & OHLC
 
-#### Realtime price of a ETH in terms of WBNB
-
-Provides real-time updates on price of ETH `0x2170Ed0880ac9A755fd29B2688956BD959F933F8` in terms of WBNB `0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c`, including details about the DEX, market, and order specifics.
-
-▶️ [Realtime price of a ETH in terms of WBNB](https://ide.bitquery.io/realtime-price-of-a-ETH-in-terms-of-WBNB)
-
 #### Stream for latest prices for Flap.sh tokens
 
-Subscribe to real-time price updates for all Flap.sh tokens.
+Subscribe to real-time price updates for all Flap.sh tokens. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [Stream for latest prices for Flap.sh tokens](https://ide.bitquery.io/Stream-for-latest-prices-for-Flapsh-tokens)
+
+#### Realtime price of a ETH in terms of WBNB — historical (beyond 30 days)
+
+Provides real-time updates on price of ETH `0x2170Ed0880ac9A755fd29B2688956BD959F933F8` in terms of WBNB `0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c`, including details about the DEX, market, and order specifics. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Realtime price of a ETH in terms of WBNB — historical (beyond 30 days)](https://ide.bitquery.io/realtime-price-of-a-ETH-in-terms-of-WBNB)
 
 ### Supply & Market Cap
 
@@ -1232,29 +1624,29 @@ Liquidity for v4 pools is reconstructed by stepping through each price range whe
 
 ### Trades
 
-#### Base DEX Trades Stream
-
-This stream returns all the real time DEX trades happening on Base. You can modify this stream to get DEX trades on a particular DEX or trades of a particular token or trades by a particular trader.
-
-▶️ [Base DEX Trades Stream](https://ide.bitquery.io/subscribe-to-dex-trades-on-base_1)
-
 #### All Base Trade Stream
 
-Crypto Trades API: one row per swap, with USD and supply. Filter `Pair.Market.Network: Base`. When to use this vs chain DEX APIs.
+Crypto Trades API: one row per swap, with USD and supply. Filter `Pair.Market.Network: Base`. When to use this vs chain DEX APIs. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
 ▶️ [All Base Trade Stream](https://ide.bitquery.io/All-Base-Trade-Stream)
 
-#### Subscribe to dex trades on base
+#### Base DEX Trades Stream — historical (beyond 30 days)
 
-Read DEXTrades vs DEXTradeByTokens vs Trades cube to get a better understanding on when to use which cube.
+This stream returns all the real time DEX trades happening on Base. You can modify this stream to get DEX trades on a particular DEX or trades of a particular token or trades by a particular trader. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Subscribe to dex trades on base](https://ide.bitquery.io/subscribe-to-dex-trades-on-base)
+▶️ [Base DEX Trades Stream — historical (beyond 30 days)](https://ide.bitquery.io/subscribe-to-dex-trades-on-base_1)
 
-#### Subscription for Latest Trades for AERO
+#### Subscribe to dex trades on base — historical (beyond 30 days)
 
-For this part, we have chosen AERO token as the token is currently trending and have high trade volume.
+Read DEXTrades vs DEXTradeByTokens vs Trades cube to get a better understanding on when to use which cube. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Subscription for Latest Trades for AERO](https://ide.bitquery.io/Subscription-for-Latest-Trades-for-AERO_1)
+▶️ [Subscribe to dex trades on base — historical (beyond 30 days)](https://ide.bitquery.io/subscribe-to-dex-trades-on-base)
+
+#### Subscription for Latest Trades for AERO — historical (beyond 30 days)
+
+For this part, we have chosen AERO token as the token is currently trending and have high trade volume. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Subscription for Latest Trades for AERO — historical (beyond 30 days)](https://ide.bitquery.io/Subscription-for-Latest-Trades-for-AERO_1)
 
 ### Transfers
 
@@ -1340,35 +1732,35 @@ Monitor transaction fee rewards received by miners.
 
 ### Price & OHLC
 
-#### Real-time 1 second OHLC
-
-This stream provides real time price and OHLC stream for all tokens on Base based on trades.
-
-▶️ [Real-time 1 second OHLC](https://ide.bitquery.io/1-second-OHLC-k-line-Base)
-
-#### Token Price Stream
-
-This stream returns the real time trade price of a token against the token it is traded with and the price in USD. You could modify the stream to get the price of the token for a particular token pair or against a particular token.
-
-▶️ [Token Price Stream](https://ide.bitquery.io/token-price-stream_2)
-
 #### Aerodrome dex - realtime prices, 1-sec ohlc, trading volumes
 
 Below API gives you instant access to live Aerodrome market data with pre-calculated OHLC, moving averages, and trading volumes updating every second—no complex calculations needed, just plug and play for your trading bots or analytics platform.
 
 ▶️ [Aerodrome dex - realtime prices, 1-sec ohlc, trading volumes](https://ide.bitquery.io/aerodrome-dex---realtime-prices-1-sec-ohlc-trading-volumes)
 
-#### Get latest price of DAI in USD on Base
+#### Real-time 1 second OHLC
 
-Retrieves the USD price of a token on Base chain by setting `SmartContract: {is: "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb"}` . Check the field `PriceInUSD` for the USD value. You can access the query.
+This stream provides real time price and OHLC stream for all tokens on Base based on trades. Trading cube — real-time and roughly the last 30 days. For anything older, use the DEXTradeByTokens entries at the bottom of this section.
 
-▶️ [Get latest price of DAI in USD on Base](https://ide.bitquery.io/Get-latest-price-of-DAI-in-USD-on-Base)
+▶️ [Real-time 1 second OHLC](https://ide.bitquery.io/1-second-OHLC-k-line-Base)
 
-#### Price of USDC in terms of DAI on Base network
+#### Price of USDC in terms of DAI on Base network — historical (beyond 30 days)
 
-Provides real-time updates on price of USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` in terms of DAI `0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb`, including details about the DEX, market, and order specifics.
+Provides real-time updates on price of USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` in terms of DAI `0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb`, including details about the DEX, market, and order specifics. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
-▶️ [Price of USDC in terms of DAI on Base network](https://ide.bitquery.io/Price-of-USDC-in-terms-of-DAI-on-Base-network)
+▶️ [Price of USDC in terms of DAI on Base network — historical (beyond 30 days)](https://ide.bitquery.io/Price-of-USDC-in-terms-of-DAI-on-Base-network)
+
+#### Token Price Stream — historical (beyond 30 days)
+
+This stream returns the real time trade price of a token against the token it is traded with and the price in USD. You could modify the stream to get the price of the token for a particular token pair or against a particular token. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Token Price Stream — historical (beyond 30 days)](https://ide.bitquery.io/token-price-stream_2)
+
+#### Get latest price of DAI in USD on Base — historical (beyond 30 days)
+
+Retrieves the USD price of a token on Base chain by setting `SmartContract: {is: "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb"}` . Check the field `PriceInUSD` for the USD value. You can access the query. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get latest price of DAI in USD on Base — historical (beyond 30 days)](https://ide.bitquery.io/Get-latest-price-of-DAI-in-USD-on-Base)
 
 ### Supply & Market Cap
 
@@ -1536,7 +1928,7 @@ Stream live liquidity for all Uniswap v4 pools on Base.
 
 #### Arbitrum Dextrades subscription
 
-This example uses the chain-specific DEXTrades cube via `EVM(network: arbitrum) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD can be weak on thin pools. For trader + USD swap rows, use the stream at the top.
+This example uses the chain-specific DEXTrades cube via `EVM(network: arbitrum) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD can be weak on thin pools. For trader + USD swap rows, use the stream at the top. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Arbitrum Dextrades subscription](https://ide.bitquery.io/Arbitrum-Dextrades-subscription)
 
@@ -1602,13 +1994,13 @@ The Uniswap v4 PoolManager contract emits all pool-related events, including poo
 
 #### Real time trades for uniswap v4 optimism
 
-The Uniswap v4 PoolManager contract emits all pool-related events, including pool initialization, swaps, and liquidity modifications, and serves as the single on-chain source of truth for Uniswap v4 activity on Optimism.
+The Uniswap v4 PoolManager contract emits all pool-related events, including pool initialization, swaps, and liquidity modifications, and serves as the single on-chain source of truth for Uniswap v4 activity on Optimism. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Real time trades for uniswap v4 optimism](https://ide.bitquery.io/Real-time-trades-for-uniswap-v4-optimism)
 
 #### Realtime optimism dex trades websocket
 
-This example uses the chain-specific DEXTrades cube via `EVM(network: optimism) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD can be weak on thin pools. For trader + USD swap rows, use the stream at the top.
+This example uses the chain-specific DEXTrades cube via `EVM(network: optimism) { DEXTrades }` (pool-side Buy/Sell; see DEXTrades cube). USD can be weak on thin pools. For trader + USD swap rows, use the stream at the top. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Realtime optimism dex trades websocket](https://ide.bitquery.io/Realtime-optimism-dex-trades-websocket)
 
@@ -1628,17 +2020,17 @@ The subscription query below fetches the whale transactions on the Optimism netw
 
 ### Price & OHLC
 
-#### Get latest price of WBTC in USD on optimism
-
-Retrieves the USD price of a token on Optimism by setting `SmartContract: {is: "0x68f180fcCe6836688e9084f035309E29Bf0A2095"}` . Check the field `PriceInUSD` for the USD value. You can access the query.
-
-▶️ [Get latest price of WBTC in USD on optimism](https://ide.bitquery.io/Get-latest-price-of-WBTC-in-USD-on-optimism)
-
 #### Price of WETH in terms of USDC on Optimism
 
-Provides real-time updates on price of WETH `0x4200000000000000000000000000000000000006` in terms of USD Coin `0x7f5c764cbc14f9669b88837ca1490cca17c31607`, including details about the DEX, market, and order specifics.
+Provides real-time updates on price of WETH `0x4200000000000000000000000000000000000006` in terms of USD Coin `0x7f5c764cbc14f9669b88837ca1490cca17c31607`, including details about the DEX, market, and order specifics. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Price of WETH in terms of USDC on Optimism](https://ide.bitquery.io/Price-of-WETH-in-terms-of-USDC-on-Optimism)
+
+#### Get latest price of WBTC in USD on optimism
+
+Retrieves the USD price of a token on Optimism by setting `SmartContract: {is: "0x68f180fcCe6836688e9084f035309E29Bf0A2095"}` . Check the field `PriceInUSD` for the USD value. You can access the query. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Get latest price of WBTC in USD on optimism](https://ide.bitquery.io/Get-latest-price-of-WBTC-in-USD-on-optimism)
 
 ## Polygon
 
@@ -1646,13 +2038,13 @@ Provides real-time updates on price of WETH `0x420000000000000000000000000000000
 
 #### Real time trades for uniswap v4 matic
 
-The Uniswap v4 PoolManager contract emits all pool-related events, including pool initialization, swaps, and liquidity modifications, and serves as the single on-chain source of truth for Uniswap v4 activity on Matic.
+The Uniswap v4 PoolManager contract emits all pool-related events, including pool initialization, swaps, and liquidity modifications, and serves as the single on-chain source of truth for Uniswap v4 activity on Matic. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Real time trades for uniswap v4 matic](https://ide.bitquery.io/Real-time-trades-for-uniswap-v4-matic)
 
 #### Realtime matic dex trades websocket
 
-Read DEXTrades vs DEXTradeByTokens vs Trades cube to understand when to use which cube.
+Read DEXTrades vs DEXTradeByTokens vs Trades cube to understand when to use which cube. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Realtime matic dex trades websocket](https://ide.bitquery.io/Realtime-matic-dex-trades-websocket)
 
@@ -1709,254 +2101,6 @@ This subscription query monitors real-time liquidity changes for a specific DEX 
 This subscription query returns real-time slippage data for all DEX pools on Matic. You can monitor price impact and liquidity depth as trades occur.
 
 ▶️ [Realtime slippage on matic](https://ide.bitquery.io/realtime-slippage-on-matic)
-
-## TRON
-
-### Trades
-
-#### Real-time Trades on Sunpump
-
-This stream returns all the real time DEX trades happening on Sunpump exchange on the Tron network. You can modify this stream to get the trades of a particular token or trades by a particular trader.
-
-▶️ [Real-time Trades on Sunpump](https://ide.bitquery.io/real-time-sunswapTrades)
-
-#### Real-time Trades on Tron
-
-This stream returns all the real time DEX trades happening on the Tron network. You can modify this stream to get DEX trades on a particular DEX or trades of a particular token or trades by a particular trader.
-
-▶️ [Real-time Trades on Tron](https://ide.bitquery.io/Latest-trades-on-Tron)
-
-#### Sunpump trades
-
-To subscribe to latest Sunpump trades you can use.
-
-▶️ [Sunpump trades](https://ide.bitquery.io/Sunpump-trades)
-
-#### USDT TRC20 DEX Trades
-
-Real-time DEX trades where USDT is the bought currency on Tron — protocol, buyer and seller, amounts and order IDs.
-
-▶️ [USDT TRC20 DEX Trades](https://ide.bitquery.io/USDT-TRC20-DEX-Trades)
-
-### Transfers
-
-#### Real-time Tether USDT Transfers
-
-This subscription streams the latest USDT (TRC20) transfers on the TRON network. You can modify the stream to monitor Transfers of USDT from or to a particular address.
-
-▶️ [Real-time Tether USDT Transfers](https://ide.bitquery.io/usdt-trc20-transfers_1)
-
-#### Sender is particular address
-
-Sender is particular address. Uses the `Transfers` cube.
-
-▶️ [Sender is particular address](https://ide.bitquery.io/Sender-is-particular-address)
-
-#### Whale transfers of USDT on Tron
-
-The subscription query below fetches the whale transactions on the Tron network. We have used USDT address `TThzxNRLrW2Brp9DcTQU8i4Wd9udCWEdZ3`.
-
-▶️ [Whale transfers of USDT on Tron](https://ide.bitquery.io/Whale-transfers-of-USDT-on-Tron)
-
-### Price & OHLC
-
-#### Track price of a tron token in realtime
-
-Provides real-time updates on price of token `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` in terms of USDT `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`, including details about the DEX.
-
-▶️ [Track price of a tron token in realtime](https://ide.bitquery.io/Track-price-of-a-tron-token-in-realtime)
-
-### Supply & Market Cap
-
-#### Get All DEX Trades on Tron With Price, Market Cap, and Supply
-
-Crypto Trades API: one row per swap, with USD and supply. Filter `Pair.Market.Network: Tron`. When to use this vs chain DEX APIs.
-
-▶️ [Get All DEX Trades on Tron With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Tron-With-Price-Market-Cap-and-Supply)
-
-### Transactions
-
-#### Monitor TRX address transactions
-
-The subscription query below fetches the transactions on the Tron network for the wallet address `TDqSquXBgUCLYvYC4XZgrprLK589dkhSCf`.
-
-▶️ [Monitor TRX address transactions](https://ide.bitquery.io/monitor-TRX-address-transactions)
-
-### Events & Calls
-
-#### Latest Buy on SunPump
-
-You can use following stream to get latest buys on Sunpump. You can try.
-
-▶️ [Latest Buy on SunPump](https://ide.bitquery.io/latest-Buy-on-SunPump)
-
-#### New tokens on sunpump
-
-Will subscribe to the latest created sun pump tokens. You will find the newly created token address in `Log { SmartContract }`.
-
-▶️ [New tokens on sunpump](https://ide.bitquery.io/New-tokens-on-sunpump_1)
-
-#### Sunpump sell event
-
-You can use following stream to get latest sells on Sunpump. You can try.
-
-▶️ [Sunpump sell event](https://ide.bitquery.io/sunpump-sell-event)
-
-#### Tron sunpump first time buy event
-
-You can use follow stream to get stream of first time buy event for any new token.
-
-▶️ [Tron sunpump first time buy event](https://ide.bitquery.io/Tron-sunpump-first-time-buy-event_1)
-
-### Mempool
-
-#### Events with argumens
-
-Events with argumens. Uses the `Events` cube. Replace the address in the `where` clause to use it.
-
-▶️ [Events with argumens](https://ide.bitquery.io/Events-with-argumens)
-
-#### Sunpump trades mempool
-
-We simulate transactions in mempool, therefore you can also get trades directly from mempool using.
-
-▶️ [Sunpump trades mempool](https://ide.bitquery.io/Sunpump-trades-mempool)
-
-#### Tron mempool transfers
-
-Provides real-time data on token transfers happening in the TRON mempool including the value of the transferred amount in USD.
-
-▶️ [Tron mempool transfers](https://ide.bitquery.io/Tron-mempool-transfers)
-
-## Robinhood Chain
-
-### Trades
-
-#### Latest DEX Trades on Robinhood Chain
-
-Latest DEX trades on Robinhood Chain (chain id 4663) via the Trading API, with price and USD amounts.
-
-▶️ [Latest DEX Trades on Robinhood Chain](https://ide.bitquery.io/Robinhood-Trades)
-
-#### Bags amm trade websocket
-
-Stream every Bags trade as it is indexed via a GraphQL `subscription` on `Trading.Trades`, scoped to the Bags protocol family on Robinhood. Includes side (buy/sell), trader, base/quote amounts (native and USD), market cap, and full transaction header.
-
-▶️ [Bags amm trade websocket](https://ide.bitquery.io/bags-amm-trade-websocket)
-
-#### Pools trade Stream new Crowd Launch auctions
-
-Every Crowd Launch deploys its auction through the auction factory `0x000000001f26a0044baa66024e7b6599c61963f8`, which emits `AuctionCreated(address,address,uint256,bytes)`.
-
-▶️ [Pools trade Stream new Crowd Launch auctions](https://ide.bitquery.io/Pools-trade-Stream-new-Crowd-Launch-auctions)
-
-#### Robinhood Chain API - Trades for a Token
-
-Using this GraphQL stream you can get real-time trades for a specific token (example: AssetHood, `ASSETH`) with details such as trader address, token details, marketcap, FDV and transaction hash.
-
-▶️ [Robinhood Chain API - Trades for a Token](https://ide.bitquery.io/Robinhood-Trades-for-a-token)
-
-#### Stream Robinhood Chain Trades in Real Time
-
-These are live examples — meme tokens go quiet over time, so swap in any token, pool, or trader you care about.
-
-▶️ [Stream Robinhood Chain Trades in Real Time](https://ide.bitquery.io/stream-robinhood-chain-trades)
-
-### Transfers
-
-#### Ape.store Newly created tokens - Websocket
-
-Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
-
-▶️ [Ape.store Newly created tokens - Websocket](https://ide.bitquery.io/Apestore-Newly-created-tokens---Websocket)
-
-#### Bags.fm Newly created tokens - Websocket
-
-Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
-
-▶️ [Bags.fm Newly created tokens - Websocket](https://ide.bitquery.io/Bagsfm-Newly-created-tokens---Websocket)
-
-#### Bankr Bot Newly created tokens - Websocket
-
-Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
-
-▶️ [Bankr Bot Newly created tokens - Websocket](https://ide.bitquery.io/Bankr-Bot-Newly-created-tokens---Websocket)
-
-#### Flap Sh Newly created tokens using transfer data - Websocket
-
-Track Flap.sh mints as transfers from the zero address with amount `1000000000` in transactions sent to the Flap.sh contract.
-
-▶️ [Flap Sh Newly created tokens using transfer data - Websocket](https://ide.bitquery.io/Flap-Sh-Newly-created-tokens-using-transfer-data---Websocket)
-
-#### Hoodfun newly creaed tokens Websocket
-
-Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
-
-▶️ [Hoodfun newly creaed tokens Websocket](https://ide.bitquery.io/hoodfun-newly-creaed-tokens---Websocket)
-
-#### Klik Finance Newly created tokens using transfers websocket
-
-Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
-
-▶️ [Klik Finance Newly created tokens using transfers websocket](https://ide.bitquery.io/Klik-Finance-Newly-created-tokens-using-transfers-websocket)
-
-#### Launchpad newly creaed tokens Websocket
-
-Every transfer query on this page is identical except two values: the launchpad address in `Transaction.To` and the launch-mint `Amount`.
-
-▶️ [Launchpad newly creaed tokens Websocket](https://ide.bitquery.io/launchpad-newly-creaed-tokens---Websocket)
-
-#### Pools trade Stream launches with token detail
-
-The transfer-based stream returns the token's name, symbol, decimals, and contract in the same payload — everything a sniping bot or listings feed needs, with no follow-up metadata call. It also carries the transaction's gas economics and success flag.
-
-▶️ [Pools trade Stream launches with token detail](https://ide.bitquery.io/Pools-trade-Stream-launches-with-token-detail)
-
-#### Real time transfers on robinhood
-
-Stream live transfers for dashboards, bots, and alerting.
-
-▶️ [Real time transfers on robinhood](https://ide.bitquery.io/real-time-transfers-on-robinhood)
-
-### Price & OHLC
-
-#### Robinhood Chain OHLCV / Candlestick API for a Token Pair
-
-This GraphQL stream for 1 second OHLCV streams the USD normalised OHLC/K-line data for a token pair, and also contains info such as interval start and end time, marketcap, volume and token details for both base and quote tokens.
-
-▶️ [Robinhood Chain OHLCV / Candlestick API for a Token Pair](https://ide.bitquery.io/OHLCV-stream-for-a-token-pair-on-robinhood)
-
-### Liquidity & Pools
-
-#### Stream New pools.trade Token Launches
-
-Websocket subscription streaming every new pools.trade token launch on Robinhood Chain the moment it happens.
-
-▶️ [Stream New pools.trade Token Launches](https://ide.bitquery.io/Pools-trade-Stream-new-launches)
-
-### Events & Calls
-
-#### Flap sh Newly created tokens using logs (TokenCreated) - Websocket
-
-Filter Flap.sh `TokenCreated` events and decode argument values (token address, metadata fields, and related parameters).
-
-▶️ [Flap sh Newly created tokens using logs (TokenCreated) - Websocket](https://ide.bitquery.io/Flap-sh-Newly-created-tokens-using-logs-TokenCreated---Websocket)
-
-#### Stream New Tokens on Robinhood Chain (All Launchpads)
-
-Follow the steps here: How to generate Bitquery API token ➤.
-
-▶️ [Stream New Tokens on Robinhood Chain (All Launchpads)](https://ide.bitquery.io/stream-new-tokens-robinhood-chain)
-
-## Bitcoin
-
-### Price & OHLC
-
-#### Latest Bitcoin Price
-
-You can stream Bitcoin price at 1-second interval using the [Crypto Price APIs](/docs/trading/crypto-price-api/introduction/).
-
-▶️ [Latest Bitcoin Price](https://ide.bitquery.io/Stream-Bitcoin-Price-Across-Chains)
 
 ## Trading API
 
@@ -2024,6 +2168,12 @@ There are two ways to track multiple tokens. You can specify token IDs using the
 
 ### Price & OHLC
 
+#### Token price stream from top market (rank 1)
+
+Streams the price of one token from its top market, one-second intervals, quoted in USD. Prices the token from its single top market rather than blending every pool, which is what you want for one specific token.
+
+▶️ [Token price stream from top market (rank 1)](https://ide.bitquery.io/Token-price-stream-from-top-market--rank-1)
+
 #### FourMeme 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders
 
 Track token activity (OHLC, price, volume) every 1 second on FourMeme DEX (BSC).
@@ -2042,18 +2192,6 @@ Raydium Launchlab 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders. Use
 
 ▶️ [Raydium Launchlab 1-second Price, OHLC, Volume, SMA, EMA Stream for Traders](https://ide.bitquery.io/Raydium-Launchpad-DEX-tokens-1-second-price-stream-with-OHLC)
 
-#### 5 minute price change api on solana
-
-5 minute price change api on solana. Uses the `Tokens` cube.
-
-▶️ [5 minute price change api on solana](https://ide.bitquery.io/5-minute-price-change-api-on-solana_6)
-
-#### Bitcoin currency price stream
-
-Get real-time Bitcoin OHLC data across all chains.
-
-▶️ [Bitcoin currency price stream](https://ide.bitquery.io/bitcoin-currency-price-stream)
-
 #### Heaven DEX tokens 1 second price stream with OHLC
 
 Real-time (1s) stream of prices, OHLC, and volumes for tokens traded on Heaven DEX (Solana).
@@ -2071,6 +2209,18 @@ Meteora DBC DEX tokens 1 second price stream with OHLC. Uses the `Pairs` cube.
 Real Time USD price on solana chain. Uses the `Pairs` cube.
 
 ▶️ [Real Time USD price on solana chain](https://ide.bitquery.io/Real-Time-USD-price-on-solana-chain_2)
+
+#### 5 minute price change api on solana
+
+5 minute price change api on solana. Uses the `Tokens` cube.
+
+▶️ [5 minute price change api on solana](https://ide.bitquery.io/5-minute-price-change-api-on-solana_6)
+
+#### Bitcoin currency price stream
+
+Get real-time Bitcoin OHLC data across all chains.
+
+▶️ [Bitcoin currency price stream](https://ide.bitquery.io/bitcoin-currency-price-stream)
 
 ### Supply & Market Cap
 
@@ -2093,20 +2243,6 @@ Subscribe to `Solana.DEXPools` with Raydium’s program and positive base change
 Use the same Raydium program filter with negative `ChangeAmount` on the base side to stream liquidity withdrawals.
 
 ▶️ [Liquidity removal for radium](https://ide.bitquery.io/liquidity-removal-for-radium_1)
-
-### PancakeSwap
-
-#### Real-time Trades on Pancakeswap
-
-This subscription returns the real-time trades happening on Pancakeswap. You can modify the stream to get real time trades for a particular token, a particular token pair, and even a particular trader.
-
-▶️ [Real-time Trades on Pancakeswap](https://ide.bitquery.io/Latest-BSC-PancakeSwap-v3-dextrades---Stream)
-
-#### PancakeSwap v3 DEX tokens 1 second price stream with OHLC
-
-PancakeSwap v3 DEX tokens 1 second price stream with OHLC. Uses the `Pairs` cube. Replace the address in the `where` clause to use it.
-
-▶️ [PancakeSwap v3 DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/PancakeSwap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
 
 ### Uniswap
 
@@ -2148,45 +2284,59 @@ Pump fun token live prices using trades api. Uses the `Trades` cube.
 
 ▶️ [Pump fun token live prices using trades api](https://ide.bitquery.io/pump-fun-token-live-prices-using-trades-api_1)
 
+### PancakeSwap
+
+#### Real-time Trades on Pancakeswap
+
+This subscription returns the real-time trades happening on Pancakeswap. You can modify the stream to get real time trades for a particular token, a particular token pair, and even a particular trader.
+
+▶️ [Real-time Trades on Pancakeswap](https://ide.bitquery.io/Latest-BSC-PancakeSwap-v3-dextrades---Stream)
+
+#### PancakeSwap v3 DEX tokens 1 second price stream with OHLC
+
+PancakeSwap v3 DEX tokens 1 second price stream with OHLC. Uses the `Pairs` cube. Replace the address in the `where` clause to use it.
+
+▶️ [PancakeSwap v3 DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/PancakeSwap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
+
 ## Stablecoins
 
 ### Trades
 
 #### Solana trades subscription
 
-Solana trades subscription. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Solana trades subscription. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Solana trades subscription](https://ide.bitquery.io/solana-trades-subscription_10_1)
 
-#### Stablecoin Depeg tracking Stream for evm
-
-Stablecoin Depeg tracking Stream for evm. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
-
-▶️ [Stablecoin Depeg tracking Stream for evm](https://ide.bitquery.io/Stablecoin-Depeg-tracking-Stream-for-evm)
-
-#### Stablecoin Depeg tracking Stream for tron
-
-Stablecoin Depeg tracking Stream for tron. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
-
-▶️ [Stablecoin Depeg tracking Stream for tron](https://ide.bitquery.io/Stablecoin-Depeg-tracking-Stream-for-tron)
-
-#### Stablecoin depeg tracking stream for USDC
-
-Below stream will be able to track specific Stablecoin depeg. In this query example, we are tracking depeg for the stablecoin `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` which has a symbol `USDC`.
-
-▶️ [Stablecoin depeg tracking stream for USDC](https://ide.bitquery.io/stablecoin-depeg-tracking-stream-for-USDC)
-
 #### Stablecoin trades for etheruem
 
-Stablecoin trades for etheruem. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Stablecoin trades for etheruem. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Stablecoin trades for etheruem](https://ide.bitquery.io/Stablecoin-trades-for-etheruem)
 
 #### Stablecoin trades for tron
 
-Stablecoin trades for tron. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+Stablecoin trades for tron. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Stablecoin trades for tron](https://ide.bitquery.io/Stablecoin-trades-for-tron)
+
+#### Stablecoin Depeg tracking Stream for evm
+
+Stablecoin Depeg tracking Stream for evm. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Stablecoin Depeg tracking Stream for evm](https://ide.bitquery.io/Stablecoin-Depeg-tracking-Stream-for-evm)
+
+#### Stablecoin Depeg tracking Stream for tron
+
+Stablecoin Depeg tracking Stream for tron. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Stablecoin Depeg tracking Stream for tron](https://ide.bitquery.io/Stablecoin-Depeg-tracking-Stream-for-tron)
+
+#### Stablecoin depeg tracking stream for USDC
+
+Below stream will be able to track specific Stablecoin depeg. In this query example, we are tracking depeg for the stablecoin `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` which has a symbol `USDC`. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
+
+▶️ [Stablecoin depeg tracking stream for USDC](https://ide.bitquery.io/stablecoin-depeg-tracking-stream-for-USDC)
 
 ### Transfers
 
@@ -2300,55 +2450,19 @@ Listen to stablecoin payments across all major blockchains. The Mempool option l
 
 ▶️ [Latest USDT/USDC Transfer stream on ethereum in Mempool](https://ide.bitquery.io/Latest-USDTUSDC-Transfer-stream-on-ethereum-in-Mempool)
 
-## Perpetuals
-
-### Trades
-
-#### Hyperliquid Real-time Trades Stream (WebSocket)
-
-Hyperliquid Real-time Trades Stream (WebSocket).
-
-▶️ [Hyperliquid Real-time Trades Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-trades-stream)
-
-#### Solana Perps Live Trades Stream (Phoenix Fills)
-
-Stream every stop-loss and take-profit placement as it happens.
-
-▶️ [Solana Perps Live Trades Stream (Phoenix Fills)](https://ide.bitquery.io/solana-perps-live-trades-stream)
-
-### Price & OHLC
-
-#### Hyperliquid Price Updates Stream (WebSocket)
-
-Hyperliquid Price Updates Stream (WebSocket).
-
-▶️ [Hyperliquid Price Updates Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-price-updates-stream)
-
-#### Hyperliquid Real-time Candles Stream (WebSocket)
-
-Hyperliquid Real-time Candles Stream (WebSocket).
-
-▶️ [Hyperliquid Real-time Candles Stream (WebSocket)](https://ide.bitquery.io/hyperliquid-candles-stream)
-
-#### Solana Perpetuals Mark Price Stream (Phoenix)
-
-Solana Perpetuals Mark Price Stream (Phoenix).
-
-▶️ [Solana Perpetuals Mark Price Stream (Phoenix)](https://ide.bitquery.io/solana-perpetuals-mark-price-stream)
-
 ## NFTs
 
 ### Trades
 
 #### NFT Trades on Opensea
 
-This stream allows you to monitor real time NFT trades on OpenSea. It could also be modified to get trades of a particular NFT collection or NFTs traded by a particular trader.
+This stream allows you to monitor real time NFT trades on OpenSea. It could also be modified to get trades of a particular NFT collection or NFTs traded by a particular trader. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [NFT Trades on Opensea](https://ide.bitquery.io/Latests-OpenSea-Trades--stream)
 
 #### Latest Solana NFT Trades
 
-The subscription query provided below fetches the most recent NFT trades on the Solana blockchain.
+The subscription query provided below fetches the most recent NFT trades on the Solana blockchain. Built from raw DEX trades, so it reaches back further than the Trading cube's ~30 days. For live prices prefer the Trading cube entries at the top of this section.
 
 ▶️ [Latest Solana NFT Trades](https://ide.bitquery.io/Latest-Solana-NFT-Trades)
 
@@ -2422,92 +2536,6 @@ Monitor NFT transfers for a specific collection across all transactions. This he
 
 ▶️ [Track Specific NFT Balance Changes](https://ide.bitquery.io/Track-specific-NFTs-Balance-Changes)
 
-## Polymarket
-
-### Trades
-
-#### Real-Time Trades Stream
-
-Real-Time Trades Stream.
-
-▶️ [Real-Time Trades Stream](https://ide.bitquery.io/prediction-market-trades-subscription)
-
-#### Trades for a Specific Market (Stream)
-
-Subscribe to trades for one market only by filtering on Question.MarketId. Replace the market ID in the query with your target market.
-
-▶️ [Trades for a Specific Market (Stream)](https://ide.bitquery.io/subscribe-to-specific-market-trades)
-
-#### Bitcoin Up or Down Trades Stream
-
-Subscribe to live Polymarket trades for markets whose question title includes "Bitcoin Up or Down".
-
-▶️ [Bitcoin Up or Down Trades Stream](https://ide.bitquery.io/Bitcoin-Up-or-Down-Trades-Stream)
-
-#### How do I track high-value or whale trades on Polymarket?
-
-Use a GraphQL subscription on `PredictionTrades` filtered by `CollateralAmountInUSD: { gt: "10000" }` and `ProtocolName: "polymarket"` to monitor trades exceeding $10,000 USD in real time. Ideal for detecting whale activity and large market movements.
-
-▶️ [How do I track high-value or whale trades on Polymarket?](https://ide.bitquery.io/How-do-I-track-high-value-or-whale-trades-on-Polymarket)
-
-#### Large trades on polymarket
-
-Start by streaming large Polymarket trades. Each event gives you a buyer address to investigate. Change `subscription` to `query` for historical results.
-
-▶️ [Large trades on polymarket](https://ide.bitquery.io/large-trades--on-polymarket)
-
-#### Monitoring specific wallets trades in realtime for Ethereum up or down market
-
-The same wallet-monitoring pattern works for every Polymarket Up or Down market — only the `Question.Title` filter changes. Open any of the pre-built IDE queries below to stream trades for the chain you care about.
-
-▶️ [Monitoring specific wallets trades in realtime for Ethereum up or down market](https://ide.bitquery.io/monitoring-specific-wallets-trades-in-realtime-for-Ethereum-up-or-down-market)
-
-#### Monitoring specific wallets trades in realtime for XRP up or down market
-
-The same wallet-monitoring pattern works for every Polymarket Up or Down market — only the `Question.Title` filter changes. Open any of the pre-built IDE queries below to stream trades for the chain you care about.
-
-▶️ [Monitoring specific wallets trades in realtime for XRP up or down market](https://ide.bitquery.io/monitoring-specific-wallets-trades-in-realtime-for-XRP-up-or-down-market)
-
-#### Polymarket AI whale trades stream
-
-Streams live AI-market trades above a USD threshold (here `$5,000`). This is ideal for whale-alert bots and detecting large, conviction bets. Filter with a `Question.Title` keyword, or swap it for a single-market `MarketId`.
-
-▶️ [Polymarket AI whale trades stream](https://ide.bitquery.io/Polymarket-AI-whale-trades-stream)
-
-#### Polymarket whale trades alert
-
-Stream successful Polymarket trades whose collateral exceeds $10,000 USD. Adjust the threshold string as needed.
-
-▶️ [Polymarket whale trades alert](https://ide.bitquery.io/polymarket-whale-trades-alert_1)
-
-### Markets
-
-#### Real-Time Management Stream (Creations + Resolutions)
-
-Real-Time Management Stream (Creations + Resolutions).
-
-▶️ [Real-Time Management Stream (Creations + Resolutions)](https://ide.bitquery.io/Prediction-Managements-subscription-resolutions-creations)
-
-#### Real-Time Market Creations
-
-Subscribe only to new market (Created) events.
-
-▶️ [Real-Time Market Creations](https://ide.bitquery.io/track-realtime-new-polymarket-creations)
-
-#### Real-Time Market Resolutions
-
-Subscribe only to Resolved events. Winning outcome is in Prediction.Outcome; token details (e.g. AssetId) in Prediction.OutcomeToken.
-
-▶️ [Real-Time Market Resolutions](https://ide.bitquery.io/track-realtime-polymarket-resolutions)
-
-### Settlements
-
-#### Real-Time Settlement Stream
-
-Real-Time Settlement Stream.
-
-▶️ [Real-Time Settlement Stream](https://ide.bitquery.io/realtime-predicion-market-settlements-stream)
-
 ## x402
 
 ### Transfers
@@ -2523,19 +2551,3 @@ Real-Time Payment Monitoring for x402 Server. Uses the `Transfers` cube.
 Real-Time Payment Monitoring for x402 Server on Solana. Uses the `Transfers` cube. Replace the address in the `where` clause to use it.
 
 ▶️ [Real-Time Payment Monitoring for x402 Server on Solana](https://ide.bitquery.io/Real-Time---Solana-transfers-stream)
-
-## Cross-Chain
-
-### Price & OHLC
-
-#### Crypto Price Stream
-
-This subscription gives you 1-second OHLC, mean price, averages for all tokens across Solana, Ethereum, BNB, Tron.
-
-▶️ [Crypto Price Stream](https://ide.bitquery.io/1-second-crypto-price-stream-with-mcap)
-
-#### Stablecoin 1 sec Price Stream
-
-This subscription gives you 1-second OHLC, mean price, averages for all stablecoins including USDC, USDT, DAI, USDS etc.
-
-▶️ [Stablecoin 1 sec Price Stream](https://ide.bitquery.io/stablecoin-1-second-price-stream)

--- a/sidebars.js
+++ b/sidebars.js
@@ -17,6 +17,7 @@ const sidebars = {
       items: [
         "start/learning-path",
         "start/first-query",
+        "start/bitquery-for-ai",
         "start/starter-queries",
         "start/starter-subscriptions",
         "tools-directory",

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -6,6 +6,7 @@
 
 ## Start here
 
+- [**Bitquery in one page**](https://docs.bitquery.io/docs/start/bitquery-for-ai/) — the whole API as one self-contained page: endpoints, chains, cubes, datasets, rules and worked queries. Written to be pasted into an AI assistant's context. Raw markdown: https://docs.bitquery.io/docs/start/bitquery-for-ai/index.md
 - [Docs home](https://docs.bitquery.io/) — platform overview and navigation
 - [GraphQL IDE](https://ide.bitquery.io/) — run queries in the browser, no setup
 - [First query in 5 minutes](https://docs.bitquery.io/docs/start/first-query/)


### PR DESCRIPTION
Follow-on to #250. **The Trading-cube commit missed that merge by minutes** — #250 merged at 06:29:55Z and `6ff5aa87` was pushed after, so it is on the old branch but not in `main`. It is cherry-picked here as the first commit.

## 1. Lead with the Trading cube (cherry-picked, was not in #250)

The docs already say `Trading.Pairs` / `Tokens` / `Currencies` are the primary source for real time and the last ~30 days, with `DEXTrades` and `DEXTradeByTokens` for history beyond that. The panel did the opposite:

- **225 of 367** trade and price entries led with a DEX cube.
- On Ethereum, Base, Arbitrum, BSC and TRON, a DEX-cube query was the **first** thing under Price & OHLC.
- **0 of 31** shipped `Pairs` queries used `Ranking: {Position: {eq: 1}}` — none of the pattern the docs recommend for pricing one token, since the `Tokens` price is volume-blended across every pool.

Now: Trading entries sort first, 92 DEX entries are relabelled `— historical (beyond 30 days)`, 195 tooltips say which side they are on, and rank-1 price queries lead Price & OHLC on Ethereum, Base, BSC, Arbitrum, Optimism and Solana.

Two traps found while authoring those, now written into the query comments:

- **`Trading` token addresses are stored lowercase and the filter is case-sensitive.** A checksummed EVM address returns zero rows and *no error*. WETH, WBNB and Arbitrum WETH all silently returned nothing until lowercased.
- Choosing the example token by "top volume" surfaced obscure tokens and, on Solana, a **homoglyph spoof of SOL** (`SoJh2C73…`, Cyrillic О). The examples use canonical addresses.

**Balances**: 16 chains lacked a current or historical balance query. Authored and verified 11 — gap down to 7.

**Ordering**: groups now lead with Bitcoin, Solana, Robinhood, Polymarket, Perpetuals, TRON, Cross-Chain, Ethereum, BSC. Perpetuals is split by venue.

## 2. New page — Bitquery in One Page

`docs/start/bitquery-for-ai.md`. We publish `llms.txt` (an index of links) and `llms-full.txt` (5 MB, the whole corpus). Neither lets you hand an AI one thing and get correct queries out. This page is self-contained: no links to follow, every query written out.

Endpoints and auth for V2 HTTP / V2 WebSocket / V1 · exactly which chains are on V2 versus V1-only · the cube list per root from schema introspection · datasets and retention · nine worked queries · an error table.

Section 6 is the important part for a model — the mistakes that produce a plausible wrong answer instead of an error: lowercase address filters, balances being cumulative, bare `EVM` meaning Ethereum, unbounded V1 queries hitting `Code: 241`, `realtime` silently truncating rather than erroring, and `Pairs` + rank 1 over `Tokens`.

**All nine example queries were executed against the live API before publishing.**

Third in the Start sidebar, first link in `llms.txt`. The artefact to paste into a model is the raw twin at `/docs/start/bitquery-for-ai/index.md`.

## Verification

| gate | result |
|---|---|
| play-link slug + tooltip on every entry | pass |
| slug resolves, not deleted, not unpublished | pass |
| zero `BalanceUpdates` | pass |
| entry on the chain its group claims | pass |
| stored endpoint matches query dialect | pass |
| no duplicate titles in a group + tab | pass |
| every entry executed live | pass |
| no unexplained drops vs the original 298 | pass |
| trading-policy audit (1,046 entries) | 0 problems |
| Docusaurus production build | success |

All 65 queries authored across this work were re-executed **read back out of the database**, not from the pre-insert test: 59 run, 6 retired (Bitcoin SV, index stopped 2026-02-02), 0 failing.

## Known gaps

- 7 chains still lack a current or historical balance query; five templates need schema fixes (Ripple `balances` argument, Algorand selections, Cardano 500) or a representative address (Robinhood, Avalanche).
- Solana's historical balance query exists but is filed under Transfers, so the audit reads Solana as missing one.
- 98 of 137 DEX-cube price entries belong to other people's accounts, so the "use the Trading cube for recent data" note is in their tooltips rather than their query text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)