### PR TITLE
docs: expand Pump.fun and the Solana launchpads, add sniper detection

### DIFF
--- a/docs/start/starter-queries.md
+++ b/docs/start/starter-queries.md
@@ -493,6 +493,12 @@ If you need to filter out the instructions from Solana logs that involve a parti
 
 ### Pump.fun
 
+#### First buyers of a token (sniper detection)
+
+The earliest buyers of a token, in time order - snipers are the first rows, buying within seconds of launch at the lowest price. Replace `token` in the Variables pane.
+
+▶️ [First buyers of a token (sniper detection)](https://ide.bitquery.io/Solana---First-buyers-of-a-Pumpfun-token-sniper-detection)
+
 #### Top 10 pump fun tokens by Marketcap change in last 5mins
 
 This query returns the top 10 pump fun tokens by Marketcap change in last 5mins. You can increase the limit to get more tokens.
@@ -528,6 +534,54 @@ To get all tokens traded on Pump.fun in the last 1 hour, use a query that filter
 To find tokens on Pump.fun that have reached a specific market capitalization threshold, you can use the following Bitquery GraphQL example.
 
 ▶️ [How do I get tokens that reached a specific market cap on Pump.fun?](https://ide.bitquery.io/How-do-I-get-tokens-that-reached-a-specific-market-cap-on-Pumpfun)
+
+#### Latest creator fee transfers on pumpfun amm
+
+Latest creator fee transfers on pumpfun amm. Uses the `InstructionBalanceUpdates` cube. Replace the address in the `where` clause to use it.
+
+▶️ [Latest creator fee transfers on pumpfun amm](https://ide.bitquery.io/latest-creator-fee-transfers-on-pumpfun-amm)
+
+#### Pumpfun transfers type v1 to pumpfun migrations
+
+Retrieve Pump.fun token migrations on a specific date. The API returns transfers to the PumpSwap migration receiver address for the given date.
+
+▶️ [Pumpfun transfers type v1 to pumpfun migrations](https://ide.bitquery.io/pumpfun-transfers-type-v1-to-pumpfun-migrations_1)
+
+#### Pumpswap latest Trades API
+
+Use `DEXTrades` with `Solana(network: solana, dataset: realtime)` and filter `Trade.Dex.ProgramAddress` to the PumpSwap AMM. This returns the most recent successful swaps on PumpSwap (snapshot query, not a live stream).
+
+▶️ [Pumpswap latest Trades API](https://ide.bitquery.io/Pumpswap-latest-Trades-API)
+
+#### Top 10 pump fun tokens by Price change in last 5min
+
+Use the below query to get top 10 Pump.fun tokens by price change in the last 5 minutes.
+
+▶️ [Top 10 pump fun tokens by Price change in last 5min](https://ide.bitquery.io/Top-10-pump-fun-tokens-by-Price-change-in-last-5min_1)
+
+#### Top 100 graduating pump fun tokens in last 5 minutes
+
+We can use below query to get top 100 About to Graduate Pump Fun Tokens. You can run and test the saved query.
+
+▶️ [Top 100 graduating pump fun tokens in last 5 minutes](https://ide.bitquery.io/Top-100-graduating-pump-fun-tokens-in-last-5-minutes_2)
+
+#### Top traders on pumpswap
+
+Aggregate `DEXTradeByTokens` by `Transaction.Signer` with `limitBy` and `orderBy` on trade count or volume (USD). Filter `Dex.ProgramAddress` to PumpSwap and optionally WSOL as the side currency to rank active wallets on the AMM.
+
+▶️ [Top traders on pumpswap](https://ide.bitquery.io/top-traders-on-pumpswap_2)
+
+#### All Pump fun tokens created by an address
+
+All Pump fun tokens created by an address. Uses the `TokenSupplyUpdates` cube. Replace the address in the `where` clause to use it.
+
+▶️ [All Pump fun tokens created by an address](https://ide.bitquery.io/all-Pump-fun-tokens-created-by-an-address_3)
+
+#### First transfers of a pump fun token
+
+Retrieves the first transfer of a token to each address, providing the timestamp when each address first received the token.
+
+▶️ [First transfers of a pump fun token](https://ide.bitquery.io/first-transfers-of-a-pump-fun-token_1)
 
 ### Meteora
 
@@ -567,6 +621,30 @@ If you want to get OHLC data for any specific currency pair on Meteora DYN, you 
 
 ▶️ [Meteora DYN OHLC API](https://ide.bitquery.io/Meteora-DYN-OHLC-API)
 
+#### Volatility of WSOL USDC Pair on AldrinAmm Dex on Solana
+
+Volatility is an important factor in trading world as it determines the fluctuation in price that implies the possibility of profit and risk of loss. Lesser volatility denotes that the pair is stable.
+
+▶️ [Volatility of WSOL USDC Pair on AldrinAmm Dex on Solana](https://ide.bitquery.io/Volatility-of-WSOL-USDC-Pair-on-AldrinAmm-Dex-on-Solana_1)
+
+#### Volatility of WSOL USDC Pair on Lifinity Dex on Solana
+
+Volatility is an important factor in trading world as it determines the fluctuation in price that implies the possibility of profit and risk of loss. Lesser volatility denotes that the pair is stable.
+
+▶️ [Volatility of WSOL USDC Pair on Lifinity Dex on Solana](https://ide.bitquery.io/Volatility-of-WSOL-USDC-Pair-on-Lifinity-Dex-on-Solana)
+
+#### Volatility of a Pair on Meteora Dynamic
+
+Volatility is an important factor in trading world as it determines the fluctuation in price that implies the possibility of profit and risk of loss. Lesser volatility denotes that the pair is stable.
+
+▶️ [Volatility of a Pair on Meteora Dynamic](https://ide.bitquery.io/Volatility-of-a-Pair-on-Meteora-Dynamic)
+
+#### Get the Top Traders of a specific Token on Meteora DBC
+
+The below query gets the Top Traders of the specified Token `4kJkgxzuk1gcjsgRSVhdeSiC15ibQLRDKTuqtf2i16Dm` on Meteora DBC.
+
+▶️ [Get the Top Traders of a specific Token on Meteora DBC](https://ide.bitquery.io/Get-the-Top-Traders-of-a-specific-Token-on-Meteora-DBC)
+
 ### Raydium
 
 #### Top 100 About to Graduate Raydium Launchpad Tokens
@@ -605,6 +683,42 @@ DecreaseLiquidityV2 latest raydium clmm. Uses the `Instructions` cube. Replace t
 
 ▶️ [DecreaseLiquidityV2 latest raydium clmm](https://ide.bitquery.io/decreaseLiquidityV2-latest-raydium-clmm_1)
 
+#### IncreaseLiquidityV2 latest raydium clmm
+
+IncreaseLiquidityV2 latest raydium clmm. Uses the `Instructions` cube. Replace the address in the `where` clause to use it.
+
+▶️ [IncreaseLiquidityV2 latest raydium clmm](https://ide.bitquery.io/increaseLiquidityV2-latest-raydium-clmm)
+
+#### Live price of token on raydium - updated
+
+You can use the following query to get the latest price of a token on Raydium DEX on Solana.
+
+▶️ [Live price of token on raydium - updated](https://ide.bitquery.io/live-price-of-token-on-raydium---updated)
+
+#### Raydium CLMM Pool Creation
+
+The mint addresses for the tokens being used in the pool are listed for example `tokenMint1` could be any newly deployed token and `tokenMint0` can be WSOL , indicating which tokens the CLMM pool will support.
+
+▶️ [Raydium CLMM Pool Creation](https://ide.bitquery.io/Raydium-CLMM-Pool-Creation)
+
+#### Raydium OHLC for specific pair
+
+If you want to get OHLC data for any specific currency pair on Raydium DEX, you can use.
+
+▶️ [Raydium OHLC for specific pair](https://ide.bitquery.io/Raydium-OHLC-for-specific-pair_5)
+
+#### Top Bought Solana Tokens
+
+Will give most bought Solana Tokens on Raydium.
+
+▶️ [Top Bought Solana Tokens](https://ide.bitquery.io/Top-Bought-Solana-Tokens)
+
+#### Top sold Solana Tokens
+
+Will give most sold Solana Tokens on Raydium.
+
+▶️ [Top sold Solana Tokens](https://ide.bitquery.io/Top-sold-Solana-Tokens)
+
 ### LetsBonk.fun
 
 #### Latest Price of a LetsBonk.fun Token on Launchpad
@@ -642,6 +756,12 @@ Pool address for letsbonk.fun token. Uses the `DEXTradeByTokens` cube. Change th
 Top buyers of a letsbonk.fun token on launchpad. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Top buyers of a letsbonk.fun token on launchpad](https://ide.bitquery.io/top-buyers-of-a-letsbonkfun-token-on-launchpad)
+
+#### Top sellers of a letsbonk.fun token on launchpad
+
+Top sellers of a letsbonk.fun token on launchpad. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top sellers of a letsbonk.fun token on launchpad](https://ide.bitquery.io/top-sellers-of-a-letsbonkfun-token-on-launchpad_1)
 
 ## Robinhood Chain
 
@@ -2013,6 +2133,30 @@ This API endpoint provides latest liquidity event for every Uniswap V4 pool for 
 
 ▶️ [Latest liquidity for a currency pair across all v4 pools](https://ide.bitquery.io/latest-liquidity-for-a-currency-pair-across-all-v4-pools_1)
 
+#### Latest liquidity for an individual pool on uniswap v4
+
+Returns the most recent liquidity event for a single Uniswap v4 pool. Replace `$poolId` with your target `PoolId` (from trades UI, subgraph, or a prior `DEXTradeByTokens` / `DEXPoolEvents` discovery query).
+
+▶️ [Latest liquidity for an individual pool on uniswap v4](https://ide.bitquery.io/latest-liquidity-for-an-individual-pool-on-uniswap-v4)
+
+#### Latest slippage of a pool on Uniswap v3 Ethereum
+
+Retrieves the latest slippage data for a specific DEX pool on Ethereum. Use it to calculate slippage and check Uniswap V3 price impact slippage for a particular token pair before trading.
+
+▶️ [Latest slippage of a pool on Uniswap v3 Ethereum](https://ide.bitquery.io/Latest-slippage-of-a-pool-on-Uniswap-v3-Ethereum)
+
+#### Latest trade price of uniswap pair
+
+Here's an example of tracking Uniswap token pair trading price.
+
+▶️ [Latest trade price of uniswap pair](https://ide.bitquery.io/latest-trade-price-of-uniswap-pair)
+
+#### Latest trades for a Pool Id on uniswap v4
+
+Latest trades for a Pool Id on uniswap v4. Uses the `DEXTrades` cube.
+
+▶️ [Latest trades for a Pool Id on uniswap v4](https://ide.bitquery.io/Latest-trades-for-a-Pool-Id-on-uniswap-v4)
+
 ### PancakeSwap
 
 #### Latest Trades on PancakeSwap V3 ETH
@@ -2441,6 +2585,18 @@ Below query will get you Latest Price of a token on PancakeSwap Infinity.
 
 ▶️ [Get Latest Price of a token on PancakeSwap Infinity](https://ide.bitquery.io/Get-Latest-Price-of-a-token-on-PancakeSwap-Infinity_1)
 
+#### Get metadata for bsc pancakeswap infnity token
+
+Use the below query to get Token's metadata like `Name`, `symbol`, `SmartContract Address`, `Decimals`.
+
+▶️ [Get metadata for bsc pancakeswap infnity token](https://ide.bitquery.io/get-metadata-for-bsc-pancakeswap-infnity-token)
+
+#### Get metadata pancakeswap
+
+Use the below query to get Token's metadata like `Name`, `symbol`, `SmartContract Address`, `Decimals`.
+
+▶️ [Get metadata pancakeswap](https://ide.bitquery.io/get-metadata-pancakeswap)
+
 ### Four Meme
 
 #### Get Dev and Age of Four Meme Token
@@ -2479,6 +2635,30 @@ Below query will only show response if a the mentioned meme rush tokens have mig
 
 ▶️ [If meme rush token migrated from four meme or not](https://ide.bitquery.io/if-meme-rush-token-migrated-from-four-meme-or-not)
 
+#### If token migrated from four meme or not
+
+Below query will only show response if a the mentioned four meme tokens have migrated to Pancakeswap. Note: Please use a `Block{Date}` filter to minimize the data processing and hence the query processing time and get fast responses.
+
+▶️ [If token migrated from four meme or not](https://ide.bitquery.io/if-token-migrated-from-four-meme-or-not_4)
+
+#### Top buyers of a four meme token
+
+Top buyers of a four meme token. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Top buyers of a four meme token](https://ide.bitquery.io/Top-buyers-of-a-four-meme-token)
+
+#### Top buyers of a meme rush token
+
+Top buyers of a meme rush token. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it. Needs the historical data add-on — see the comment at the top of the query.
+
+▶️ [Top buyers of a meme rush token](https://ide.bitquery.io/Top-buyers-of-a-meme-rush-token)
+
+#### Top tokens by launch marketcap on fourmeme
+
+Below API can be used to get top four meme tokens by launch marketcap (marketcap at the time of launching). You can get all the data through us and create a min and max marketcap filter in your application.
+
+▶️ [Top tokens by launch marketcap on fourmeme](https://ide.bitquery.io/top-tokens-by-launch-marketcap-on-fourmeme_1)
+
 ### Uniswap
 
 #### Trading Pairs on a BSC DEX
@@ -2516,6 +2696,30 @@ Will fetch the top bought tokens on uniswap v3.
 Top buyers of a currency on uniswap v4 bsc. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Top buyers of a currency on uniswap v4 bsc](https://ide.bitquery.io/top-buyers-of-a-currency-on-uniswap-v4-bsc)
+
+#### Top sellers of a token on uniswap v4 pool bsc
+
+Top sellers of a token on uniswap v4 pool bsc. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top sellers of a token on uniswap v4 pool bsc](https://ide.bitquery.io/top-sellers-of-a-token-on-uniswap-v4-pool-bsc)
+
+#### Top sold tokens on bsc uniswap v3
+
+Will fetch the top bought tokens on uniswap v3.
+
+▶️ [Top sold tokens on bsc uniswap v3](https://ide.bitquery.io/top-sold-tokens-on-bsc-uniswap-v3)
+
+#### Top traders of a token on uniswapv3 bsc
+
+Will fetch top traders of a token for the selected network.
+
+▶️ [Top traders of a token on uniswapv3 bsc](https://ide.bitquery.io/top-traders-of-a-token-on-uniswapv3-bsc)
+
+#### Trade stats for a token pair on uniswap v4 bsc
+
+Trade stats for a token pair on uniswap v4 bsc. Uses the `DEXTradeByTokens` cube.
+
+▶️ [Trade stats for a token pair on uniswap v4 bsc](https://ide.bitquery.io/trade-stats-for-a-token-pair-on-uniswap-v4-bsc_1)
 
 ## Base
 
@@ -2789,12 +2993,6 @@ This query separates results by whether cbBTC is listed as the first token (`Cur
 
 ▶️ [Top liquidity pools of cbBTC](https://ide.bitquery.io/top-liquidity-pools-of-cbBTC)
 
-#### Latest liquidity of a base pool
-
-This API gives you latest liquidity of a Base Pool. Try it out.
-
-▶️ [Latest liquidity of a base pool](https://ide.bitquery.io/latest-liquidity-of-a-base-pool)
-
 ### Transactions
 
 #### Get transactions by wallet
@@ -2941,6 +3139,30 @@ Will fetch the top bought tokens on uniswap v3.
 
 ▶️ [Top sold tokens on uniswap v3](https://ide.bitquery.io/top-sold-tokens-on-uniswap-v3)
 
+#### Top traders of a token on uniswapv3
+
+Will fetch top traders of a token for the selected network.
+
+▶️ [Top traders of a token on uniswapv3](https://ide.bitquery.io/top-traders-of-a-token-on-uniswapv3_4)
+
+#### Trade volume base uniswapv3
+
+Fetches the traded volume, buy volume and sell volume of a token `0x22af33fe49fd1fa80c7149773dde5890d3c76f3b`.
+
+▶️ [Trade volume base uniswapv3](https://ide.bitquery.io/trade_volume_base_uniswapv3)
+
+#### Uniswap v3 trades
+
+Below query will subscribe you to the latest DEX Trades on Uniswap v3.
+
+▶️ [Uniswap v3 trades](https://ide.bitquery.io/uniswap-v3-trades_2)
+
+#### Virtual pool addresses for a token on uniswap v4 base
+
+Virtual pool addresses for a token on uniswap v4 base. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Virtual pool addresses for a token on uniswap v4 base](https://ide.bitquery.io/virtual-pool-addresses-for-a-token-on-uniswap-v4-base)
+
 ### PancakeSwap
 
 #### Get Latest Price of a token on PancakeSwap Infinity
@@ -2978,6 +3200,18 @@ Use the below query to get Token's metadata like `Name`, `symbol`, `SmartContrac
 Retrieves the Open, High, Low, and Close (OHLC) prices in USD for a specific token traded on PancakeSwap Infinity over a defined time period and interval.
 
 ▶️ [OHLC on BASE pancakeswap infinity](https://ide.bitquery.io/OHLC-on-BASE-pancakeswap-infinity)
+
+#### Top traders of a token on pancakeswap
+
+Will fetch top traders of a token on PancakeSwap Infinity for the selected network.
+
+▶️ [Top traders of a token on pancakeswap](https://ide.bitquery.io/top-traders-of-a-token-on-pancakeswap)
+
+#### Trade volume base pancakeswap infinity
+
+Fetches the traded volume, buy volume and sell volume of a token `0x22af33fe49fd1fa80c7149773dde5890d3c76f3b` on PancakeSwap Infinity.
+
+▶️ [Trade volume base pancakeswap infinity](https://ide.bitquery.io/trade_volume_base_pancakeswap_infinity)
 
 ### Aerodrome
 
@@ -3438,6 +3672,30 @@ Will fetch top traders of a token for the selected network.
 Fetches the traded volume, buy volume and sell volume of a token `0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270`.
 
 ▶️ [Trade volume matic uniswapv3](https://ide.bitquery.io/trade_volume_matic_uniswapv3)
+
+#### Uniswap v3 trades matic
+
+Below query will subscribe you to the latest DEX Trades on MATIC Uniswap v3.
+
+▶️ [Uniswap v3 trades matic](https://ide.bitquery.io/uniswap-v3-trades-matic)
+
+#### Latest Trades for a currency pair on matic
+
+Latest Trades for a currency pair on matic. Uses the `DEXTrades` cube.
+
+▶️ [Latest Trades for a currency pair on matic](https://ide.bitquery.io/Latest-Trades-for-a-currency-pair-on-matic_1)
+
+#### Top buyers of a currency on uniswap v4 matic
+
+Top buyers of a currency on uniswap v4 matic. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top buyers of a currency on uniswap v4 matic](https://ide.bitquery.io/top-buyers-of-a-currency-on-uniswap-v4-matic)
+
+#### Top sellers of a token on uniswap v4 pool matic
+
+Top sellers of a token on uniswap v4 pool matic. Uses the `DEXTrades` cube. Change the token address in the `where` clause to use it.
+
+▶️ [Top sellers of a token on uniswap v4 pool matic](https://ide.bitquery.io/top-sellers-of-a-token-on-uniswap-v4-pool-matic)
 
 ## Avalanche
 

--- a/docs/start/starter-subscriptions.md
+++ b/docs/start/starter-subscriptions.md
@@ -370,6 +370,36 @@ Returns Raydium Launchpad tokens which have more than 95% bonding curve progress
 
 ▶️ [Track Raydium Launchpad tokens above 95% Bonding Curve Progress in realtime](https://ide.bitquery.io/LetsBonkfun-Tokens-between-95-and-100-bonding-curve-progress_2)
 
+#### Newly launched token on PumpFun, Raydium Launchpad, Meteora DBC, Heaven DEX, Bags , Jupiter studio, Moonit
+
+Subscribe to newly launched tokens across multiple Solana launchpads and DEXs in a single subscription.
+
+▶️ [Newly launched token on PumpFun, Raydium Launchpad, Meteora DBC, Heaven DEX, Bags , Jupiter studio, Moonit](https://ide.bitquery.io/newly-launched-token-on-PumpFun-Raydium-Launchpad-Meteora-DBC-Heaven-DEX-Bags--Jupiter-studio-Moonit)
+
+#### Raydium CLMM DEX Trades with AccountNames
+
+In this section we will see how to get data on Raydium CLMM trades in real-time. According to the official docs available here.
+
+▶️ [Raydium CLMM DEX Trades with AccountNames](https://ide.bitquery.io/Raydium-CLMM-DEX-Trades-with-AccountNames)
+
+#### Raydium dextrades through OpenBook order book
+
+If you want to track latest Raydium DEXTrades enabled by OpenBook order book Protocol, you can use.
+
+▶️ [Raydium dextrades through OpenBook order book](https://ide.bitquery.io/Raydium-dextrades-through-OpenBook-order-book)
+
+#### Realtime stream raydium launchpad tokens with marketcap above 10k marketcap
+
+Subscribe when the token is on Solana, `Market.Protocol` is `raydium_launchpad`, `Supply.MarketCap` &gt; 10,000 (USD), and interval duration &gt; 1 second. Adjust `gt` to change the threshold.
+
+▶️ [Realtime stream raydium launchpad tokens with marketcap above 10k marketcap](https://ide.bitquery.io/realtime-stream-raydium-launchpad-tokens-with-marketcap-above-10k-marketcap)
+
+#### Track Add Liquidity Transactions on Solana Raydium DEX
+
+If you want to track latest liquidity additions in Raydium pools, you can use.
+
+▶️ [Track Add Liquidity Transactions on Solana Raydium DEX](https://ide.bitquery.io/Track-Add-Liquidity-Transactions-on-Solana-Raydium-DEX)
+
 ### Pump.fun
 
 #### PumpFun Token Creation
@@ -408,6 +438,60 @@ Live stream of token price updates on Pump.fun.
 
 ▶️ [Price of a pump fun token using price index in usd](https://ide.bitquery.io/Price-of-a-pump-fun-token-using-price-index-in-usd)
 
+#### Pump Fun Tokens between 95% and 100% bonding curve progress
+
+We can use above Bonding Curve formulae and get the Balance of the Pool needed to get to 95% and 100% Bonding Curve Progress range. And then track liquidity changes which result in `Base{PostAmount}` to fall in this range.
+
+▶️ [Pump Fun Tokens between 95% and 100% bonding curve progress](https://ide.bitquery.io/Pump-Fun-Tokens-between-95-and-100-bonding-curve-progress_3)
+
+#### Pump fun token mcap monitoring
+
+In case PostAmountInUSD is 0 then, you need to pull price from our Crypto price API. Here is an example which gets both supply and Price.
+
+▶️ [Pump fun token mcap monitoring](https://ide.bitquery.io/pump-fun-token-mcap-monitoring)
+
+#### PumpSwap new pools Stream
+
+Subscribe to `Instructions` where the program method is `create_pool` and the program address is the PumpSwap AMM ID above. Each event reflects a new pool on PumpSwap; use account and argument fields for pair and liquidity details.
+
+▶️ [PumpSwap new pools Stream](https://ide.bitquery.io/pumpSwap-new-pools-Stream)
+
+#### Pumpfun DEX Trades stream
+
+Use Bitquery's `DEXTrades` GraphQL subscription filtered by `ProtocolName: "pump"` to stream live Pump.fun trades including buy/sell sides, amounts, accounts, and methods. For gRPC or Kafka, see Pump.fun gRPC Streams.
+
+▶️ [Pumpfun DEX Trades stream](https://ide.bitquery.io/Pumpfun-DEX-Trades-stream)
+
+#### Pumpswap latest Trade for a trader stream
+
+Use a `subscription` on `DEXTrades` with the same `Signer` and PumpSwap `ProgramAddress` filters. New trades for that wallet on PumpSwap stream as they are confirmed.
+
+▶️ [Pumpswap latest Trade for a trader stream](https://ide.bitquery.io/Pumpswap-latest-Trade-for-a-trader-stream_1)
+
+#### Realtime price of a pumpswap token
+
+Subscribe to `DEXTradeByTokens` filtered by PumpSwap `ProgramAddress` and the token `MintAddress`. Each event includes `Price` and `PriceInUSD` for the latest leg—use it as a live price feed for that token on PumpSwap.
+
+▶️ [Realtime price of a pumpswap token](https://ide.bitquery.io/realtime-price-of-a-pumpswap-token)
+
+#### Realtime stream of "King of the Hill" Pump.fun tokens (30K–35K market cap)
+
+Tokens in the $30K–$35K `Supply.MarketCap` band on Pumpfun (see Pump.fun on King of the Hill). Subscribe to Trading `Pairs` with `MarketCap` between 30,000 and 35,000 USD.
+
+▶️ [Realtime stream of "King of the Hill" Pump.fun tokens (30K–35K market cap)](https://ide.bitquery.io/realtime-stream-of-King-of-the-Hill-Pumpfun-tokens-30K35K-market-cap)
+
+#### Realtime stream pumpfun tokens with marketcap above 10k marketcap
+
+Subscribe to Trading `Pairs` when the token is on Solana, `Market.ProtocolFamily` is Pumpfun, `Supply.MarketCap` &gt; 10,000 (USD), and interval duration &gt; 1 second.
+
+▶️ [Realtime stream pumpfun tokens with marketcap above 10k marketcap](https://ide.bitquery.io/realtime-stream-pumpfun-tokens-with-marketcap-above-10k-marketcap)
+
+#### Track creator fee transfers on pumpfun amm
+
+Subscribe to `InstructionBalanceUpdates` with the same `collect_coin_creator_fee` method and PumpSwap program address filter. Each event streams a new creator fee collection as it happens—use this to monitor creator revenue on PumpSwap tokens in real time.
+
+▶️ [Track creator fee transfers on pumpfun amm](https://ide.bitquery.io/track-creator-fee-transfers-on-pumpfun-amm)
+
 ### Meteora
 
 #### Jup studio token migrations from Meteora DBC to Meteors DEX
@@ -445,6 +529,30 @@ The below query gets real-time information whenever there's a new trade on the M
 This query subscribes to real-time trades on the Meteora DAMM v2 (Dynamic Automated Market Maker) on the Solana blockchain by filtering using the program address `cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG`.
 
 ▶️ [Real time trades on MeteoraDAMMv2 DEX on Solana](https://ide.bitquery.io/Real-time-trades-on-MeteoraDAMMv2-DEX-on-Solana)
+
+#### Real time trades on MeteoraDLMM DEX on Solana
+
+This query subscribes to real-time trades on the Meteora DLMM (Dynamic Liquidity Market Maker) on the Solana blockchain by filtering using the program address `LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo`.
+
+▶️ [Real time trades on MeteoraDLMM DEX on Solana](https://ide.bitquery.io/Real-time-trades-on-MeteoraDLMM-DEX-on-Solana)
+
+#### Real time trades on MeteoraDYN DEX on Solana
+
+The below query gets real-time information whenever there's a new trade on the Meteora DYN DEX including detailed information about the trade, including the buy and sell details, the block information, and the transaction specifics.
+
+▶️ [Real time trades on MeteoraDYN DEX on Solana](https://ide.bitquery.io/Real-time-trades-on-MeteoraDYN-DEX-on-Solana)
+
+#### Realtime Price feed of a Token on Meteora DAMM v2
+
+You can use the following subscription to get real-time price updates of a token on Meteora DAMM v2 on Solana. This provides live price data as new trades occur.
+
+▶️ [Realtime Price feed of a Token on Meteora DAMM v2](https://ide.bitquery.io/Realtime-Price-feed-of-a-Token-on-Meteora-DAMM-v2)
+
+#### Realtime Price feed of a Token on Meteora DLMM
+
+You can use the following subscription to get real-time price updates of a token on Meteora DLMM on Solana. This provides live price data as new trades occur.
+
+▶️ [Realtime Price feed of a Token on Meteora DLMM](https://ide.bitquery.io/Realtime-Price-feed-of-a-Token-on-Meteora-DLMM)
 
 ### Orca
 
@@ -1282,6 +1390,30 @@ Open this query on our GraphQL IDE using this.
 
 ▶️ [Latest pools created Uniswap v3](https://ide.bitquery.io/Latest-pools-created-Uniswap-v3_9)
 
+#### Real time trades on uniswap v4 -- subscription
+
+These swaps use the chain-specific DEXTrades cube via `EVM { DEXTrades }`: `Trade.PoolId`, pool-relative Buy/Sell (DEXTrades cube). USD can be thin on small pools—use live swaps above when you want the Trading row shape.
+
+▶️ [Real time trades on uniswap v4 -- subscription](https://ide.bitquery.io/Real-time-trades-on-uniswap-v4----subscription)
+
+#### Stream all Uniswap Seconds OHLC Kline
+
+The new Price Index Stream helps you get token-level, pair-level, and market-level OHLC data for 1 sec interval( or higher), in real-time across all chains. These also includes trading metrics like SMA, EMA, VWAP, and more.
+
+▶️ [Stream all Uniswap Seconds OHLC Kline](https://ide.bitquery.io/Stream-all-Uniswap-Seconds-OHLC-Kline_1)
+
+#### Uniswap all versions trades stream
+
+Track live trades across all Uniswap versions.
+
+▶️ [Uniswap all versions trades stream](https://ide.bitquery.io/uniswap-all-versions-trades-stream_1)
+
+#### Uniswap v3 pairs websocket
+
+Open this query on our GraphQL IDE using this.
+
+▶️ [Uniswap v3 pairs websocket](https://ide.bitquery.io/uniswap-v3-pairs-websocket)
+
 ## BSC
 
 ### Trades
@@ -1550,6 +1682,30 @@ Monitor large buy orders in the mempool to detect whale activity and potential p
 
 ▶️ [Four Meme large buys mempool](https://ide.bitquery.io/Four-Meme-large-buys-mempool)
 
+#### Four Meme liquidity add mempool
+
+Monitor when liquidity is being added to Four Meme tokens before confirmation. Important for detecting graduation events.
+
+▶️ [Four Meme liquidity add mempool](https://ide.bitquery.io/Four-Meme-liquidity-add-mempool)
+
+#### Four Meme mempool trades
+
+Monitor Four Meme DEX trades in real-time as they appear in the mempool, before they are confirmed on-chain. This allows you to detect trading opportunities early and front-run or back-run trades.
+
+▶️ [Four Meme mempool trades](https://ide.bitquery.io/Four-Meme-mempool-trades)
+
+#### Four Meme migration mempool
+
+Track when Four Meme tokens are graduating to PancakeSwap before the migration completes. Critical for trading strategies.
+
+▶️ [Four Meme migration mempool](https://ide.bitquery.io/Four-Meme-migration-mempool)
+
+#### Four Meme rug pull detection mempool
+
+Monitor for suspicious activity like developers selling large amounts in mempool.
+
+▶️ [Four Meme rug pull detection mempool](https://ide.bitquery.io/Four-Meme-rug-pull-detection-mempool)
+
 ### PancakeSwap
 
 #### Real-time Mempool Trades on Pancakeswap
@@ -1587,6 +1743,18 @@ Mempool - Latest BSC PancakeSwap v3 dextrades - Stream. Uses the `DEXTrades` cub
 Stream - BSC PancakeSwap v3 Trades for a token. Uses the `DEXTradeByTokens` cube. Change the token address in the `where` clause to use it.
 
 ▶️ [Stream - BSC PancakeSwap v3 Trades for a token](https://ide.bitquery.io/Stream---BSC-PancakeSwap-v3-Trades-for-a-token)
+
+#### Stream - Liqiidity add for all tokens on PancakeSwap v3
+
+Liquidity addition is an important event related to any liquidity pool. Using.
+
+▶️ [Stream - Liqiidity add for all tokens on PancakeSwap v3](https://ide.bitquery.io/Stream---Liqiidity-add-for-all-tokens-on-PancakeSwap-v3)
+
+#### Stream - Liquidity remove for all tokens on PancakeSwap v3
+
+Filter `Burn` signatures on the same PancakeSwap v3 manager to track liquidity withdrawals in real time.
+
+▶️ [Stream - Liquidity remove for all tokens on PancakeSwap v3](https://ide.bitquery.io/Stream---Liquidity-remove-for-all-tokens-on-PancakeSwap-v3)
 
 ### Uniswap
 
@@ -1922,6 +2090,12 @@ Stream live liquidity for all Uniswap v4 pools on Base.
 
 ▶️ [Uniswap v4 pool liquidity base](https://ide.bitquery.io/uniswap-v4-pool-liquidity-base)
 
+#### Uniswap v4 pool liquidity by poolid base
+
+Liquidity for v4 pools is reconstructed by stepping through each price range where liquidity is concentrated , so `AmountCurrencyA` / `AmountCurrencyB` reflect the actual PoolManager balances for that `PoolId`.
+
+▶️ [Uniswap v4 pool liquidity by poolid base](https://ide.bitquery.io/uniswap-v4-pool-liquidity-by-poolid-base)
+
 ## Arbitrum
 
 ### Trades
@@ -2244,6 +2418,26 @@ Use the same Raydium program filter with negative `ChangeAmount` on the base sid
 
 ▶️ [Liquidity removal for radium](https://ide.bitquery.io/liquidity-removal-for-radium_1)
 
+### Uniswap
+
+#### 1-second price, OHLC, volume, SMA and EMA — Uniswap v3
+
+One-second candles with moving averages for Uniswap v3 tokens, built for trading front-ends.
+
+▶️ [1-second price, OHLC, volume, SMA and EMA — Uniswap v3](https://ide.bitquery.io/Uniswap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
+
+#### Stream all Uniswap Seconds OHLC Kline
+
+Subscribe to `Trading.Pairs` filtered by Uniswap protocols and 1s interval to power sub-minute charts and HFT analytics.
+
+▶️ [Stream all Uniswap Seconds OHLC Kline](https://ide.bitquery.io/Stream-all-Uniswap-Seconds-OHLC-Kline)
+
+#### Uniswap all versions trades stream
+
+Filter `DEXTrades` with `ProtocolName` in `uniswap_v3`, `uniswap_v2`, `uniswap_v1` to stream only Uniswap family pools on mainnet.
+
+▶️ [Uniswap all versions trades stream](https://ide.bitquery.io/uniswap-all-versions-trades-stream)
+
 ### PancakeSwap
 
 #### Real-time Trades on Pancakeswap
@@ -2277,26 +2471,6 @@ All pumpfun Trade Stream. Uses the `Trades` cube.
 Pump fun token live prices using trades api. Uses the `Trades` cube.
 
 ▶️ [Pump fun token live prices using trades api](https://ide.bitquery.io/pump-fun-token-live-prices-using-trades-api_1)
-
-### Uniswap
-
-#### 1-second price, OHLC, volume, SMA and EMA — Uniswap v3
-
-One-second candles with moving averages for Uniswap v3 tokens, built for trading front-ends.
-
-▶️ [1-second price, OHLC, volume, SMA and EMA — Uniswap v3](https://ide.bitquery.io/Uniswap-v3-DEX-tokens-1-second-price-stream-with-OHLC)
-
-#### Stream all Uniswap Seconds OHLC Kline
-
-Subscribe to `Trading.Pairs` filtered by Uniswap protocols and 1s interval to power sub-minute charts and HFT analytics.
-
-▶️ [Stream all Uniswap Seconds OHLC Kline](https://ide.bitquery.io/Stream-all-Uniswap-Seconds-OHLC-Kline)
-
-#### Uniswap all versions trades stream
-
-Filter `DEXTrades` with `ProtocolName` in `uniswap_v3`, `uniswap_v2`, `uniswap_v1` to stream only Uniswap family pools on mainnet.
-
-▶️ [Uniswap all versions trades stream](https://ide.bitquery.io/uniswap-all-versions-trades-stream)
 
 ## Stablecoins
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -72,10 +72,24 @@ Contact [sales@bitquery.io](mailto:sales@bitquery.io) for custom historical expo
 ## Popular protocol APIs
 
 - [Solana DEX trades](https://docs.bitquery.io/docs/blockchain/Solana/solana-dextrades/)
-- [Pump.fun API](https://docs.bitquery.io/docs/blockchain/Solana/Pumpfun/Pump-Fun-API/)
-- [Raydium DEX API](https://docs.bitquery.io/docs/blockchain/Solana/Solana-Raydium-DEX-API/)
 - [Polymarket API](https://docs.bitquery.io/docs/examples/polymarket-api/polymarket-api/)
 - [Token holders API](https://docs.bitquery.io/docs/blockchain/Ethereum/token-holders/token-holder-api/)
+- [Hyperliquid perpetuals](https://docs.bitquery.io/docs/perpetuals/hyperliquid/)
+- [Phoenix perpetuals on Solana](https://docs.bitquery.io/docs/perpetuals/solana/phoenix-perpetuals-api/)
+
+## Solana launchpads and memecoins
+
+The most asked-about area. The IDE's Solana section carries ~15 Pump.fun
+queries and ~15 Pump.fun streams, plus Raydium, Meteora and LetsBonk.fun — new
+token creation, bonding curve progress, graduation to PumpSwap, ATH market cap,
+top traders, creator fees, and first-buyer/sniper detection.
+
+- [Pump.fun API](https://docs.bitquery.io/docs/blockchain/Solana/Pumpfun/Pump-Fun-API/) — token creation, trades, migrations
+- [Pump.fun market cap & bonding curve](https://docs.bitquery.io/docs/blockchain/Solana/Pumpfun/Pump-Fun-Marketcap-Bonding-Curve-API/) — graduation progress
+- [Raydium DEX API](https://docs.bitquery.io/docs/blockchain/Solana/Solana-Raydium-DEX-API/)
+- [Meteora dynamic bonding curve](https://docs.bitquery.io/docs/blockchain/Solana/meteora-dynamic-bonding-curve-api/)
+- [Four Meme on BSC](https://docs.bitquery.io/docs/blockchain/BSC/four-meme-api/)
+- [Sniper trading with Kafka](https://docs.bitquery.io/docs/streams/sniper-trade-using-bitquery-kafka-stream/)
 
 ## MCP for AI agents
 


### PR DESCRIPTION
Pump.fun is the most asked-about subject in the support channel, and the panel was showing **six** queries for it.

## The cap was hiding working queries

The corpus holds **63 Pump.fun queries. 12 were shown. 31 more were verified working and hidden by a per-venue cap of six.**

The cap is now set from demand instead of uniformly — Pump.fun 16, Raydium 12, LetsBonk.fun / Meteora / Four Meme / Uniswap 10, PancakeSwap 8, everything else unchanged at six.

Pump.fun goes **6 → 15 queries and 6 → 15 streams**, surfacing work that was already written and tested: graduating tokens in the last five minutes, tokens created by an address, creator fee transfers, PumpSwap trades and pools, market-cap monitoring, King of the Hill, and the 95–100% bonding-curve stream.

## One genuine gap

Telegram asks *"how do I find snipers"* repeatedly — sniper criteria, "trying to find snipers", "pair this with pumpfun buys". The corpus had **zero** queries matching sniper or snipe.

Added **first buyers of a token, in ascending time order**, which is what sniper detection is actually built on: who bought in the first seconds, how much, and at what price. Written against a live Pump.fun token and executed before saving.

## Near-duplicate filter

Raising the caps surfaced three variants of "top pump fun tokens by market cap" that differ only in wording. Titles that normalise to the same string now collapse to one, so a bigger cap adds coverage rather than noise.

## llms.txt

New **Solana launchpads and memecoins** section, plus Hyperliquid and Phoenix perpetuals under protocol APIs. Every `docs.bitquery.io` link in the file was checked for a 200.

## Verification

**733 query entries across 32 groups, 412 stream entries across 17.**

| gate | result |
|---|---|
| play-link slug + tooltip on every entry | pass |
| slug resolves, not deleted, not unpublished | pass |
| zero `BalanceUpdates` | pass |
| entry on the chain its group claims | pass |
| stored endpoint matches query dialect | pass |
| no V1 query on a migrating chain | pass |
| no duplicate or near-duplicate titles | pass |
| every entry executed successfully, live | pass |
| no unexplained drops vs the original 298 | pass |
| non-ASCII in any panel comment | 0 of 1,141 |
| widest comment line | 78 chars |
| Docusaurus production build | success |

The 17 newly surfaced subscriptions were executed over WebSocket before shipping; none had a prior verdict, and the audit refused to pass until they did.

## Unrelated finding worth flagging

**docs.bitquery.io has not been redeployed since #251 and #252 merged.** The IDE reads `refs/heads/main` directly so the panel is current, but the docs website still serves the old build — `/docs/start/bitquery-for-ai/` returns 404 and the live `llms.txt` lacks the entries added in #251. Nothing to fix in this PR; the deploy just needs to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)