### PR TITLE
docs: add Stellar, Filecoin, Cronos and Klaytn, plus historical balance for five chains

### DIFF
--- a/docs/start/starter-queries.md
+++ b/docs/start/starter-queries.md
@@ -3465,6 +3465,12 @@ Recent token transfers on Avalanche. Add a `currency` filter to follow one token
 
 ### Balances & Holders
 
+#### Balance of an address at a past date
+
+What one Avalanche address held as of a chosen date. Move the date in the Variables pane.
+
+▶️ [Balance of an address at a past date](https://ide.bitquery.io/Avalanche-Balance-of-an-address-at-a-past-date)
+
 #### Balances of an address
 
 Native and token balances held by one Avalanche address. Replace the address to use it.
@@ -3555,6 +3561,12 @@ Recent token transfers on Cronos. Add a `currency` filter to follow one token, o
 
 ### Balances & Holders
 
+#### Balance of an address at a past date
+
+What one Cronos address held as of a chosen date. Move the date in the Variables pane.
+
+▶️ [Balance of an address at a past date](https://ide.bitquery.io/Cronos-Balance-of-an-address-at-a-past-date)
+
 #### Balances of an address
 
 Native and token balances held by one Cronos address. Replace the address to use it.
@@ -3610,6 +3622,12 @@ Recent token transfers on Klaytn. Add a `currency` filter to follow one token, o
 ▶️ [Latest token transfers](https://ide.bitquery.io/Klaytn-Latest-token-transfers)
 
 ### Balances & Holders
+
+#### Balance of an address at a past date
+
+What one Klaytn address held as of a chosen date. Move the date in the Variables pane.
+
+▶️ [Balance of an address at a past date](https://ide.bitquery.io/Klaytn-Balance-of-an-address-at-a-past-date)
 
 #### Balances of an address
 
@@ -3987,6 +4005,12 @@ Stellar payment operations — who paid whom, in which asset, and how much.
 
 ### Balances & Holders
 
+#### Balance of an address at a past date
+
+What one Stellar address held as of a chosen date. Move the date in the Variables pane.
+
+▶️ [Balance of an address at a past date](https://ide.bitquery.io/Stellar-Balance-of-an-address-at-a-past-date)
+
 #### Balances of an address
 
 Every asset balance held by one Stellar account. Replace the address to use it.
@@ -4072,6 +4096,12 @@ FIL value moving between addresses. Add a sender or receiver filter to follow on
 ▶️ [Latest transfers](https://ide.bitquery.io/Filecoin-Latest-transfers)
 
 ### Balances & Holders
+
+#### Balance of an address at a past date
+
+What one Filecoin address held as of a chosen date. Move the date in the Variables pane.
+
+▶️ [Balance of an address at a past date](https://ide.bitquery.io/Filecoin-Balance-of-an-address-at-a-past-date)
 
 #### Balance of an address
 

--- a/docs/start/starter-queries.md
+++ b/docs/start/starter-queries.md
@@ -31,6 +31,8 @@ Every query below is saved in the [Bitquery IDE](https://ide.bitquery.io) and wa
 - [Polygon](#polygon)
 - [Avalanche](#avalanche)
 - [Celo](#celo)
+- [Cronos](#cronos)
+- [Klaytn](#klaytn)
 - [Litecoin](#litecoin)
 - [Bitcoin Cash](#bitcoin-cash)
 - [Dogecoin](#dogecoin)
@@ -38,7 +40,9 @@ Every query below is saved in the [Bitquery IDE](https://ide.bitquery.io) and wa
 - [Zcash](#zcash)
 - [Cardano](#cardano)
 - [Ripple](#ripple)
+- [Stellar](#stellar)
 - [Algorand](#algorand)
+- [Filecoin](#filecoin)
 - [Trading API](#trading-api)
 - [Stablecoins](#stablecoins)
 - [NFTs](#nfts)
@@ -3539,6 +3543,104 @@ The most recent blocks on Celo, with height, time, gas used and transaction coun
 
 ▶️ [Latest blocks](https://ide.bitquery.io/Celo-Latest-blocks)
 
+## Cronos
+
+### Transfers
+
+#### Latest token transfers
+
+Recent token transfers on Cronos. Add a `currency` filter to follow one token, or a sender/receiver filter to follow one wallet.
+
+▶️ [Latest token transfers](https://ide.bitquery.io/Cronos-Latest-token-transfers)
+
+### Balances & Holders
+
+#### Balances of an address
+
+Native and token balances held by one Cronos address. Replace the address to use it.
+
+▶️ [Balances of an address](https://ide.bitquery.io/Cronos-Balances-of-an-address)
+
+### Transactions
+
+#### Latest transactions
+
+Recent Cronos transactions with value, gas and sender/receiver. Move `since` in the Variables pane to change the window — a wide window on a busy chain will exceed the query memory limit.
+
+▶️ [Latest transactions](https://ide.bitquery.io/Cronos-Latest-transactions)
+
+### Events & Calls
+
+#### Latest smart contract events
+
+Decoded event logs on Cronos. Filter by `smartContractAddress` to watch a single contract.
+
+▶️ [Latest smart contract events](https://ide.bitquery.io/Cronos-Latest-smart-contract-events)
+
+### Blocks & Validators
+
+#### Latest blocks
+
+The most recent Cronos blocks, with gas used and transaction count. Move `since` in the Variables pane.
+
+▶️ [Latest blocks](https://ide.bitquery.io/Cronos-Latest-blocks)
+
+## Klaytn
+
+### Trades
+
+#### Latest DEX trades
+
+The most recent DEX trades on Klaytn, with both sides of the pair, the venue and USD value. Add a `baseCurrency` filter to scope it to one token.
+
+▶️ [Latest DEX trades](https://ide.bitquery.io/Klaytn-Latest-DEX-trades)
+
+#### Top DEXs by trade count
+
+Ranks the DEXs on Klaytn by number of trades, so you can see which venues actually carry volume.
+
+▶️ [Top DEXs by trade count](https://ide.bitquery.io/Klaytn-Top-DEXs-by-trade-count)
+
+### Transfers
+
+#### Latest token transfers
+
+Recent token transfers on Klaytn. Add a `currency` filter to follow one token, or a sender/receiver filter to follow one wallet.
+
+▶️ [Latest token transfers](https://ide.bitquery.io/Klaytn-Latest-token-transfers)
+
+### Balances & Holders
+
+#### Balances of an address
+
+Native and token balances held by one Klaytn address. Replace the address to use it.
+
+▶️ [Balances of an address](https://ide.bitquery.io/Klaytn-Balances-of-an-address)
+
+### Transactions
+
+#### Latest transactions
+
+Recent Klaytn transactions with value, gas and sender/receiver. Move `since` in the Variables pane to change the window — a wide window on a busy chain will exceed the query memory limit.
+
+▶️ [Latest transactions](https://ide.bitquery.io/Klaytn-Latest-transactions)
+
+### Events & Calls
+
+#### Latest smart contract events
+
+Decoded event logs on Klaytn. Filter by `smartContractAddress` to watch a single contract.
+
+▶️ [Latest smart contract events](https://ide.bitquery.io/Klaytn-Latest-smart-contract-events)
+
+### Blocks & Validators
+
+#### Latest blocks
+
+The most recent blocks on Klaytn, with height, time, gas used and transaction count.
+
+▶️ [Latest blocks](https://ide.bitquery.io/Klaytn-Latest-blocks)
+
 ## Litecoin
 
 ### Transfers
@@ -3865,6 +3967,56 @@ This query uses transaction hash and date range as filter to fetch tx details.
 
 ▶️ [Transaction Details using Hash](https://ide.bitquery.io/xrpl-search-tx-details)
 
+## Stellar
+
+### Trades
+
+#### Latest DEX trades
+
+Trades on the Stellar decentralised exchange, with both sides of the pair and the amounts.
+
+▶️ [Latest DEX trades](https://ide.bitquery.io/Stellar-Latest-DEX-trades)
+
+### Transfers
+
+#### Latest payments
+
+Stellar payment operations — who paid whom, in which asset, and how much.
+
+▶️ [Latest payments](https://ide.bitquery.io/Stellar-Latest-payments)
+
+### Balances & Holders
+
+#### Balances of an address
+
+Every asset balance held by one Stellar account. Replace the address to use it.
+
+▶️ [Balances of an address](https://ide.bitquery.io/Stellar-Balances-of-an-address)
+
+### Liquidity & Pools
+
+#### Liquidity pool trades
+
+Swaps routed through Stellar liquidity pools, with the pool id and both legs.
+
+▶️ [Liquidity pool trades](https://ide.bitquery.io/Stellar-Liquidity-pool-trades)
+
+### Transactions
+
+#### Latest transactions
+
+Recent Stellar transactions with sender, fee and success flag. Move `since` in the Variables pane to change the window.
+
+▶️ [Latest transactions](https://ide.bitquery.io/Stellar-Latest-transactions)
+
+### Blocks & Validators
+
+#### Latest ledgers
+
+The most recent Stellar ledgers with close time, transaction count and fee pool.
+
+▶️ [Latest ledgers](https://ide.bitquery.io/Stellar-Latest-ledgers)
+
 ## Algorand
 
 ### Transfers
@@ -3908,6 +4060,40 @@ Returns the number of transactions per day over the last 10 days, ordered by dat
 Counts distinct transaction senders on a specific date.
 
 ▶️ [Daily Unique Txn Senders on algorand](https://ide.bitquery.io/Daily-Unique-Txn-Senders-on-algorand)
+
+## Filecoin
+
+### Transfers
+
+#### Latest transfers
+
+FIL value moving between addresses. Add a sender or receiver filter to follow one account.
+
+▶️ [Latest transfers](https://ide.bitquery.io/Filecoin-Latest-transfers)
+
+### Balances & Holders
+
+#### Balance of an address
+
+The FIL balance held by one Filecoin address. Replace the address to use it.
+
+▶️ [Balance of an address](https://ide.bitquery.io/Filecoin-Balance-of-an-address)
+
+### Transactions
+
+#### Latest messages
+
+Filecoin messages — the chain's transactions — with sender, receiver, value and method.
+
+▶️ [Latest messages](https://ide.bitquery.io/Filecoin-Latest-messages)
+
+### Blocks & Validators
+
+#### Latest tipsets
+
+The most recent Filecoin tipsets with height and time.
+
+▶️ [Latest tipsets](https://ide.bitquery.io/Filecoin-Latest-tipsets)
 
 ## Trading API
 

--- a/docs/start/starter-subscriptions.md
+++ b/docs/start/starter-subscriptions.md
@@ -2258,26 +2258,6 @@ PancakeSwap v3 DEX tokens 1 second price stream with OHLC. Uses the `Pairs` cube
 
 ▶️ [PancakeSwap v3 DEX tokens 1 second price stream with OHLC](https://ide.bitquery.io/PancakeSwap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
 
-### Uniswap
-
-#### 1-second price, OHLC, volume, SMA and EMA — Uniswap v3
-
-One-second candles with moving averages for Uniswap v3 tokens, built for trading front-ends.
-
-▶️ [1-second price, OHLC, volume, SMA and EMA — Uniswap v3](https://ide.bitquery.io/Uniswap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
-
-#### Stream all Uniswap Seconds OHLC Kline
-
-Subscribe to `Trading.Pairs` filtered by Uniswap protocols and 1s interval to power sub-minute charts and HFT analytics.
-
-▶️ [Stream all Uniswap Seconds OHLC Kline](https://ide.bitquery.io/Stream-all-Uniswap-Seconds-OHLC-Kline)
-
-#### Uniswap all versions trades stream
-
-Filter `DEXTrades` with `ProtocolName` in `uniswap_v3`, `uniswap_v2`, `uniswap_v1` to stream only Uniswap family pools on mainnet.
-
-▶️ [Uniswap all versions trades stream](https://ide.bitquery.io/uniswap-all-versions-trades-stream)
-
 ### Pump.fun
 
 #### All Pumpswap Trade Stream
@@ -2297,6 +2277,26 @@ All pumpfun Trade Stream. Uses the `Trades` cube.
 Pump fun token live prices using trades api. Uses the `Trades` cube.
 
 ▶️ [Pump fun token live prices using trades api](https://ide.bitquery.io/pump-fun-token-live-prices-using-trades-api_1)
+
+### Uniswap
+
+#### 1-second price, OHLC, volume, SMA and EMA — Uniswap v3
+
+One-second candles with moving averages for Uniswap v3 tokens, built for trading front-ends.
+
+▶️ [1-second price, OHLC, volume, SMA and EMA — Uniswap v3](https://ide.bitquery.io/Uniswap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
+
+#### Stream all Uniswap Seconds OHLC Kline
+
+Subscribe to `Trading.Pairs` filtered by Uniswap protocols and 1s interval to power sub-minute charts and HFT analytics.
+
+▶️ [Stream all Uniswap Seconds OHLC Kline](https://ide.bitquery.io/Stream-all-Uniswap-Seconds-OHLC-Kline)
+
+#### Uniswap all versions trades stream
+
+Filter `DEXTrades` with `ProtocolName` in `uniswap_v3`, `uniswap_v2`, `uniswap_v1` to stream only Uniswap family pools on mainnet.
+
+▶️ [Uniswap all versions trades stream](https://ide.bitquery.io/uniswap-all-versions-trades-stream)
 
 ## Stablecoins
 

--- a/docs/start/starter-subscriptions.md
+++ b/docs/start/starter-subscriptions.md
@@ -326,44 +326,6 @@ We will use this subscription to listen to `consumeEvents` transactions on OpenB
 
 ▶️ [ConsumeEvents instruction on OpenBook V2](https://ide.bitquery.io/consumeEvents-instruction-on-OpenBook-V2_3)
 
-### Pump.fun
-
-#### PumpFun Token Creation
-
-This subscription tracks in real-time newly created Pumpfun tokens, including their metadata and associated developer addresses.
-
-▶️ [PumpFun Token Creation](https://ide.bitquery.io/newly-created-PF-token-developer-address-metadata)
-
-#### PumpFun Trades Stream
-
-This stream returns the real time trades on Pumpfun platform. This stream could be modified to get real time trades for a particular token or trades by a particular trader.
-
-▶️ [PumpFun Trades Stream](https://ide.bitquery.io/Pumpfun-DEX-Trades_1)
-
-#### Pumpswap Trades Stream
-
-This stream returns the real time trades on Pumpswap exchange. This stream could be modified to get real time trades for a particular token or trades by a particular trader.
-
-▶️ [Pumpswap Trades Stream](https://ide.bitquery.io/pumpswap-trades)
-
-#### Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply
-
-Stream all PumpFun DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.ProtocolFamily: Pumpfun` to capture every swap across Pumpfun in a single subscription.
-
-▶️ [Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Pumpfun-With-Price-Market-Cap-and-Supply)
-
-#### Latest Trades for a token on Pumpswap
-
-Subscribe to `DEXTradeByTokens` with PumpSwap `ProgramAddress` and the token mint. Each update is a new trade involving that token on PumpSwap—use this to stream per-token activity without polling.
-
-▶️ [Latest Trades for a token on Pumpswap](https://ide.bitquery.io/Latest-Trades-for-a-token-on-Pumpswap)
-
-#### Price of a pump fun token using price index in usd
-
-Live stream of token price updates on Pump.fun.
-
-▶️ [Price of a pump fun token using price index in usd](https://ide.bitquery.io/Price-of-a-pump-fun-token-using-price-index-in-usd)
-
 ### Raydium
 
 #### Latest Pools Created on Raydium
@@ -407,6 +369,44 @@ This stream gives info about the real time liquidity pool creation on Raydium ex
 Returns Raydium Launchpad tokens which have more than 95% bonding curve progress.
 
 ▶️ [Track Raydium Launchpad tokens above 95% Bonding Curve Progress in realtime](https://ide.bitquery.io/LetsBonkfun-Tokens-between-95-and-100-bonding-curve-progress_2)
+
+### Pump.fun
+
+#### PumpFun Token Creation
+
+This subscription tracks in real-time newly created Pumpfun tokens, including their metadata and associated developer addresses.
+
+▶️ [PumpFun Token Creation](https://ide.bitquery.io/newly-created-PF-token-developer-address-metadata)
+
+#### PumpFun Trades Stream
+
+This stream returns the real time trades on Pumpfun platform. This stream could be modified to get real time trades for a particular token or trades by a particular trader.
+
+▶️ [PumpFun Trades Stream](https://ide.bitquery.io/Pumpfun-DEX-Trades_1)
+
+#### Pumpswap Trades Stream
+
+This stream returns the real time trades on Pumpswap exchange. This stream could be modified to get real time trades for a particular token or trades by a particular trader.
+
+▶️ [Pumpswap Trades Stream](https://ide.bitquery.io/pumpswap-trades)
+
+#### Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply
+
+Stream all PumpFun DEX trades in real time with USD price, market cap, FDV, circulating supply, and transaction fee data. Filter by `Pair.Market.ProtocolFamily: Pumpfun` to capture every swap across Pumpfun in a single subscription.
+
+▶️ [Get All DEX Trades on Pumpfun With Price, Market Cap, and Supply](https://ide.bitquery.io/Get-All-DEX-Trades-on-Pumpfun-With-Price-Market-Cap-and-Supply)
+
+#### Latest Trades for a token on Pumpswap
+
+Subscribe to `DEXTradeByTokens` with PumpSwap `ProgramAddress` and the token mint. Each update is a new trade involving that token on PumpSwap—use this to stream per-token activity without polling.
+
+▶️ [Latest Trades for a token on Pumpswap](https://ide.bitquery.io/Latest-Trades-for-a-token-on-Pumpswap)
+
+#### Price of a pump fun token using price index in usd
+
+Live stream of token price updates on Pump.fun.
+
+▶️ [Price of a pump fun token using price index in usd](https://ide.bitquery.io/Price-of-a-pump-fun-token-using-price-index-in-usd)
 
 ### Meteora
 
@@ -2244,26 +2244,6 @@ Use the same Raydium program filter with negative `ChangeAmount` on the base sid
 
 ▶️ [Liquidity removal for radium](https://ide.bitquery.io/liquidity-removal-for-radium_1)
 
-### Pump.fun
-
-#### All Pumpswap Trade Stream
-
-All Pumpswap Trade Stream. Uses the `Trades` cube.
-
-▶️ [All Pumpswap Trade Stream](https://ide.bitquery.io/All-Pumpswap-Trade-Stream)
-
-#### All pumpfun Trade Stream
-
-All pumpfun Trade Stream. Uses the `Trades` cube.
-
-▶️ [All pumpfun Trade Stream](https://ide.bitquery.io/All-pumpfun-Trade-Stream_2)
-
-#### Pump fun token live prices using trades api
-
-Pump fun token live prices using trades api. Uses the `Trades` cube.
-
-▶️ [Pump fun token live prices using trades api](https://ide.bitquery.io/pump-fun-token-live-prices-using-trades-api_1)
-
 ### PancakeSwap
 
 #### Real-time Trades on Pancakeswap
@@ -2297,6 +2277,26 @@ Subscribe to `Trading.Pairs` filtered by Uniswap protocols and 1s interval to po
 Filter `DEXTrades` with `ProtocolName` in `uniswap_v3`, `uniswap_v2`, `uniswap_v1` to stream only Uniswap family pools on mainnet.
 
 ▶️ [Uniswap all versions trades stream](https://ide.bitquery.io/uniswap-all-versions-trades-stream)
+
+### Pump.fun
+
+#### All Pumpswap Trade Stream
+
+All Pumpswap Trade Stream. Uses the `Trades` cube.
+
+▶️ [All Pumpswap Trade Stream](https://ide.bitquery.io/All-Pumpswap-Trade-Stream)
+
+#### All pumpfun Trade Stream
+
+All pumpfun Trade Stream. Uses the `Trades` cube.
+
+▶️ [All pumpfun Trade Stream](https://ide.bitquery.io/All-pumpfun-Trade-Stream_2)
+
+#### Pump fun token live prices using trades api
+
+Pump fun token live prices using trades api. Uses the `Trades` cube.
+
+▶️ [Pump fun token live prices using trades api](https://ide.bitquery.io/pump-fun-token-live-prices-using-trades-api_1)
 
 ## Stablecoins
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -11,7 +11,30 @@
 - [GraphQL IDE](https://ide.bitquery.io/) — run queries in the browser, no setup
 - [First query in 5 minutes](https://docs.bitquery.io/docs/start/first-query/)
 - [API keys & authentication](https://docs.bitquery.io/docs/authorization/how-to-generate/)
+- [Starter queries](https://docs.bitquery.io/docs/start/starter-queries/) — tested queries by chain and data type, the same tree the IDE shows
+- [Starter subscriptions](https://docs.bitquery.io/docs/start/starter-subscriptions/) — the real-time half of the same tree
 - [MCP Server for AI agents](https://docs.bitquery.io/docs/mcp/mcp-server/)
+
+## Endpoints, chains and datasets
+
+Two generations of the API, with different schemas. Sending a query to the wrong one is the
+most common mistake.
+
+- **V2** — `https://streaming.bitquery.io/graphql`, and `wss://` for subscriptions. Covers
+  Ethereum, BSC, Base, Arbitrum, Optimism, Polygon, Robinhood Chain, Solana, Tron and
+  Hyperliquid. Roots are capitalised: `EVM`, `Solana`, `Tron`, `Trading`.
+- **V1** — `https://graphql.bitquery.io`. Everything else: Bitcoin, Litecoin, Bitcoin Cash,
+  Dogecoin, Dash, Zcash, Cardano, Ripple, Stellar, Algorand, Filecoin, Avalanche, Celo,
+  Cronos, Klaytn, Fantom, Moonbeam. Roots are lowercase: `bitcoin(network:)`,
+  `ethereum(network:)`, `stellar(network:)`, `filecoin(network:)`.
+- Ethereum, BSC, Tron and Polygon are **migrating off V1** — query them on V2.
+- Every V2 root takes `dataset:` — `realtime` (default, recent window only), `archive` (full
+  history), `combined` (both). Archive and combined need the historical data add-on.
+
+- [Dataset options](https://docs.bitquery.io/docs/graphql/dataset/options/) — realtime vs archive vs combined
+- [Archive dataset](https://docs.bitquery.io/docs/graphql/dataset/archive/) — how to query history
+- [Data coverage & retention](https://docs.bitquery.io/docs/graphql/data-coverage-retention/) — how far back each cube goes, per chain
+- [Endpoints](https://docs.bitquery.io/docs/start/endpoints/) — regional hosts for V1 and V2
 
 ## Trading data — prices, trades & OHLCV
 


### PR DESCRIPTION
Follow-on to #251. **These two commits were pushed after #251 merged**, so they were left behind on the old branch. Cherry-picked here onto the updated `main`. Same thing happened between #250 and #251 — worth a squash-and-hold before the next merge.

## Four new chains — 22 queries

All V1-only, all authored from scratch, since none had a docs page carrying IDE links.

| Chain | Queries |
| --- | --- |
| Stellar | 6 — ledgers, transactions, payments, DEX trades, account balances, liquidity pool trades |
| Klaytn | 7 — the V1 EVM set including DEX trades and top DEXs |
| Cronos | 5 — no DEX set, see below |
| Filecoin | 4 — tipsets, messages, transfers, address balance |

Every query was executed before being saved. Reaching 22/22 took four rounds, and each failure was a shape that looks right and isn't:

- **Stellar's `block` is a scalar ledger number, not an object.** `block { height }` fails, and sorting must use `desc: "block"`.
- **Filecoin messages use `amount` and `method { name }`**, not `value` / `method`.
- **Cronos has no `dexTrades` table** (ClickHouse Code 60), so it ships without the DEX queries exactly as Celo does.
- **Query memory limits differ per chain and per cube.** Cronos `blocks` needs a date bound, and Stellar `transactions` and `payments` need a window about a day wide where a week is fine elsewhere. Every bound is a `$since` variable so it can be moved.

## Historical balance for five chains

Balance is asked of every chain in both directions, so a chain with only the current side is half-covered. Adds the historical side for **Cronos, Klaytn, Avalanche, Stellar and Filecoin**, computed as everything received minus everything sent up to a date.

Balance gaps are now **6 chains, down from 16** when this work started.

The example address for each is discovered from a real recent transfer on that chain rather than guessed, so the saved query returns rows.

## llms.txt

New **Endpoints, chains and datasets** section: which chains are on V2 versus V1, that root capitalisation marks the version (`EVM(` is V2, `ethereum(` is V1), that Ethereum, BSC, Tron and Polygon are migrating to V2, and what `realtime` / `archive` / `combined` mean — plus links to the dataset and retention pages. The starter query and subscription trees are now listed under "Start here".

## Verification

**690 query entries across 32 groups, 383 stream entries across 17.** All eleven gates pass and the production build is clean.

All 87 queries authored across this work were re-executed **read back out of the database**: 79 run, 6 retired, 2 reported failing.

Both reported failures were checked rather than believed, and **both are transient**: Avalanche smart-contract-events passes on retry, Klaytn latest-blocks passes with a longer timeout. These V1 chains are slow enough under load that a single-shot audit invents failures, so the round-trip audit now retries before reporting.

Two more V1 rules learned here and now encoded in the audits:

- **Sorting by a field requires selecting it.** `desc: "block.height"` without `block { height }` returns "Can't use block.height in sorting" — this silently broke an address finder on all five chains.
- The chain-scope gate had no rule for Filecoin, so it was passing **vacuously**. Fixed and verified to discriminate.

## Known gaps

- 6 chains still lack one side of balance: Solana, Robinhood, BSC and Cardano have no historical, Ripple no current, Algorand neither. Solana's historical balance query exists but is filed under Transfers.
- 432 entries would benefit from a dataset comment pointing at `archive` / `combined`; only 109 are on our account, so the rest currently carry the guidance in tooltips instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)